### PR TITLE
Improving clustering algorithm

### DIFF
--- a/src/UglyToad.PdfPig/DocumentLayoutAnalysis/ClusteringAlgorithms.cs
+++ b/src/UglyToad.PdfPig/DocumentLayoutAnalysis/ClusteringAlgorithms.cs
@@ -23,7 +23,7 @@ namespace UglyToad.PdfPig.DocumentLayoutAnalysis
         /// <param name="candidatesPoint">The candidates' point to use for pairing, e.g. BottomLeft, TopLeft.</param>
         /// <param name="filterPivot">Filter to apply to the pivot point. If false, point will not be paired at all, e.g. is white space.</param>
         /// <param name="filterFinal">Filter to apply to both the pivot and the paired point. If false, point will not be paired at all, e.g. pivot and paired point have same font.</param>
-        internal static IEnumerable<HashSet<int>> SimpleTransitiveClosure<T>(List<T> elements,
+        internal static IEnumerable<HashSet<int>> ClusterNearestNeighbours<T>(List<T> elements,
             Func<PdfPoint, PdfPoint, double> distMeasure,
             Func<T, T, double> maxDistanceFunction,
             Func<T, PdfPoint> pivotPoint, Func<T, PdfPoint> candidatesPoint,
@@ -41,7 +41,7 @@ namespace UglyToad.PdfPig.DocumentLayoutAnalysis
              *  that if indexes[i] = j then indexes[j] != i.
              *  
              * 2. Group indexes
-             *  Group indexes if share neighbours in common - Transitive closure
+             *  Group indexes if share neighbours in common - Depth-first search
              *  e.g. if we have indexes[i] = j, indexes[j] = k, indexes[m] = n and indexes[n] = -1
              *  (i,j,k) will form a group and (m,n) will form another group.
              *************************************************************************************/
@@ -56,12 +56,15 @@ namespace UglyToad.PdfPig.DocumentLayoutAnalysis
 
                 if (filterPivot(pivot))
                 {
-                    int index = pivotPoint(pivot).FindIndexNearest(candidatesPoints, distMeasure, out double dist);
-                    var paired = elements[index];
+                    int index = pivot.FindIndexNearest(elements, candidatesPoint, pivotPoint, distMeasure, out double dist);
 
-                    if (filterFinal(pivot, paired) && dist < maxDistanceFunction(pivot, paired))
+                    if (index != -1)
                     {
-                        indexes[e] = index;
+                        var paired = elements[index];
+                        if (filterFinal(pivot, paired) && dist < maxDistanceFunction(pivot, paired))
+                        {
+                            indexes[e] = index;
+                        }
                     }
                 }
             });
@@ -84,7 +87,7 @@ namespace UglyToad.PdfPig.DocumentLayoutAnalysis
         /// <param name="candidatesPoint">The candidates' point to use for pairing, e.g. BottomLeft, TopLeft.</param>
         /// <param name="filterPivot">Filter to apply to the pivot point. If false, point will not be paired at all, e.g. is white space.</param>
         /// <param name="filterFinal">Filter to apply to both the pivot and the paired point. If false, point will not be paired at all, e.g. pivot and paired point have same font.</param>
-        internal static IEnumerable<HashSet<int>> SimpleTransitiveClosure<T>(T[] elements,
+        internal static IEnumerable<HashSet<int>> ClusterNearestNeighbours<T>(T[] elements,
             Func<PdfPoint, PdfPoint, double> distMeasure,
             Func<T, T, double> maxDistanceFunction,
             Func<T, PdfPoint> pivotPoint, Func<T, PdfPoint> candidatesPoint,
@@ -102,7 +105,7 @@ namespace UglyToad.PdfPig.DocumentLayoutAnalysis
              *  that if indexes[i] = j then indexes[j] != i.
              *  
              * 2. Group indexes
-             *  Group indexes if share neighbours in common - Transitive closure
+             *  Group indexes if share neighbours in common - Depth-first search
              *  e.g. if we have indexes[i] = j, indexes[j] = k, indexes[m] = n and indexes[n] = -1
              *  (i,j,k) will form a group and (m,n) will form another group.
              *************************************************************************************/
@@ -117,12 +120,15 @@ namespace UglyToad.PdfPig.DocumentLayoutAnalysis
 
                 if (filterPivot(pivot))
                 {
-                    int index = pivotPoint(pivot).FindIndexNearest(candidatesPoints, distMeasure, out double dist);
-                    var paired = elements[index];
+                    int index = pivot.FindIndexNearest(elements, candidatesPoint, pivotPoint, distMeasure, out double dist);
 
-                    if (filterFinal(pivot, paired) && dist < maxDistanceFunction(pivot, paired))
+                    if (index != -1)
                     {
-                        indexes[e] = index;
+                        var paired = elements[index];
+                        if (filterFinal(pivot, paired) && dist < maxDistanceFunction(pivot, paired))
+                        {
+                            indexes[e] = index;
+                        }
                     }
                 }
             });
@@ -145,7 +151,7 @@ namespace UglyToad.PdfPig.DocumentLayoutAnalysis
         /// <param name="candidatesLine">The candidates' line to use for pairing.</param>
         /// <param name="filterPivot">Filter to apply to the pivot point. If false, point will not be paired at all, e.g. is white space.</param>
         /// <param name="filterFinal">Filter to apply to both the pivot and the paired point. If false, point will not be paired at all, e.g. pivot and paired point have same font.</param>
-        internal static IEnumerable<HashSet<int>> SimpleTransitiveClosure<T>(T[] elements,
+        internal static IEnumerable<HashSet<int>> ClusterNearestNeighbours<T>(T[] elements,
             Func<PdfLine, PdfLine, double> distMeasure,
             Func<T, T, double> maxDistanceFunction,
             Func<T, PdfLine> pivotLine, Func<T, PdfLine> candidatesLine,
@@ -163,7 +169,7 @@ namespace UglyToad.PdfPig.DocumentLayoutAnalysis
              *  that if indexes[i] = j then indexes[j] != i.
              *  
              * 2. Group indexes
-             *  Group indexes if share neighbours in common - Transitive closure
+             *  Group indexes if share neighbours in common - Depth-first search
              *  e.g. if we have indexes[i] = j, indexes[j] = k, indexes[m] = n and indexes[n] = -1
              *  (i,j,k) will form a group and (m,n) will form another group.
              *************************************************************************************/
@@ -178,12 +184,15 @@ namespace UglyToad.PdfPig.DocumentLayoutAnalysis
 
                 if (filterPivot(pivot))
                 {
-                    int index = pivotLine(pivot).FindIndexNearest(candidatesLines, distMeasure, out double dist);
-                    var paired = elements[index];
+                    int index = pivot.FindIndexNearest(elements, candidatesLine, pivotLine, distMeasure, out double dist);
 
-                    if (filterFinal(pivot, paired) && dist < maxDistanceFunction(pivot, paired))
+                    if (index != -1)
                     {
-                        indexes[e] = index;
+                        var paired = elements[index];
+                        if (filterFinal(pivot, paired) && dist < maxDistanceFunction(pivot, paired))
+                        {
+                            indexes[e] = index;
+                        }
                     }
                 }
             });
@@ -195,104 +204,98 @@ namespace UglyToad.PdfPig.DocumentLayoutAnalysis
         }
 
         /// <summary>
-        /// Group elements via transitive closure. Each element has only one connected neighbour.
-        /// https://en.wikipedia.org/wiki/Transitive_closure
+        /// Group elements using Depth-first search.
+        /// <para>https://en.wikipedia.org/wiki/Depth-first_search</para>
         /// </summary>
-        /// <param name="indexes">Array of paired elements index.</param>
-        /// <returns></returns>
-        private static List<HashSet<int>> GroupIndexes(int[] indexes)
+        /// <param name="edges">The graph. edges[i] = j indicates that there is an edge between i and j.</param>
+        /// <returns>A List of HashSets containing containing the grouped indexes.</returns>
+        internal static List<HashSet<int>> GroupIndexes(int[] edges)
         {
-            int[][] adjacency = new int[indexes.Length][];
-            for (int i = 0; i < indexes.Length; i++)
+            int[][] adjacency = new int[edges.Length][];
+            for (int i = 0; i < edges.Length; i++)
             {
                 HashSet<int> matches = new HashSet<int>();
-                for (int j = 0; j < indexes.Length; ++j)
+                if (edges[i] != -1) matches.Add(edges[i]);
+                for (int j = 0; j < edges.Length; j++)
                 {
-                    if (indexes[j] == i) matches.Add(j);
+                    if (edges[j] == i) matches.Add(j);
                 }
                 adjacency[i] = matches.ToArray();
             }
 
             List<HashSet<int>> groupedIndexes = new List<HashSet<int>>();
-            bool[] isDone = new bool[indexes.Length];
+            bool[] isDone = new bool[edges.Length];
 
-            for (int p = 0; p < indexes.Length; p++)
+            for (int p = 0; p < edges.Length; p++)
             {
                 if (isDone[p]) continue;
+                groupedIndexes.Add(DfsIterative(p, adjacency, ref isDone));
+            }
+            return groupedIndexes;
+        }
 
-                LinkedList<int[]> L = new LinkedList<int[]>();
-                HashSet<int> grouped = new HashSet<int>();
-                L.AddLast(new[] { p, indexes[p] });
-
-                while (L.Any())
+        /// <summary>
+        /// Group elements using Depth-first search.
+        /// <para>https://en.wikipedia.org/wiki/Depth-first_search</para>
+        /// </summary>
+        /// <param name="edges">The graph. edges[i] = [j, k, l, ...] indicates that there is an edge between i and each element j, k, l, ...</param>
+        /// <returns>A List of HashSets containing containing the grouped indexes.</returns>
+        internal static List<HashSet<int>> GroupIndexes(int[][] edges)
+        {
+            int[][] adjacency = new int[edges.Length][];
+            for (int i = 0; i < edges.Length; i++)
+            {
+                HashSet<int> matches = new HashSet<int>();
+                for (int j = 0; j < edges[i].Length; j++)
                 {
-                    var current = L.First.Value;
-                    L.RemoveFirst();
-                    var current0 = current[0];
-                    var current1 = current[1];
+                    if (edges[i][j] != -1) matches.Add(edges[i][j]);
+                }
 
-                    if (current0 != -1 && !isDone[current0])
+                for (int j = 0; j < edges.Length; j++)
+                {
+                    for (int k = 0; k < edges[j].Length; k++)
                     {
-                        var adjs = adjacency[current0];
-                        foreach (var k in adjs)
-                        {
-                            if (isDone[k]) continue;
-                            L.AddLast(new[] { k, current0 });
-                        }
-
-                        int current0P = indexes[current0];
-                        if (current0P != -1)
-                        {
-                            var adjsP = adjacency[current0P];
-                            foreach (var k in adjsP)
-                            {
-                                if (isDone[k]) continue;
-                                L.AddLast(new[] { k, current0P });
-                                isDone[k] = true;
-                                grouped.Add(k);
-                            }
-                        }
-                        else
-                        {
-                            L.AddLast(new[] { current0, current0P });
-                            isDone[current0] = true;
-                            grouped.Add(current0);
-                        }
-                    }
-
-                    if (current1 != -1 && !isDone[current1])
-                    {
-                        var adjs = adjacency[current1];
-                        foreach (var k in adjs)
-                        {
-                            if (isDone[k]) continue;
-                            L.AddLast(new[] { k, current1 });
-                        }
-
-                        int current1P = indexes[current1];
-                        if (current1P != -1)
-                        {
-                            var adjsP = adjacency[current1P];
-                            foreach (var k in adjsP)
-                            {
-                                if (isDone[k]) continue;
-                                L.AddLast(new[] { k, current1P });
-                                isDone[k] = true;
-                                grouped.Add(k);
-                            }
-                        }
-                        else
-                        {
-                            L.AddLast(new[] { current1, current1P });
-                            isDone[current1] = true;
-                            grouped.Add(current1);
-                        }
+                        if (edges[j][k] == i) matches.Add(j);
                     }
                 }
-                groupedIndexes.Add(grouped);
+                adjacency[i] = matches.ToArray();
             }
 
+            List<HashSet<int>> groupedIndexes = new List<HashSet<int>>();
+            bool[] isDone = new bool[edges.Length];
+
+            for (int p = 0; p < edges.Length; p++)
+            {
+                if (isDone[p]) continue;
+                groupedIndexes.Add(DfsIterative(p, adjacency, ref isDone));
+            }
             return groupedIndexes;
+        }
+
+        /// <summary>
+        /// Depth-first search
+        /// <para>https://en.wikipedia.org/wiki/Depth-first_search</para>
+        /// </summary>
+        private static HashSet<int> DfsIterative(int c, int[][] adj, ref bool[] isDone)
+        {
+            HashSet<int> group = new HashSet<int>();
+            Stack<int> S = new Stack<int>();
+            S.Push(c);
+
+            while (S.Any())
+            {
+                var v = S.Pop();
+                if (!isDone[v])
+                {
+                    group.Add(v);
+                    isDone[v] = true;
+                    foreach (var w in adj[v])
+                    {
+                        S.Push(w);
+                    }
+                }
+            }
+            return group;
         }
     }
 }

--- a/src/UglyToad.PdfPig/DocumentLayoutAnalysis/ClusteringAlgorithms.cs
+++ b/src/UglyToad.PdfPig/DocumentLayoutAnalysis/ClusteringAlgorithms.cs
@@ -12,8 +12,7 @@ namespace UglyToad.PdfPig.DocumentLayoutAnalysis
     internal class ClusteringAlgorithms
     {
         /// <summary>
-        /// Algorithm to group elements via transitive closure, using nearest neighbours and maximum distance.
-        /// https://en.wikipedia.org/wiki/Transitive_closure
+        /// Algorithm to group elements using nearest neighbours.
         /// </summary>
         /// <typeparam name="T">Letter, Word, TextLine, etc.</typeparam>
         /// <param name="elements">List of elements to group.</param>
@@ -76,8 +75,7 @@ namespace UglyToad.PdfPig.DocumentLayoutAnalysis
         }
 
         /// <summary>
-        /// Algorithm to group elements via transitive closure, using nearest neighbours and maximum distance.
-        /// https://en.wikipedia.org/wiki/Transitive_closure
+        /// Algorithm to group elements using nearest neighbours.
         /// </summary>
         /// <typeparam name="T">Letter, Word, TextLine, etc.</typeparam>
         /// <param name="elements">Array of elements to group.</param>
@@ -140,8 +138,7 @@ namespace UglyToad.PdfPig.DocumentLayoutAnalysis
         }
 
         /// <summary>
-        /// Algorithm to group elements via transitive closure, using nearest neighbours and maximum distance.
-        /// https://en.wikipedia.org/wiki/Transitive_closure
+        /// Algorithm to group elements using nearest neighbours.
         /// </summary>
         /// <typeparam name="T">Letter, Word, TextLine, etc.</typeparam>
         /// <param name="elements">Array of elements to group.</param>

--- a/src/UglyToad.PdfPig/DocumentLayoutAnalysis/Distances.cs
+++ b/src/UglyToad.PdfPig/DocumentLayoutAnalysis/Distances.cs
@@ -91,7 +91,7 @@ namespace UglyToad.PdfPig.DocumentLayoutAnalysis
         /// <param name="distanceMeasure">The distance measure to use.</param>
         /// <param name="distance">The distance between reference point, and its nearest neighbour.</param>
         /// <returns></returns>
-        public static int FindIndexNearest<T>(this T element, IReadOnlyList<T> candidates,
+        internal static int FindIndexNearest<T>(this T element, IReadOnlyList<T> candidates,
             Func<T, PdfPoint> candidatesPoint, Func<T, PdfPoint> pivotPoint,
             Func<PdfPoint, PdfPoint, double> distanceMeasure, out double distance)
         {
@@ -133,7 +133,7 @@ namespace UglyToad.PdfPig.DocumentLayoutAnalysis
         /// <param name="pivotLine"></param>
         /// <param name="distanceMeasure">The distance measure between two lines to use.</param>
         /// <param name="distance">The distance between reference line, and its nearest neighbour.</param>
-        public static int FindIndexNearest<T>(this T element, IReadOnlyList<T> candidates,
+        internal static int FindIndexNearest<T>(this T element, IReadOnlyList<T> candidates,
             Func<T, PdfLine> candidatesLine, Func<T, PdfLine> pivotLine,
             Func<PdfLine, PdfLine, double> distanceMeasure, out double distance)
         {

--- a/src/UglyToad.PdfPig/DocumentLayoutAnalysis/Distances.cs
+++ b/src/UglyToad.PdfPig/DocumentLayoutAnalysis/Distances.cs
@@ -81,52 +81,21 @@ namespace UglyToad.PdfPig.DocumentLayoutAnalysis
         }
 
         /// <summary>
-        /// Find the nearest point.
+        /// Find the index of the nearest point, excluding itself.
         /// </summary>
-        /// <param name="pdfPoint">The reference point, for which to find the nearest neighbour.</param>
-        /// <param name="points">The list of neighbours candidates.</param>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="element">The reference point, for which to find the nearest neighbour.</param>
+        /// <param name="candidates">The list of neighbours candidates.</param>
+        /// <param name="candidatesPoint"></param>
+        /// <param name="pivotPoint"></param>
         /// <param name="distanceMeasure">The distance measure to use.</param>
         /// <param name="distance">The distance between reference point, and its nearest neighbour.</param>
-        public static PdfPoint FindNearest(this PdfPoint pdfPoint, IReadOnlyList<PdfPoint> points,
+        /// <returns></returns>
+        public static int FindIndexNearest<T>(this T element, IReadOnlyList<T> candidates,
+            Func<T, PdfPoint> candidatesPoint, Func<T, PdfPoint> pivotPoint,
             Func<PdfPoint, PdfPoint, double> distanceMeasure, out double distance)
         {
-            if (points == null || points.Count == 0)
-            {
-                throw new ArgumentException("Distances.FindNearest(): The list of neighbours candidates is either null or empty.", "points");
-            }
-
-            if (distanceMeasure == null)
-            {
-                throw new ArgumentException("Distances.FindNearest(): The distance measure must not be null.", "distanceMeasure");
-            }
-            
-            distance = double.MaxValue;
-            PdfPoint closestPoint = default;
-
-            for (var i = 0; i < points.Count; i++)
-            {
-                double currentDistance = distanceMeasure(points[i], pdfPoint);
-                if (currentDistance < distance)
-                {
-                    distance = currentDistance;
-                    closestPoint = points[i];
-                }
-            }
-
-            return closestPoint;
-        }
-
-        /// <summary>
-        /// Find the index of the nearest point.
-        /// </summary>
-        /// <param name="pdfPoint">The reference point, for which to find the nearest neighbour.</param>
-        /// <param name="points">The list of neighbours candidates.</param>
-        /// <param name="distanceMeasure">The distance measure to use.</param>
-        /// <param name="distance">The distance between reference point, and its nearest neighbour.</param>
-        public static int FindIndexNearest(this PdfPoint pdfPoint, IReadOnlyList<PdfPoint> points,
-            Func<PdfPoint, PdfPoint, double> distanceMeasure, out double distance)
-        {
-            if (points == null || points.Count == 0)
+            if (candidates == null || candidates.Count == 0)
             {
                 throw new ArgumentException("Distances.FindIndexNearest(): The list of neighbours candidates is either null or empty.", "points");
             }
@@ -138,11 +107,13 @@ namespace UglyToad.PdfPig.DocumentLayoutAnalysis
 
             distance = double.MaxValue;
             int closestPointIndex = -1;
+            var candidatesPoints = candidates.Select(candidatesPoint).ToList();
+            var pivot = pivotPoint(element);
 
-            for (var i = 0; i < points.Count; i++)
+            for (var i = 0; i < candidates.Count; i++)
             {
-                double currentDistance = distanceMeasure(points[i], pdfPoint);
-                if (currentDistance < distance)
+                double currentDistance = distanceMeasure(candidatesPoints[i], pivot);
+                if (currentDistance < distance && !candidates[i].Equals(element))
                 {
                     distance = currentDistance;
                     closestPointIndex = i;
@@ -153,16 +124,20 @@ namespace UglyToad.PdfPig.DocumentLayoutAnalysis
         }
 
         /// <summary>
-        /// Find the index of the nearest line.
+        /// Find the index of the nearest line, excluding itself.
         /// </summary>
-        /// <param name="pdfLine">The reference line, for which to find the nearest neighbour.</param>
-        /// <param name="lines">The list of neighbours candidates.</param>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="element">The reference line, for which to find the nearest neighbour.</param>
+        /// <param name="candidates">The list of neighbours candidates.</param>
+        /// <param name="candidatesLine"></param>
+        /// <param name="pivotLine"></param>
         /// <param name="distanceMeasure">The distance measure between two lines to use.</param>
         /// <param name="distance">The distance between reference line, and its nearest neighbour.</param>
-        public static int FindIndexNearest(this PdfLine pdfLine, IReadOnlyList<PdfLine> lines,
+        public static int FindIndexNearest<T>(this T element, IReadOnlyList<T> candidates,
+            Func<T, PdfLine> candidatesLine, Func<T, PdfLine> pivotLine,
             Func<PdfLine, PdfLine, double> distanceMeasure, out double distance)
         {
-            if (lines == null || lines.Count == 0)
+            if (candidates == null || candidates.Count == 0)
             {
                 throw new ArgumentException("Distances.FindIndexNearest(): The list of neighbours candidates is either null or empty.", "lines");
             }
@@ -174,11 +149,13 @@ namespace UglyToad.PdfPig.DocumentLayoutAnalysis
 
             distance = double.MaxValue;
             int closestLineIndex = -1;
+            var candidatesLines = candidates.Select(candidatesLine).ToList();
+            var pivot = pivotLine(element);
 
-            for (var i = 0; i < lines.Count; i++)
+            for (var i = 0; i < candidates.Count; i++)
             {
-                double currentDistance = distanceMeasure(lines[i], pdfLine);
-                if (currentDistance < distance)
+                double currentDistance = distanceMeasure(candidatesLines[i], pivot);
+                if (currentDistance < distance && !candidates[i].Equals(element))
                 {
                     distance = currentDistance;
                     closestLineIndex = i;

--- a/src/UglyToad.PdfPig/DocumentLayoutAnalysis/DocstrumBoundingBoxes.cs
+++ b/src/UglyToad.PdfPig/DocumentLayoutAnalysis/DocstrumBoundingBoxes.cs
@@ -207,9 +207,6 @@ namespace UglyToad.PdfPig.DocumentLayoutAnalysis
             return finalDistanceMeasure(pointR, wordsWithinAngleBoundDistancePoints[closestWordIndex]);
         }
 
-        /// <summary>
-        /// Build lines via transitive closure.
-        /// </summary>
         private static IEnumerable<TextLine> GetLines(List<Word> words, double maxDist, AngleBounds withinLine)
         {
             TextDirection textDirection = words[0].TextDirection;
@@ -245,9 +242,6 @@ namespace UglyToad.PdfPig.DocumentLayoutAnalysis
             }
         }
 
-        /// <summary>
-        /// Build blocks via transitive closure.
-        /// </summary>
         private static IEnumerable<TextBlock> GetLinesGroups(TextLine[] lines, double maxDist)
         {
             /**************************************************************************************************

--- a/src/UglyToad.PdfPig/DocumentLayoutAnalysis/NearestNeighbourWordExtractor .cs
+++ b/src/UglyToad.PdfPig/DocumentLayoutAnalysis/NearestNeighbourWordExtractor .cs
@@ -102,7 +102,7 @@ namespace UglyToad.PdfPig.DocumentLayoutAnalysis
 
             Letter[] letters = pageLetters.ToArray();
 
-            var groupedIndexes = ClusteringAlgorithms.SimpleTransitiveClosure(letters,
+            var groupedIndexes = ClusteringAlgorithms.ClusterNearestNeighbours(letters,
                 distMeasure, maxDistanceFunction,
                 l => l.EndBaseLine, l => l.StartBaseLine,
                 l => !string.IsNullOrWhiteSpace(l.Value),


### PR DESCRIPTION
- Changing the `GroupIndexes()` function to use depth first search. The previous implementation was not working properly in some cases.
- Changing the name of `SimpleTransitiveClosure` to `ClusterNearestNeighbours`.
- Changing `FindIndexNearest()` implementation so that it cannot return itsefl.
- Updating `DocstrumBoundingBoxes` by removing the warnings and making the line merging phase (4) more efficient.

More on Depht first search can be found in 'Algorithm design' by Jon Kleinberg and Eva Tardos, on pages 93 and 94. They give a pseudo code and explain its use in grouping (cf. 'Finding the Set of All Connected Components')