### PR TITLE
Enhancing NearestNeighbourWordExtractor

### DIFF
--- a/src/UglyToad.PdfPig.Tests/PublicApiScannerTests.cs
+++ b/src/UglyToad.PdfPig.Tests/PublicApiScannerTests.cs
@@ -215,6 +215,7 @@
                 "UglyToad.PdfPig.Tokens.StreamToken",
                 "UglyToad.PdfPig.Tokens.StringToken",
                 "UglyToad.PdfPig.Util.IWordExtractor",
+                "UglyToad.PdfPig.Util.DefaultWordExtractor",
                 "UglyToad.PdfPig.Writer.PdfDocumentBuilder",
                 "UglyToad.PdfPig.Writer.PdfPageBuilder",
                 "UglyToad.PdfPig.Writer.TokenWriter",

--- a/src/UglyToad.PdfPig/Util/DefaultWordExtractor.cs
+++ b/src/UglyToad.PdfPig/Util/DefaultWordExtractor.cs
@@ -5,8 +5,15 @@
     using System.Linq;
     using Content;
 
-    internal class DefaultWordExtractor : IWordExtractor
+    /// <summary>
+    /// Default Word Extractor.
+    /// </summary>
+    public class DefaultWordExtractor : IWordExtractor
     {
+        /// <summary>
+        /// Gets the words.
+        /// </summary>
+        /// <param name="letters">The letters in the page.</param>
         public IEnumerable<Word> GetWords(IReadOnlyList<Letter> letters)
         {
             var lettersOrder = letters.OrderByDescending(x => x.Location.Y)
@@ -99,6 +106,9 @@
             return new Word(letters.ToList());
         }
 
+        /// <summary>
+        /// Create an instance of Default Word Extractor, <see cref="DefaultWordExtractor"/>.
+        /// </summary>
         public static IWordExtractor Instance { get; } = new DefaultWordExtractor();
 
         private DefaultWordExtractor()


### PR DESCRIPTION
- Making the code easier to read
- Using 20% of Width instead of 60% for the `maxDistanceFunction`
- Also making `DefaultWordExtractor` public, so that it can be used in the exporters