### PR TITLE
Fix issue with leaf/nodes in RecursiveXYCut that only have whitespaces words.

### DIFF
--- a/src/UglyToad.PdfPig/DocumentLayoutAnalysis/RecursiveXYCut.cs
+++ b/src/UglyToad.PdfPig/DocumentLayoutAnalysis/RecursiveXYCut.cs
@@ -70,11 +70,18 @@ namespace UglyToad.PdfPig.DocumentLayoutAnalysis
             XYLeaf root = new XYLeaf(pageWords); // Create a root node.
             XYNode node = VerticalCut(root, minimumWidth, dominantFontWidthFunc, dominantFontHeightFunc);
 
-            var leafs = node.GetLeafs();
-
-            if (leafs.Count > 0)
+            if (node.IsLeaf)
             {
-                return leafs.Select(l => new TextBlock(l.GetLines())).ToList();
+                return new List<TextBlock>{ new TextBlock((node as XYLeaf).GetLines())};
+            }
+            else
+            {
+                var leafs = node.GetLeafs();
+
+                if (leafs.Count > 0)
+                {
+                    return leafs.Select(l => new TextBlock(l.GetLines())).ToList();
+                }
             }
 
             return new List<TextBlock>();
@@ -84,6 +91,18 @@ namespace UglyToad.PdfPig.DocumentLayoutAnalysis
             Func<IEnumerable<decimal>, decimal> dominantFontWidthFunc,
             Func<IEnumerable<decimal>, decimal> dominantFontHeightFunc, int level = 0)
         {
+            // order words left to right
+            var words = leaf.Words.Where(w => !string.IsNullOrWhiteSpace(w.Text)).OrderBy(w => w.BoundingBox.Left).ToArray();
+
+            if(!words.Any())
+            {
+                return new XYNode(null);
+            }
+            else
+            {
+                //Create new leaf with non-whitespace words.
+                leaf = new XYLeaf(words);
+            }
             if (leaf.CountWords() <= 1 || leaf.BoundingBox.Width <= minimumWidth)
             {
                 // we stop cutting if 
@@ -91,9 +110,6 @@ namespace UglyToad.PdfPig.DocumentLayoutAnalysis
                 // - width is too small
                 return leaf;
             }
-
-            // order words left to right
-            var words = leaf.Words.Where(w => !string.IsNullOrWhiteSpace(w.Text)).OrderBy(w => w.BoundingBox.Left).ToArray();
 
             // determine dominantFontWidth and dominantFontHeight
             decimal domFontWidth = dominantFontWidthFunc(words.SelectMany(x => x.Letters)
@@ -177,6 +193,18 @@ namespace UglyToad.PdfPig.DocumentLayoutAnalysis
             Func<IEnumerable<decimal>, decimal> dominantFontWidthFunc,
             Func<IEnumerable<decimal>, decimal> dominantFontHeightFunc, int level = 0)
         {
+            var words = leaf.Words.Where(w => !string.IsNullOrWhiteSpace(w.Text)).OrderBy(w => w.BoundingBox.Bottom).ToArray(); // order bottom to top
+
+            if (!words.Any())
+            {
+                return new XYNode(null);
+            }
+            else
+            {
+                //Create new leaf with non-whitespace words.
+                leaf = new XYLeaf(words);
+            }
+
             if (leaf.CountWords() <= 1)
             {
                 // we stop cutting if 
@@ -184,7 +212,6 @@ namespace UglyToad.PdfPig.DocumentLayoutAnalysis
                 return leaf;
             }
 
-            var words = leaf.Words.Where(w => !string.IsNullOrWhiteSpace(w.Text)).OrderBy(w => w.BoundingBox.Bottom).ToArray(); // order bottom to top
 
             // determine dominantFontWidth and dominantFontHeight
             decimal domFontWidth = dominantFontWidthFunc(words.SelectMany(x => x.Letters)

--- a/src/UglyToad.PdfPig/DocumentLayoutAnalysis/RecursiveXYCut.cs
+++ b/src/UglyToad.PdfPig/DocumentLayoutAnalysis/RecursiveXYCut.cs
@@ -103,6 +103,7 @@ namespace UglyToad.PdfPig.DocumentLayoutAnalysis
                 //Create new leaf with non-whitespace words.
                 leaf = new XYLeaf(words);
             }
+
             if (leaf.CountWords() <= 1 || leaf.BoundingBox.Width <= minimumWidth)
             {
                 // we stop cutting if 
@@ -211,7 +212,6 @@ namespace UglyToad.PdfPig.DocumentLayoutAnalysis
                 // - only one word remains
                 return leaf;
             }
-
 
             // determine dominantFontWidth and dominantFontHeight
             decimal domFontWidth = dominantFontWidthFunc(words.SelectMany(x => x.Letters)


### PR DESCRIPTION
In VerticalCut and HorizontalCut, it's using `CountWords() <= 1` as part of the condition to stop cutting with small text segments. This function doesn't exclude all the whitespace words. I made changes to make sure that those two functions will return when finding  XYLeaf/XYNode only have whitespaces words.

In `GetBlocks()`, if the returned node is an XYLeaf node, the `node.GetLeafs()` will return null which will cause the following lines to throw an exception.  I modified that part to make sure it's handling leaf node differently.