### PR TITLE
AltoDocument: make all `xxxSpecified` setters public to allow `Deserialize`

### DIFF
--- a/src/UglyToad.PdfPig/Export/Alto/AltoDocument.AltoBlock.cs
+++ b/src/UglyToad.PdfPig/Export/Alto/AltoDocument.AltoBlock.cs
@@ -61,7 +61,7 @@
 
             /// <remarks/>
             [XmlIgnore]
-            public bool RotationSpecified { get; private set; }
+            public bool RotationSpecified { get; set; }
 
             /// <summary>
             /// The next block in reading sequence on the page.
@@ -86,7 +86,7 @@
 
             /// <remarks/>
             [XmlIgnore]
-            public bool CorrectionStatusSpecified { get; private set; }
+            public bool CorrectionStatusSpecified { get; set; }
 
             /// <remarks/>
             [XmlAttribute("type", Form = XmlSchemaForm.Qualified, Namespace = "http://www.w3.org/1999/xlink")]
@@ -122,7 +122,7 @@
 
             /// <remarks/>
             [XmlIgnore]
-            public bool ShowSpecified { get; private set; }
+            public bool ShowSpecified { get; set; }
 
             /// <remarks/>
             [XmlAttribute("actuate", Form = XmlSchemaForm.Qualified, Namespace = "http://www.w3.org/1999/xlink")]
@@ -138,7 +138,7 @@
 
             /// <remarks/>
             [XmlIgnore]
-            public bool ActuateSpecified { get; private set; }
+            public bool ActuateSpecified { get; set; }
         }
     }
 }

--- a/src/UglyToad.PdfPig/Export/Alto/AltoDocument.AltoBlockTypeActuate.cs
+++ b/src/UglyToad.PdfPig/Export/Alto/AltoDocument.AltoBlockTypeActuate.cs
@@ -17,12 +17,15 @@
             /// <remarks/>
             [XmlEnum("onLoad")]
             OnLoad,
+
             /// <remarks/>
             [XmlEnum("onRequest")]
             OnRequest,
+
             /// <remarks/>
             [XmlEnum("other")]
             Other,
+
             /// <remarks/>
             [XmlEnum("none")]
             None,

--- a/src/UglyToad.PdfPig/Export/Alto/AltoDocument.AltoBlockTypeShow.cs
+++ b/src/UglyToad.PdfPig/Export/Alto/AltoDocument.AltoBlockTypeShow.cs
@@ -17,15 +17,19 @@
             /// <remarks/>
             [XmlEnum("new")]
             New,
+
             /// <remarks/>
             [XmlEnum("replace")]
             Replace,
+
             /// <remarks/>
             [XmlEnum("embed")]
             Embed,
+
             /// <remarks/>
             [XmlEnum("other")]
             Other,
+
             /// <remarks/>
             [XmlEnum("none")]
             None

--- a/src/UglyToad.PdfPig/Export/Alto/AltoDocument.AltoEllipse.cs
+++ b/src/UglyToad.PdfPig/Export/Alto/AltoDocument.AltoEllipse.cs
@@ -51,7 +51,7 @@
 
             /// <remarks/>
             [XmlIgnore]
-            public bool RotationSpecified { get; private set; }
+            public bool RotationSpecified { get; set; }
         }
     }
 }

--- a/src/UglyToad.PdfPig/Export/Alto/AltoDocument.AltoGlyph.cs
+++ b/src/UglyToad.PdfPig/Export/Alto/AltoDocument.AltoGlyph.cs
@@ -78,7 +78,7 @@
 
             /// <remarks/>
             [XmlIgnore]
-            public bool GcSpecified { get; private set; }
+            public bool GcSpecified { get; set; }
 
             /// <remarks/>
             public override string ToString()

--- a/src/UglyToad.PdfPig/Export/Alto/AltoDocument.AltoOcrProcessing.cs
+++ b/src/UglyToad.PdfPig/Export/Alto/AltoDocument.AltoOcrProcessing.cs
@@ -28,7 +28,5 @@
             [XmlElement("postProcessingStep")]
             public AltoProcessingStep[] PostProcessingStep { get; set; }
         }
-
-
     }
 }

--- a/src/UglyToad.PdfPig/Export/Alto/AltoDocument.AltoPage.cs
+++ b/src/UglyToad.PdfPig/Export/Alto/AltoDocument.AltoPage.cs
@@ -82,7 +82,7 @@
 
             /// <remarks/>
             [XmlIgnore]
-            public bool HeightSpecified { get; private set; }
+            public bool HeightSpecified { get; set; }
 
             /// <remarks/>
             [XmlAttribute("WIDTH")]
@@ -98,7 +98,7 @@
 
             /// <remarks/>
             [XmlIgnore]
-            public bool WidthSpecified { get; private set; }
+            public bool WidthSpecified { get; set; }
 
             /// <summary>
             /// The number of the page within the document.
@@ -126,7 +126,7 @@
 
             /// <remarks/>
             [XmlIgnore]
-            public bool QualitySpecified { get; private set; }
+            public bool QualitySpecified { get; set; }
 
             /// <remarks/>
             [XmlAttribute("QUALITY_DETAIL")]
@@ -146,7 +146,7 @@
 
             /// <remarks/>
             [XmlIgnore]
-            public bool PositionSpecified { get; private set; }
+            public bool PositionSpecified { get; set; }
 
             /// <summary>
             /// A link to the processing description that has been used for this page.
@@ -170,7 +170,7 @@
 
             /// <remarks/>
             [XmlIgnore]
-            public bool AccuracySpecified { get; private set; }
+            public bool AccuracySpecified { get; set; }
 
             /// <summary>
             /// 
@@ -188,7 +188,7 @@
 
             /// <remarks/>
             [XmlIgnore]
-            public bool PcSpecified { get; private set; }
+            public bool PcSpecified { get; set; }
         }
     }
 }

--- a/src/UglyToad.PdfPig/Export/Alto/AltoDocument.AltoPositionedElement.cs
+++ b/src/UglyToad.PdfPig/Export/Alto/AltoDocument.AltoPositionedElement.cs
@@ -38,7 +38,7 @@
             /// Whether to include <see cref="Height"/> in the output.
             /// </summary>
             [XmlIgnore]
-            public bool HeightSpecified { get; private set; }
+            public bool HeightSpecified { get; set; }
 
             /// <summary>
             /// Width.
@@ -58,7 +58,7 @@
             /// Whether to include <see cref="Width"/> in the output.
             /// </summary>
             [XmlIgnore]
-            public bool WidthSpecified { get; private set; }
+            public bool WidthSpecified { get; set; }
 
             /// <summary>
             /// Horizontal position.
@@ -78,7 +78,7 @@
             /// Whether to include <see cref="HorizontalPosition"/> in the output.
             /// </summary>
             [XmlIgnore]
-            public bool HorizontalPositionSpecified { get; private set; }
+            public bool HorizontalPositionSpecified { get; set; }
 
             /// <summary>
             /// Vertical position.
@@ -98,9 +98,7 @@
             /// Whether to include <see cref="VerticalPosition"/> in the output.
             /// </summary>
             [XmlIgnore]
-            public bool VerticalPositionSpecified { get; private set; }
+            public bool VerticalPositionSpecified { get; set; }
         }
-
-
     }
 }

--- a/src/UglyToad.PdfPig/Export/Alto/AltoDocument.AltoProcessingStep.cs
+++ b/src/UglyToad.PdfPig/Export/Alto/AltoDocument.AltoProcessingStep.cs
@@ -35,7 +35,7 @@
 
             /// <remarks/>
             [XmlIgnore]
-            public bool ProcessingCategorySpecified { get; private set; }
+            public bool ProcessingCategorySpecified { get; set; }
 
             /// <summary>
             /// Date or DateTime the image was processed.

--- a/src/UglyToad.PdfPig/Export/Alto/AltoDocument.AltoQuality.cs
+++ b/src/UglyToad.PdfPig/Export/Alto/AltoDocument.AltoQuality.cs
@@ -17,17 +17,23 @@
             /// <remarks/>
             // ReSharper disable once InconsistentNaming
             OK,
+
             /// <remarks/>
             Missing,
+
             /// <remarks/>
             [XmlEnum("Missing in original")]
             MissingInOriginal,
+
             /// <remarks/>
             Damaged,
+
             /// <remarks/>
             Retained,
+
             /// <remarks/>
             Target,
+
             /// <remarks/>
             [XmlEnum("As in original")]
             AsInOriginal,

--- a/src/UglyToad.PdfPig/Export/Alto/AltoDocument.AltoString.cs
+++ b/src/UglyToad.PdfPig/Export/Alto/AltoDocument.AltoString.cs
@@ -66,7 +66,7 @@
 
             /// <remarks/>
             [XmlIgnore]
-            public bool StyleSpecified { get; private set; }
+            public bool StyleSpecified { get; set; }
 
             /// <remarks/>
             [XmlAttribute("SUBS_TYPE")]
@@ -82,7 +82,7 @@
 
             /// <remarks/>
             [XmlIgnore]
-            public bool SubsTypeSpecified { get; private set; }
+            public bool SubsTypeSpecified { get; set; }
 
             /// <summary>
             /// Content of the substitution.
@@ -104,7 +104,7 @@
 
             /// <remarks/>
             [XmlIgnore]
-            public bool WcSpecified { get; private set; }
+            public bool WcSpecified { get; set; }
 
             /// <summary>
             /// Confidence level of each character in that string. A list of numbers,
@@ -130,7 +130,7 @@
 
             /// <remarks/>
             [XmlIgnore]
-            public bool CorrectionStatusSpecified { get; private set; }
+            public bool CorrectionStatusSpecified { get; set; }
 
             /// <summary>
             /// Attribute to record language of the string. The language should be recorded at the highest level possible.

--- a/src/UglyToad.PdfPig/Export/Alto/AltoDocument.AltoTextBlockTextLine.cs
+++ b/src/UglyToad.PdfPig/Export/Alto/AltoDocument.AltoTextBlockTextLine.cs
@@ -66,7 +66,7 @@
 
             /// <remarks/>
             [XmlIgnore]
-            public bool BaseLineSpecified { get; private set; }
+            public bool BaseLineSpecified { get; set; }
 
             /// <remarks/>
             [XmlAttribute("LANG", DataType = "language")]
@@ -89,7 +89,7 @@
 
             /// <remarks/>
             [XmlIgnore]
-            public bool CorrectionStatusSpecified { get; private set; }
+            public bool CorrectionStatusSpecified { get; set; }
 
             /// <remarks/>
             public override string ToString()

--- a/src/UglyToad.PdfPig/Export/Alto/AltoDocument.AltoTextStyle.cs
+++ b/src/UglyToad.PdfPig/Export/Alto/AltoDocument.AltoTextStyle.cs
@@ -44,7 +44,7 @@
 
             /// <remarks/>
             [XmlIgnore]
-            public bool FontTypeSpecified { get; private set; }
+            public bool FontTypeSpecified { get; set; }
 
             /// <remarks/>
             [XmlAttribute("FONTWIDTH")]
@@ -60,7 +60,7 @@
 
             /// <remarks/>
             [XmlIgnore]
-            public bool FontWidthSpecified { get; private set; }
+            public bool FontWidthSpecified { get; set; }
 
             /// <summary>
             /// The font size, in points (1/72 of an inch).
@@ -90,7 +90,7 @@
 
             /// <remarks/>
             [XmlIgnore]
-            public bool FontStyleSpecified { get; private set; }
+            public bool FontStyleSpecified { get; set; }
         }
     }
 }

--- a/src/UglyToad.PdfPig/Export/Alto/AltoDocument.AltoVariant.cs
+++ b/src/UglyToad.PdfPig/Export/Alto/AltoDocument.AltoVariant.cs
@@ -50,7 +50,7 @@
 
             /// <remarks/>
             [XmlIgnore]
-            public bool VcSpecified { get; private set; }
+            public bool VcSpecified { get; set; }
         }
     }
 }


### PR DESCRIPTION
If you try to deserialise this [alto xml](https://github.com/UglyToad/PdfPig/files/3747790/Random.2.Columns.Lists.Images.1.alto.zip), you will receive the error below as the `xxxSpecified` setters are `private`. Fixing this by switching them to `public`.

`MethodAccessException: Attempt by method 'Microsoft.Xml.Serialization.GeneratedAssembly.XmlSerializationReaderAltoDocument.Read11_AltoDescriptionProcessing(Boolean, Boolean)' to access method 'UglyToad.PdfPig.Export.Alto.AltoDocument+AltoProcessingStep.set_ProcessingCategorySpecified(Boolean)' failed.`