### PR TITLE
Change StreamInputBytes.Seek to reset isAtEnd to false

### DIFF
--- a/src/UglyToad.PdfPig.Tests/IO/InputBytesTests.cs
+++ b/src/UglyToad.PdfPig.Tests/IO/InputBytesTests.cs
@@ -64,6 +64,12 @@
 
                 Assert.True(stream.IsAtEnd());
                 Assert.True(array.IsAtEnd());
+
+                stream.Seek(0);
+                array.Seek(0);
+
+                Assert.False(stream.IsAtEnd());
+                Assert.False(array.IsAtEnd());
             }
         }
     }

--- a/src/UglyToad.PdfPig/IO/StreamInputBytes.cs
+++ b/src/UglyToad.PdfPig/IO/StreamInputBytes.cs
@@ -75,6 +75,8 @@
 
         public void Seek(long position)
         {
+            isAtEnd = false;
+
             if (position == 0)
             {
                 stream.Seek(0, SeekOrigin.Begin);


### PR DESCRIPTION
When trying to do some tests with 0.0.7 I noticed that some files were failing to open when using the variant of PdfDocument.Open that takes a stream, but were working when using the variant that takes a file path.

Debugging through the code, I think that might be because StreamInputBytes doesn't reset isAtEnd when the stream is seeked away from the end, so once the end has been reached isAtEnd gets left at true permanently.