### PR TITLE
use doubles where calculations are being run

### DIFF
--- a/src/UglyToad.PdfPig.Tests/DoubleComparer.cs
+++ b/src/UglyToad.PdfPig.Tests/DoubleComparer.cs
@@ -3,21 +3,21 @@ using System.Collections.Generic;
 
 namespace UglyToad.PdfPig.Tests
 {
-    internal class DecimalComparer : IEqualityComparer<decimal>
+    internal class DoubleComparer : IEqualityComparer<double>
     {
-        private readonly decimal precision;
+        private readonly double precision;
 
-        public DecimalComparer(decimal precision)
+        public DoubleComparer(double precision)
         {
             this.precision = precision;
         }
 
-        public bool Equals(decimal x, decimal y)
+        public bool Equals(double x, double y)
         {
             return Math.Abs(x - y) < precision;
         }
 
-        public int GetHashCode(decimal obj)
+        public int GetHashCode(double obj)
         {
             return obj.GetHashCode();
         }

--- a/src/UglyToad.PdfPig.Tests/Fonts/CidFonts/VerticalWritingMetricsTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Fonts/CidFonts/VerticalWritingMetricsTests.cs
@@ -30,16 +30,16 @@
             var data = new VerticalWritingMetrics(defaults, null, null);
 
             var position = data.GetPositionVector(9, 120);
-            Assert.Equal(120 / 2m, position.X);
+            Assert.Equal(120 / 2d, position.X);
 
             var displacement = data.GetDisplacementVector(10);
-            Assert.Equal(0m, displacement.X);
+            Assert.Equal(0d, displacement.X);
         }
 
         [Fact]
         public void UsesVectorOverridesWhenPresent()
         {
-            var data = new VerticalWritingMetrics(defaults, new Dictionary<int, decimal> {{7, 120}},
+            var data = new VerticalWritingMetrics(defaults, new Dictionary<int, double> {{7, 120}},
                 new Dictionary<int, PdfVector> {{7, new PdfVector(25, 250)}});
 
             var position = data.GetPositionVector(7, 360);

--- a/src/UglyToad.PdfPig.Tests/Fonts/TrueType/Parser/TrueTypeFontParserTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Fonts/TrueType/Parser/TrueTypeFontParserTests.cs
@@ -202,8 +202,8 @@
             {
                 var match = regex.Match(lines[i]);
 
-                var width = decimal.Parse(match.Groups["width"].Value, CultureInfo.InvariantCulture);
-                var height = decimal.Parse(match.Groups["height"].Value, CultureInfo.InvariantCulture);
+                var width = double.Parse(match.Groups["width"].Value, CultureInfo.InvariantCulture);
+                var height = double.Parse(match.Groups["height"].Value, CultureInfo.InvariantCulture);
                 var points = int.Parse(match.Groups["points"].Value, CultureInfo.InvariantCulture);
 
                 var glyph = font.TableRegister.GlyphTable.Glyphs[i];

--- a/src/UglyToad.PdfPig.Tests/Fonts/TrueType/Parser/TrueTypeFontParserTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Fonts/TrueType/Parser/TrueTypeFontParserTests.cs
@@ -1,4 +1,5 @@
-﻿namespace UglyToad.PdfPig.Tests.Fonts.TrueType.Parser
+﻿// ReSharper disable CompareOfFloatsByEqualityOperator
+namespace UglyToad.PdfPig.Tests.Fonts.TrueType.Parser
 {
     using System;
     using System.Globalization;
@@ -159,7 +160,7 @@
 
             Assert.Equal("Andada Regular", name);
 
-            Assert.Equal(1.001999m, font.TableRegister.HeaderTable.Revision);
+            Assert.Equal(1.001999, font.TableRegister.HeaderTable.Revision, new DoubleComparer(5));
 
             Assert.Equal(11, font.TableRegister.HeaderTable.Flags);
 
@@ -182,6 +183,8 @@
             var input = new TrueTypeDataBytes(new ByteArrayInputBytes(bytes));
 
             var font = parser.Parse(input);
+
+            Assert.NotNull(font);
         }
 
         [Fact]

--- a/src/UglyToad.PdfPig.Tests/Geometry/PdfLineTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Geometry/PdfLineTests.cs
@@ -21,50 +21,50 @@ namespace UglyToad.PdfPig.Tests.Geometry
         public void Length()
         {
             var line = new PdfLine(2, 1, 6, 4);
-            Assert.Equal(5m, line.Length);
+            Assert.Equal(5d, line.Length);
 
             var line2 = new PdfLine(-2, 8, -7, -5);
-            Assert.Equal(13.93m, Math.Round(line2.Length, 2));
+            Assert.Equal(13.93d, Math.Round(line2.Length, 2));
         }
 
         [Fact]
         public void Contains()
         {
-            var line = new PdfLine(10, 7.5m, 26.3m, 12);
+            var line = new PdfLine(10, 7.5d, 26.3d, 12);
             Assert.False(line.Contains(new PdfPoint(5, 2)));
-            Assert.False(line.Contains(new PdfPoint(5, 6.11963190184049m)));
-            Assert.False(line.Contains(new PdfPoint(27, 12.1932515337423m)));
+            Assert.False(line.Contains(new PdfPoint(5, 6.11963190184049d)));
+            Assert.False(line.Contains(new PdfPoint(27, 12.1932515337423d)));
             Assert.False(line.Contains(new PdfPoint(12, 15)));
             Assert.False(line.Contains(new PdfPoint(10, 12)));
-            Assert.True(line.Contains(new PdfPoint(20, 10.260736196319m)));
-            Assert.True(line.Contains(new PdfPoint(10, 7.5m)));
+            Assert.True(line.Contains(new PdfPoint(20, 10.260736196319d)));
+            Assert.True(line.Contains(new PdfPoint(10, 7.5d)));
 
-            var verticalLine = new PdfLine(10, 7.5m, 10, 15);
+            var verticalLine = new PdfLine(10, 7.5d, 10, 15);
             Assert.False(verticalLine.Contains(new PdfPoint(5, 2)));
             Assert.False(verticalLine.Contains(new PdfPoint(12, 15)));
             Assert.False(verticalLine.Contains(new PdfPoint(10, 16)));
             Assert.False(verticalLine.Contains(new PdfPoint(10, 7)));
             Assert.True(verticalLine.Contains(new PdfPoint(10, 12)));
-            Assert.True(verticalLine.Contains(new PdfPoint(10, 7.5m)));
+            Assert.True(verticalLine.Contains(new PdfPoint(10, 7.5d)));
 
-            var horizontalLine = new PdfLine(10, 7.5m, 26.3m, 7.5m);
+            var horizontalLine = new PdfLine(10, 7.5d, 26.3d, 7.5d);
             Assert.False(horizontalLine.Contains(new PdfPoint(5, 2)));
             Assert.False(horizontalLine.Contains(new PdfPoint(5, 7.5)));
             Assert.False(horizontalLine.Contains(new PdfPoint(27, 7.5)));
             Assert.False(horizontalLine.Contains(new PdfPoint(10, 12)));
             Assert.True(horizontalLine.Contains(new PdfPoint(20, 7.5)));
-            Assert.True(horizontalLine.Contains(new PdfPoint(26.3m, 7.5m)));
+            Assert.True(horizontalLine.Contains(new PdfPoint(26.3d, 7.5d)));
         }
 
         [Fact]
         public void ParallelTo()
         {
-            var verticalLine1 = new PdfLine(10, 7.5m, 10, 15);
-            var verticalLine2 = new PdfLine(200, 0, 200, 551.5467m);
-            var horizontalLine1 = new PdfLine(10, 7.5m, 26.3m, 7.5m);
-            var horizontalLine2 = new PdfLine(27, 57, 200.9999872m, 57);
-            var obliqueLine1 = new PdfLine(10, 7.5m, 26.3m, 12);
-            var obliqueLine2 = new PdfLine(60, 28.8036809815951m, 40, 23.2822085889571m);
+            var verticalLine1 = new PdfLine(10, 7.5d, 10, 15);
+            var verticalLine2 = new PdfLine(200, 0, 200, 551.5467d);
+            var horizontalLine1 = new PdfLine(10, 7.5d, 26.3d, 7.5d);
+            var horizontalLine2 = new PdfLine(27, 57, 200.9999872d, 57);
+            var obliqueLine1 = new PdfLine(10, 7.5d, 26.3d, 12);
+            var obliqueLine2 = new PdfLine(60, 28.8036809815951d, 40, 23.2822085889571d);
 
             Assert.True(verticalLine1.ParallelTo(verticalLine2));
             Assert.True(verticalLine2.ParallelTo(verticalLine1));
@@ -92,82 +92,6 @@ namespace UglyToad.PdfPig.Tests.Geometry
 
             Assert.True(obliqueLine1.ParallelTo(obliqueLine2));
             Assert.True(obliqueLine2.ParallelTo(obliqueLine1));
-        }
-
-        [Fact]
-        public void IntersectsWithLine()
-        {
-            var verticalLine1 = new PdfLine(10, 7.5m, 10, 15);
-            var verticalLine2 = new PdfLine(200, 0, 200, 551.5467m);
-            var horizontalLine1 = new PdfLine(10, 7.5m, 26.3m, 7.5m);
-            var horizontalLine2 = new PdfLine(27, 57, 200.9999872m, 57);
-            var horizontalLine3 = new PdfLine(27, 57, 250, 57);
-            var obliqueLine1 = new PdfLine(10, 7.5m, 26.3m, 12);
-            var obliqueLine2 = new PdfLine(60, 28.8036809815951m, 40, 23.2822085889571m);
-            var obliqueLine3 = new PdfLine(20, 7.5m, 10, 15);
-
-            Assert.False(verticalLine1.IntersectsWith(verticalLine2));
-            Assert.False(verticalLine2.IntersectsWith(verticalLine1));
-            Assert.False(horizontalLine1.IntersectsWith(horizontalLine2));
-            Assert.False(horizontalLine2.IntersectsWith(horizontalLine1));
-            Assert.False(obliqueLine1.IntersectsWith(obliqueLine2));
-            Assert.False(obliqueLine2.IntersectsWith(obliqueLine1));
-            Assert.False(obliqueLine1.IntersectsWith(obliqueLine1));
-            Assert.False(obliqueLine1.IntersectsWith(verticalLine2));
-            Assert.False(verticalLine2.IntersectsWith(obliqueLine1));
-            Assert.False(obliqueLine1.IntersectsWith(horizontalLine2));
-            Assert.False(horizontalLine2.IntersectsWith(obliqueLine1));
-            Assert.False(verticalLine1.IntersectsWith(horizontalLine2));
-            Assert.False(horizontalLine2.IntersectsWith(verticalLine1));
-
-            Assert.True(obliqueLine1.IntersectsWith(horizontalLine1));
-            Assert.True(horizontalLine1.IntersectsWith(obliqueLine1));
-            Assert.True(obliqueLine1.IntersectsWith(verticalLine1));
-            Assert.True(verticalLine1.IntersectsWith(obliqueLine1));
-            Assert.True(verticalLine2.IntersectsWith(horizontalLine2));
-            Assert.True(horizontalLine2.IntersectsWith(verticalLine2));
-            Assert.True(verticalLine2.IntersectsWith(horizontalLine3));
-            Assert.True(horizontalLine3.IntersectsWith(verticalLine2));
-            Assert.True(obliqueLine1.IntersectsWith(obliqueLine3));
-            Assert.True(obliqueLine3.IntersectsWith(obliqueLine1));
-        }
-
-        [Fact]
-        public void IntersectLine()
-        {
-            var verticalLine1 = new PdfLine(10, 7.5m, 10, 15);
-            var verticalLine2 = new PdfLine(200, 0, 200, 551.5467m);
-            var horizontalLine1 = new PdfLine(10, 7.5m, 26.3m, 7.5m);
-            var horizontalLine2 = new PdfLine(27, 57, 200.9999872m, 57);
-            var horizontalLine3 = new PdfLine(27, 57, 250, 57);
-            var obliqueLine1 = new PdfLine(10, 7.5m, 26.3m, 12);
-            var obliqueLine2 = new PdfLine(60, 28.8036809815951m, 40, 23.2822085889571m);
-            var obliqueLine3 = new PdfLine(20, 7.5m, 10, 15);
-
-            Assert.Null(verticalLine1.Intersect(verticalLine2));
-            Assert.Null(verticalLine2.Intersect(verticalLine1));
-            Assert.Null(horizontalLine1.Intersect(horizontalLine2));
-            Assert.Null(horizontalLine2.Intersect(horizontalLine1));
-            Assert.Null(obliqueLine1.Intersect(obliqueLine2));
-            Assert.Null(obliqueLine2.Intersect(obliqueLine1));
-            Assert.Null(obliqueLine1.Intersect(obliqueLine1));
-            Assert.Null(obliqueLine1.Intersect(verticalLine2));
-            Assert.Null(verticalLine2.Intersect(obliqueLine1));
-            Assert.Null(obliqueLine1.Intersect(horizontalLine2));
-            Assert.Null(horizontalLine2.Intersect(obliqueLine1));
-            Assert.Null(verticalLine1.Intersect(horizontalLine2));
-            Assert.Null(horizontalLine2.Intersect(verticalLine1));
-
-            Assert.Equal(new PdfPoint(10, 7.5m), obliqueLine1.Intersect(horizontalLine1));
-            Assert.Equal(new PdfPoint(10, 7.5m), horizontalLine1.Intersect(obliqueLine1));
-            Assert.Equal(new PdfPoint(10, 7.5m), obliqueLine1.Intersect(verticalLine1));
-            Assert.Equal(new PdfPoint(10, 7.5m), verticalLine1.Intersect(obliqueLine1));
-            Assert.Equal(new PdfPoint(200, 57), verticalLine2.Intersect(horizontalLine2));
-            Assert.Equal(new PdfPoint(200, 57), horizontalLine2.Intersect(verticalLine2));
-            Assert.Equal(new PdfPoint(200, 57), verticalLine2.Intersect(horizontalLine3));
-            Assert.Equal(new PdfPoint(200, 57), horizontalLine3.Intersect(verticalLine2));
-            Assert.Equal(new PdfPoint(17.3094170403587m, 9.51793721973094m), obliqueLine1.Intersect(obliqueLine3));
-            Assert.Equal(new PdfPoint(17.3094170403587m, 9.51793721973094m), obliqueLine3.Intersect(obliqueLine1));
         }
     }
 }

--- a/src/UglyToad.PdfPig.Tests/Geometry/PdfPointTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Geometry/PdfPointTests.cs
@@ -28,8 +28,8 @@
         {
             var origin = new PdfPoint(0.534436, 0.32552);
 
-            Assert.Equal(0.534436m, origin.X);
-            Assert.Equal(0.32552m, origin.Y);
+            Assert.Equal(0.534436, origin.X);
+            Assert.Equal(0.32552, origin.Y);
         }
     }
 }

--- a/src/UglyToad.PdfPig.Tests/Geometry/PdfRectangleTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Geometry/PdfRectangleTests.cs
@@ -8,10 +8,10 @@ namespace UglyToad.PdfPig.Tests.Geometry
         public void Area()
         {
             PdfRectangle rectangle = new PdfRectangle(10, 10, 20, 20);
-            Assert.Equal(100m, rectangle.Area);
+            Assert.Equal(100d, rectangle.Area);
 
-            PdfRectangle rectangle1 = new PdfRectangle(149.95376m, 687.13456m, 451.73539m, 1478.4997m);
-            Assert.Equal(238819.4618743782m, rectangle1.Area);
+            PdfRectangle rectangle1 = new PdfRectangle(149.95376d, 687.13456d, 451.73539d, 1478.4997d);
+            Assert.Equal(238819.4618743782d, rectangle1.Area);
         }
 
         public void Centroid()
@@ -19,19 +19,19 @@ namespace UglyToad.PdfPig.Tests.Geometry
             PdfRectangle rectangle = new PdfRectangle(10, 10, 20, 20);
             Assert.Equal(new PdfPoint(15, 15), rectangle.Centroid);
 
-            PdfRectangle rectangle1 = new PdfRectangle(149.95376m, 687.13456m, 451.73539m, 1478.4997m);
-            Assert.Equal(new PdfPoint(300.844575m, 1082.81713m), rectangle1.Centroid);
+            PdfRectangle rectangle1 = new PdfRectangle(149.95376d, 687.13456d, 451.73539d, 1478.4997d);
+            Assert.Equal(new PdfPoint(300.844575d, 1082.81713d), rectangle1.Centroid);
         }
 
         public void Intersect()
         {
             PdfRectangle rectangle = new PdfRectangle(10, 10, 20, 20);
-            PdfRectangle rectangle1 = new PdfRectangle(149.95376m, 687.13456m, 451.73539m, 1478.4997m);
+            PdfRectangle rectangle1 = new PdfRectangle(149.95376d, 687.13456d, 451.73539d, 1478.4997d);
             Assert.Null(rectangle.Intersect(rectangle1));
             Assert.Equal(rectangle1, rectangle1.Intersect(rectangle1));
 
-            PdfRectangle rectangle2 = new PdfRectangle(50, 687.13456m, 350, 1478.4997m);
-            Assert.Equal(new PdfRectangle(149.95376m, 687.13456m, 350, 1478.4997m), rectangle1.Intersect(rectangle2));
+            PdfRectangle rectangle2 = new PdfRectangle(50, 687.13456d, 350, 1478.4997d);
+            Assert.Equal(new PdfRectangle(149.95376d, 687.13456d, 350, 1478.4997d), rectangle1.Intersect(rectangle2));
 
             PdfRectangle rectangle3 = new PdfRectangle(200, 800, 350, 1200);
             Assert.Equal(rectangle3, rectangle1.Intersect(rectangle3));
@@ -40,11 +40,11 @@ namespace UglyToad.PdfPig.Tests.Geometry
         public void IntersectsWith()
         {
             PdfRectangle rectangle = new PdfRectangle(10, 10, 20, 20);
-            PdfRectangle rectangle1 = new PdfRectangle(149.95376m, 687.13456m, 451.73539m, 1478.4997m);
+            PdfRectangle rectangle1 = new PdfRectangle(149.95376d, 687.13456d, 451.73539d, 1478.4997d);
             Assert.False(rectangle.IntersectsWith(rectangle1));
             Assert.True(rectangle1.IntersectsWith(rectangle1));
 
-            PdfRectangle rectangle2 = new PdfRectangle(50, 687.13456m, 350, 1478.4997m);
+            PdfRectangle rectangle2 = new PdfRectangle(50, 687.13456d, 350, 1478.4997d);
             Assert.True(rectangle1.IntersectsWith(rectangle2));
 
             PdfRectangle rectangle3 = new PdfRectangle(200, 800, 350, 1200);

--- a/src/UglyToad.PdfPig.Tests/Geometry/PdfVectorTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Geometry/PdfVectorTests.cs
@@ -8,24 +8,24 @@
         [Fact]
         public void ConstructorSetsValues()
         {
-            var vector = new PdfVector(5.2m, 6.9m);
+            var vector = new PdfVector(5.2d, 6.9d);
 
-            Assert.Equal(5.2m, vector.X);
-            Assert.Equal(6.9m, vector.Y);
+            Assert.Equal(5.2d, vector.X);
+            Assert.Equal(6.9d, vector.Y);
         }
 
         [Fact]
         public void ScaleMultipliesLeavesOriginalUnchanged()
         {
-            var vector = new PdfVector(5.2m, 6.9m);
+            var vector = new PdfVector(5.2d, 6.9d);
 
-            var scaled = vector.Scale(0.7m);
+            var scaled = vector.Scale(0.7d);
 
-            Assert.Equal(5.2m, vector.X);
-            Assert.Equal(5.2m * 0.7m, scaled.X);
+            Assert.Equal(5.2d, vector.X);
+            Assert.Equal(5.2d * 0.7d, scaled.X);
 
-            Assert.Equal(6.9m, vector.Y);
-            Assert.Equal(6.9m * 0.7m, scaled.Y);
+            Assert.Equal(6.9d, vector.Y);
+            Assert.Equal(6.9d * 0.7d, scaled.Y);
         }
     }
 }

--- a/src/UglyToad.PdfPig.Tests/Graphics/Operations/TextState/SetFontAndSizeTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Graphics/Operations/TextState/SetFontAndSizeTests.cs
@@ -62,7 +62,7 @@
 
             var state = context.GetCurrentState();
 
-            Assert.Equal(69.42m, state.FontState.FontSize);
+            Assert.Equal(69.42, state.FontState.FontSize);
             Assert.Equal(Font1Name, state.FontState.FontName);
         }
     }

--- a/src/UglyToad.PdfPig.Tests/Integration/AssertablePositionData.cs
+++ b/src/UglyToad.PdfPig.Tests/Integration/AssertablePositionData.cs
@@ -7,19 +7,19 @@
 
     public class AssertablePositionData
     {
-        public decimal X { get; set; }
+        public double X { get; set; }
 
-        public decimal Y { get; set; }
+        public double Y { get; set; }
 
-        public decimal Width { get; set; }
+        public double Width { get; set; }
 
         public string Text { get; set; }
 
-        public decimal FontSize { get; set; }
+        public double FontSize { get; set; }
 
         public string FontName { get; set; }
 
-        public decimal Height { get; set; }
+        public double Height { get; set; }
 
         public static AssertablePositionData Parse(string line)
         {
@@ -30,15 +30,15 @@
                 throw new ArgumentException($"Expected 6 parts to the line, instead got {parts.Length}");
             }
 
-            var height = parts.Length < 7 ? 0 : decimal.Parse(parts[6], CultureInfo.InvariantCulture);
+            var height = parts.Length < 7 ? 0 : double.Parse(parts[6], CultureInfo.InvariantCulture);
 
             return new AssertablePositionData
             {
-                X = decimal.Parse(parts[0], CultureInfo.InvariantCulture),
-                Y = decimal.Parse(parts[1], CultureInfo.InvariantCulture),
-                Width = decimal.Parse(parts[2], CultureInfo.InvariantCulture),
+                X = double.Parse(parts[0], CultureInfo.InvariantCulture),
+                Y = double.Parse(parts[1], CultureInfo.InvariantCulture),
+                Width = double.Parse(parts[2], CultureInfo.InvariantCulture),
                 Text = parts[3],
-                FontSize = decimal.Parse(parts[4], CultureInfo.InvariantCulture),
+                FontSize = double.Parse(parts[4], CultureInfo.InvariantCulture),
                 FontName = parts[5],
                 Height = height
             };

--- a/src/UglyToad.PdfPig.Tests/Integration/SinglePageFormContentIText1Tests.cs
+++ b/src/UglyToad.PdfPig.Tests/Integration/SinglePageFormContentIText1Tests.cs
@@ -63,7 +63,7 @@
                 {
                     var stripped = x.Trim();
                     var parts = stripped.Split('|');
-                    return (index: int.Parse(parts[0]), letter: parts[1], x: decimal.Parse(parts[2]), y: decimal.Parse(parts[3]));
+                    return (index: int.Parse(parts[0]), letter: parts[1], x: double.Parse(parts[2]), y: double.Parse(parts[3]));
                 }).ToArray();
 
             using (var document = PdfDocument.Open(GetFilename()))
@@ -75,8 +75,8 @@
                     var letter = page.Letters[expected.index];
 
                     Assert.Equal(expected.letter, letter.Value);
-                    Assert.Equal(expected.x, decimal.Round(letter.Location.X, 2));
-                    Assert.Equal(expected.y, decimal.Round(letter.Location.Y, 2));
+                    Assert.Equal(expected.x, Math.Round(letter.Location.X, 2));
+                    Assert.Equal(expected.y, Math.Round(letter.Location.Y, 2));
                 }
             }
         }

--- a/src/UglyToad.PdfPig.Tests/Integration/SinglePageLibreOfficeImages.cs
+++ b/src/UglyToad.PdfPig.Tests/Integration/SinglePageLibreOfficeImages.cs
@@ -24,6 +24,8 @@
         [Fact]
         public void ImagesHaveCorrectDimensionsAndLocations()
         {
+            var doubleComparer = new DoubleComparer(1);
+
             using (var document = PdfDocument.Open(GetFilePath(), ParsingOptions.LenientParsingOff))
             {
                 var page = document.GetPage(1);
@@ -32,24 +34,25 @@
 
                 var pdfPigSquare = images[0];
 
-                Assert.Equal(148.3m, pdfPigSquare.Bounds.Width);
-                Assert.Equal(148.3m, pdfPigSquare.Bounds.Height);
-                Assert.Equal(60.1m, pdfPigSquare.Bounds.Left);
-                Assert.Equal(765.8m, pdfPigSquare.Bounds.Top);
+                Assert.Equal(148.3d, pdfPigSquare.Bounds.Width, doubleComparer);
+                Assert.Equal(148.3d, pdfPigSquare.Bounds.Height, doubleComparer);
+                Assert.Equal(60.1d, pdfPigSquare.Bounds.Left, doubleComparer);
+                Assert.Equal(765.8d, pdfPigSquare.Bounds.Top, doubleComparer);
+
 
                 var pdfPigSquished = images[1];
 
-                Assert.Equal(206.8m, pdfPigSquished.Bounds.Width);
-                Assert.Equal(83.2m, pdfPigSquished.Bounds.Height);
-                Assert.Equal(309.8m, pdfPigSquished.Bounds.Left);
-                Assert.Equal(552.1m, pdfPigSquished.Bounds.Top);
+                Assert.Equal(206.8d, pdfPigSquished.Bounds.Width, doubleComparer);
+                Assert.Equal(83.2d, pdfPigSquished.Bounds.Height, doubleComparer);
+                Assert.Equal(309.8d, pdfPigSquished.Bounds.Left, doubleComparer);
+                Assert.Equal(552.1d, pdfPigSquished.Bounds.Top, doubleComparer);
 
                 var birthdayPigs = images[2];
 
-                Assert.Equal(391m, birthdayPigs.Bounds.Width);
-                Assert.Equal(267.1m, birthdayPigs.Bounds.Height);
-                Assert.Equal(102.2m, birthdayPigs.Bounds.Left);
-                Assert.Equal(426.3m, birthdayPigs.Bounds.Top);
+                Assert.Equal(391d, birthdayPigs.Bounds.Width, doubleComparer);
+                Assert.Equal(267.1d, birthdayPigs.Bounds.Height, doubleComparer);
+                Assert.Equal(102.2d, birthdayPigs.Bounds.Left, doubleComparer);
+                Assert.Equal(426.3d, birthdayPigs.Bounds.Top, doubleComparer);
             }
         }
 

--- a/src/UglyToad.PdfPig.Tests/Integration/SinglePageNonLatinAcrobatDistillerTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Integration/SinglePageNonLatinAcrobatDistillerTests.cs
@@ -79,7 +79,7 @@
                         continue;
                     }
 
-                    var comparer = new DecimalComparer(3m);
+                    var comparer = new DoubleComparer(3);
 
                     Assert.Equal(theirLetter, myLetter);
 
@@ -95,7 +95,7 @@
         [Fact]
         public void LetterPositionsAreCorrectXfinium()
         {
-            var comparer = new DecimalComparer(1);
+            var comparer = new DoubleComparer(1);
 
             using (var document = PdfDocument.Open(GetFilename()))
             {

--- a/src/UglyToad.PdfPig.Tests/Integration/SinglePageSimpleGoogleChromeTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Integration/SinglePageSimpleGoogleChromeTests.cs
@@ -183,7 +183,7 @@ namespace UglyToad.PdfPig.Tests.Integration
                     Assert.Equal(datum.Y, transformed, 2);
 
                     // Until we get width from glyphs we're a bit out.
-                    Assert.True(Math.Abs(datum.Width - letter.Width) < 0.03m);
+                    Assert.True(Math.Abs(datum.Width - letter.Width) < 0.03);
 
                     index++;
                 }

--- a/src/UglyToad.PdfPig.Tests/Integration/SinglePageSimpleOpenOfficeTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Integration/SinglePageSimpleOpenOfficeTests.cs
@@ -41,31 +41,31 @@
             {
                 var page = document.GetPage(1);
 
-                var comparer = new DecimalComparer(3m);
+                var comparer = new DoubleComparer(3d);
 
                 Assert.Equal("I", page.Letters[0].Value);
 
-                Assert.Equal(90.1m, page.Letters[0].GlyphRectangle.BottomLeft.X, comparer);
-                Assert.Equal(709.2m, page.Letters[0].GlyphRectangle.BottomLeft.Y, comparer);
+                Assert.Equal(90.1d, page.Letters[0].GlyphRectangle.BottomLeft.X, comparer);
+                Assert.Equal(709.2d, page.Letters[0].GlyphRectangle.BottomLeft.Y, comparer);
 
-                Assert.Equal(94.0m, page.Letters[0].GlyphRectangle.TopRight.X, comparer);
-                Assert.Equal(719.89m, page.Letters[0].GlyphRectangle.TopRight.Y, comparer);
+                Assert.Equal(94.0d, page.Letters[0].GlyphRectangle.TopRight.X, comparer);
+                Assert.Equal(719.89d, page.Letters[0].GlyphRectangle.TopRight.Y, comparer);
 
                 Assert.Equal("a", page.Letters[5].Value);
 
-                Assert.Equal(114.5m, page.Letters[5].GlyphRectangle.BottomLeft.X, comparer);
-                Assert.Equal(709.2m, page.Letters[5].GlyphRectangle.BottomLeft.Y, comparer);
+                Assert.Equal(114.5d, page.Letters[5].GlyphRectangle.BottomLeft.X, comparer);
+                Assert.Equal(709.2d, page.Letters[5].GlyphRectangle.BottomLeft.Y, comparer);
 
-                Assert.Equal(119.82m, page.Letters[5].GlyphRectangle.TopRight.X, comparer);
-                Assert.Equal(714.89m, page.Letters[5].GlyphRectangle.TopRight.Y, comparer);
+                Assert.Equal(119.82d, page.Letters[5].GlyphRectangle.TopRight.X, comparer);
+                Assert.Equal(714.89d, page.Letters[5].GlyphRectangle.TopRight.Y, comparer);
 
                 Assert.Equal("f", page.Letters[16].Value);
 
-                Assert.Equal(169.9m, page.Letters[16].GlyphRectangle.BottomLeft.X, comparer);
-                Assert.Equal(709.2m, page.Letters[16].GlyphRectangle.BottomLeft.Y, comparer);
+                Assert.Equal(169.9d, page.Letters[16].GlyphRectangle.BottomLeft.X, comparer);
+                Assert.Equal(709.2d, page.Letters[16].GlyphRectangle.BottomLeft.Y, comparer);
 
-                Assert.Equal(176.89m, page.Letters[16].GlyphRectangle.TopRight.X, comparer);
-                Assert.Equal(719.89m, page.Letters[16].GlyphRectangle.TopRight.Y, comparer);
+                Assert.Equal(176.89d, page.Letters[16].GlyphRectangle.TopRight.X, comparer);
+                Assert.Equal(719.89d, page.Letters[16].GlyphRectangle.TopRight.Y, comparer);
             }
         }
 

--- a/src/UglyToad.PdfPig.Tests/Writer/PdfDocumentBuilderTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Writer/PdfDocumentBuilderTests.cs
@@ -250,10 +250,10 @@
             page1.AddText("incididunt ut labore et dolore magna aliqua.", 9, new PdfPoint(30, topLine.Y - letters.Max(x => x.GlyphRectangle.Height) - 5), font);
 
             var page2Letters = page2.AddText("The very hungry caterpillar ate all the apples in the garden.", 12, topLine, font);
-            var left = page2Letters[0].GlyphRectangle.Left;
-            var bottom = page2Letters.Min(x => x.GlyphRectangle.Bottom);
-            var right = page2Letters[page2Letters.Count - 1].GlyphRectangle.Right;
-            var top = page2Letters.Max(x => x.GlyphRectangle.Top);
+            var left = (decimal)page2Letters[0].GlyphRectangle.Left;
+            var bottom = (decimal)page2Letters.Min(x => x.GlyphRectangle.Bottom);
+            var right = (decimal)page2Letters[page2Letters.Count - 1].GlyphRectangle.Right;
+            var top = (decimal)page2Letters.Max(x => x.GlyphRectangle.Top);
             page2.SetStrokeColor(10, 250, 69);
             page2.DrawRectangle(new PdfPoint(left, bottom), right - left, top - bottom);
 

--- a/src/UglyToad.PdfPig/Annotations/HyperlinkFactory.cs
+++ b/src/UglyToad.PdfPig/Annotations/HyperlinkFactory.cs
@@ -40,7 +40,7 @@
                 var bounds = annotation.Rectangle;
 
                 // Build in tolerance for letters close to the link region.
-                var tolerantBounds = new PdfRectangle(bounds.TopLeft.Translate(-0.5m, 0), bounds.BottomRight.Translate(0.5m, 0));
+                var tolerantBounds = new PdfRectangle(bounds.TopLeft.Translate(-0.5, 0), bounds.BottomRight.Translate(0.5, 0));
 
                 var linkLetters = new List<Letter>();
 

--- a/src/UglyToad.PdfPig/Content/Letter.cs
+++ b/src/UglyToad.PdfPig/Content/Letter.cs
@@ -36,7 +36,7 @@
         /// <summary>
         /// The width occupied by the character within the PDF content.
         /// </summary>
-        public decimal Width { get; }
+        public double Width { get; }
 
         /// <summary>
         /// Position of the bounding box for the glyph, this is the box surrounding the visible glyph as it appears on the page.
@@ -48,7 +48,7 @@
         /// <summary>
         /// Size as defined in the PDF file. This is not equivalent to font size in points but is relative to other font sizes on the page.
         /// </summary>
-        public decimal FontSize { get; }
+        public double FontSize { get; }
 
         /// <summary>
         /// The name of the font.
@@ -63,7 +63,7 @@
         /// <summary>
         /// The size of the font in points. This is not ready for public consumption as the calculation is incorrect.
         /// </summary>
-        internal decimal PointSize { get; }
+        internal double PointSize { get; }
 
         /// <summary>
         /// Sequence number of the ShowText operation that printed this letter.
@@ -76,11 +76,11 @@
         internal Letter(string value, PdfRectangle glyphRectangle, 
             PdfPoint startBaseLine, 
             PdfPoint endBaseLine,
-            decimal width, 
-            decimal fontSize,
+            double width,
+            double fontSize,
             string fontName, 
             IColor color,
-            decimal pointSize,
+            double pointSize,
             int textSequence)
         {
             Value = value;
@@ -98,7 +98,7 @@
 
         private TextDirection GetTextDirection()
         {
-            if (System.Math.Abs(StartBaseLine.Y - EndBaseLine.Y) < 10e-5m)
+            if (System.Math.Abs(StartBaseLine.Y - EndBaseLine.Y) < 10e-5)
             {
                 if (StartBaseLine.X > EndBaseLine.X)
                 {
@@ -108,7 +108,7 @@
                 return TextDirection.Horizontal;
             }
 
-            if (System.Math.Abs(StartBaseLine.X - EndBaseLine.X) < 10e-5m)
+            if (System.Math.Abs(StartBaseLine.X - EndBaseLine.X) < 10e-5)
             {
                 if (StartBaseLine.Y > EndBaseLine.Y)
                 {

--- a/src/UglyToad.PdfPig/Content/MediaBox.cs
+++ b/src/UglyToad.PdfPig/Content/MediaBox.cs
@@ -14,22 +14,22 @@
         ///<summary>
         /// User space units per inch.
         /// </summary>
-        private const decimal PointsPerInch = 72;
+        private const double PointsPerInch = 72;
 
         /// <summary>
         /// User space units per millimeter.
         /// </summary>
-        private const decimal PointsPerMm = 1 / (10 * 2.54m) * PointsPerInch;
+        private const double PointsPerMm = 1 / (10 * 2.54) * PointsPerInch;
 
         /// <summary>
         /// A <see cref="MediaBox"/> the size of U.S. Letter, 8.5" x 11" Paper.
         /// </summary>
-        public static readonly MediaBox Letter = new MediaBox(new PdfRectangle(0, 0, 8.5m * PointsPerInch, 11m * PointsPerInch));
+        public static readonly MediaBox Letter = new MediaBox(new PdfRectangle(0, 0, 8.5 * PointsPerInch, 11 * PointsPerInch));
 
         /// <summary>
         /// A <see cref="MediaBox"/> the size of U.S. Legal, 8.5" x 14" Paper.
         /// </summary>
-        public static readonly MediaBox Legal = new MediaBox(new PdfRectangle(0, 0, 8.5m * PointsPerInch, 14m * PointsPerInch));
+        public static readonly MediaBox Legal = new MediaBox(new PdfRectangle(0, 0, 8.5 * PointsPerInch, 14 * PointsPerInch));
 
         /// <summary>
         /// A <see cref="MediaBox"/> the size of A0 Paper.

--- a/src/UglyToad.PdfPig/Content/Page.cs
+++ b/src/UglyToad.PdfPig/Content/Page.cs
@@ -57,12 +57,12 @@
         /// <summary>
         /// Gets the width of the page in points.
         /// </summary>
-        public decimal Width { get; }
+        public double Width { get; }
 
         /// <summary>
         /// Gets the height of the page in points.
         /// </summary>
-        public decimal Height { get; }
+        public double Height { get; }
 
         /// <summary>
         /// The size of the page according to the standard page sizes or <see cref="PageSize.Custom"/> if no matching standard size found.
@@ -185,7 +185,7 @@
             /// Gets the calculated letter size in points.
             /// This is considered experimental because the calculated value is incorrect for some documents at present.
             /// </summary>
-            public decimal GetPointSize(Letter letter)
+            public double GetPointSize(Letter letter)
             {
                 return letter.PointSize;
             }

--- a/src/UglyToad.PdfPig/Content/PageRotationDegrees.cs
+++ b/src/UglyToad.PdfPig/Content/PageRotationDegrees.cs
@@ -9,9 +9,9 @@
     /// </summary>
     public struct PageRotationDegrees : IEquatable<PageRotationDegrees>
     {
-        private static readonly TransformationMatrix Rotate90 = TransformationMatrix.FromValues(0m, -1, 1, 0);
-        private static readonly TransformationMatrix Rotate180 = TransformationMatrix.FromValues(-1m, 0, 0, -1);
-        private static readonly TransformationMatrix Rotate270 = TransformationMatrix.FromValues(0m, 1, -1, 0);
+        private static readonly TransformationMatrix Rotate90 = TransformationMatrix.FromValues(0, -1, 1, 0);
+        private static readonly TransformationMatrix Rotate180 = TransformationMatrix.FromValues(-1, 0, 0, -1);
+        private static readonly TransformationMatrix Rotate270 = TransformationMatrix.FromValues(0, 1, -1, 0);
 
         /// <summary>
         /// The rotation of the page in degrees clockwise.

--- a/src/UglyToad.PdfPig/Content/PageSize.cs
+++ b/src/UglyToad.PdfPig/Content/PageSize.cs
@@ -135,11 +135,11 @@
 
         private struct WidthHeight
         {
-            public decimal Width { get; }
+            public double Width { get; }
 
-            public decimal Height { get; }
+            public double Height { get; }
 
-            public WidthHeight(decimal width, decimal height)
+            public WidthHeight(double width, double height)
             {
                 Width = width;
                 Height = height;

--- a/src/UglyToad.PdfPig/Content/Word.cs
+++ b/src/UglyToad.PdfPig/Content/Word.cs
@@ -55,10 +55,10 @@
 
             var builder = new StringBuilder();
 
-            var minX = decimal.MaxValue;
-            var minY = decimal.MaxValue;
-            var maxX = decimal.MinValue;
-            var maxY = decimal.MinValue;
+            var minX = double.MaxValue;
+            var minY = double.MaxValue;
+            var maxX = double.MinValue;
+            var maxY = double.MinValue;
 
             for (var i = 0; i < letters.Count; i++)
             {

--- a/src/UglyToad.PdfPig/Core/TransformationMatrix.cs
+++ b/src/UglyToad.PdfPig/Core/TransformationMatrix.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.Diagnostics.Contracts;
+    using System.Linq;
     using Geometry;
 
     /// <summary>
@@ -19,43 +20,43 @@
         /// <summary>
         /// Create a new <see cref="TransformationMatrix"/> with the X and Y translation values set.
         /// </summary>
-        public static TransformationMatrix GetTranslationMatrix(decimal x, decimal y) => new TransformationMatrix(1, 0, 0,
+        public static TransformationMatrix GetTranslationMatrix(double x, double y) => new TransformationMatrix(1, 0, 0,
             0, 1, 0,
             x, y, 1);
 
-        private readonly decimal row1;
-        private readonly decimal row2;
-        private readonly decimal row3;
+        private readonly double row1;
+        private readonly double row2;
+        private readonly double row3;
 
         /// <summary>
         /// The value at (0, 0) - The scale for the X dimension.
         /// </summary>
-        public readonly decimal A;
+        public readonly double A;
         /// <summary>
         /// The value at (0, 1).
         /// </summary>
-        public readonly decimal B;
+        public readonly double B;
         /// <summary>
         /// The value at (1, 0).
         /// </summary>
-        public readonly decimal C;
+        public readonly double C;
         /// <summary>
         /// The value at (1, 1) - The scale for the Y dimension.
         /// </summary>
-        public readonly decimal D;
+        public readonly double D;
         /// <summary>
         /// The value at (2, 0) - translation in X.
         /// </summary>
-        public readonly decimal E;
+        public readonly double E;
         /// <summary>
         /// The value at (2, 1) - translation in Y.
         /// </summary>
-        public readonly decimal F;
+        public readonly double F;
         
         /// <summary>
         /// Get the value at the specific row and column.
         /// </summary>
-        public decimal this[int row, int col]
+        public double this[int row, int col]
         {
             get
             {
@@ -142,14 +143,14 @@
         /// Create a new <see cref="TransformationMatrix"/>.
         /// </summary>
         /// <param name="value">The 9 values of the matrix.</param>
-        public TransformationMatrix(decimal[] value) : this(value[0], value[1], value[2], value[3], value[4], value[5], value[6], value[7], value[8])
+        public TransformationMatrix(double[] value) : this(value[0], value[1], value[2], value[3], value[4], value[5], value[6], value[7], value[8])
         {
         }
 
         /// <summary>
         /// Create a new <see cref="TransformationMatrix"/>.
         /// </summary>
-        public TransformationMatrix(decimal a, decimal b, decimal r1, decimal c, decimal d, decimal r2, decimal e, decimal f, decimal r3)
+        public TransformationMatrix(double a, double b, double r1, double c, double d, double r2, double e, double f, double r3)
         {
             A = a;
             B = b;
@@ -182,7 +183,7 @@
         /// <param name="x">The X coordinate.</param>
         /// <returns>The transformed X coordinate.</returns>
         [Pure]
-        internal decimal TransformX(decimal x)
+        internal double TransformX(double x)
         {
             var xt = A * x + C * 0 + E;
 
@@ -220,7 +221,7 @@
         }
 
         [Pure]
-        internal TransformationMatrix Translate(decimal x, decimal y)
+        internal TransformationMatrix Translate(double x, double y)
         {
             var a = A;
             var b = B;
@@ -242,13 +243,13 @@
         /// <summary>
         /// Create a new <see cref="TransformationMatrix"/> from the 6 values provided in the default PDF order.
         /// </summary>
-        public static TransformationMatrix FromValues(decimal a, decimal b, decimal c, decimal d, decimal e, decimal f)
+        public static TransformationMatrix FromValues(double a, double b, double c, double d, double e, double f)
             => new TransformationMatrix(a, b, 0, c, d, 0, e, f, 1);
 
         /// <summary>
         /// Create a new <see cref="TransformationMatrix"/> from the 4 values provided in the default PDF order.
         /// </summary>
-        public static TransformationMatrix FromValues(decimal a, decimal b, decimal c, decimal d)
+        public static TransformationMatrix FromValues(double a, double b, double c, double d)
             => new TransformationMatrix(a, b, 0, c, d, 0, 0, 0, 1);
 
         /// <summary>
@@ -257,6 +258,14 @@
         /// <param name="values">Either all 9 values of the matrix, 6 values in the default PDF order or the 4 values of the top left square.</param>
         /// <returns></returns>
         public static TransformationMatrix FromArray(decimal[] values)
+            => FromArray(values.Select(x => (double) x).ToArray());
+
+        /// <summary>
+        /// Create a new <see cref="TransformationMatrix"/> from the values.
+        /// </summary>
+        /// <param name="values">Either all 9 values of the matrix, 6 values in the default PDF order or the 4 values of the top left square.</param>
+        /// <returns></returns>
+        public static TransformationMatrix FromArray(double[] values)
         {
             if (values.Length == 9)
             {
@@ -311,7 +320,7 @@
         /// <param name="scalar">The value to multiply.</param>
         /// <returns>A new matrix which is multiplied by the scalar value.</returns>
         [Pure]
-        public TransformationMatrix Multiply(decimal scalar)
+        public TransformationMatrix Multiply(double scalar)
         {
             return new TransformationMatrix(A * scalar, B * scalar, row1 * scalar,
                 C * scalar, D * scalar, row2 * scalar,
@@ -321,8 +330,8 @@
         /// <summary>
         /// Get the X scaling component of the current matrix.
         /// </summary>
-        /// <returns></returns>
-        internal decimal GetScalingFactorX()
+        /// <returns>The scaling factor for the x dimension in this matrix.</returns>
+        internal double GetScalingFactorX()
         {
             var xScale = A;
 
@@ -343,9 +352,9 @@
              * sqrt(x2) =
              * abs(x)
              */
-            if (!(B == 0m && C == 0m))
+            if (!(B == 0 && C == 0))
             {
-                xScale = (decimal)Math.Sqrt((double)(A * A + B * B));
+                xScale = Math.Sqrt(A * A + B * B);
             }
 
             return xScale;

--- a/src/UglyToad.PdfPig/DocumentLayoutAnalysis/MathExtensions.cs
+++ b/src/UglyToad.PdfPig/DocumentLayoutAnalysis/MathExtensions.cs
@@ -22,7 +22,7 @@ namespace UglyToad.PdfPig.DocumentLayoutAnalysis
         /// Computes the mode of a sequence of decimal values.
         /// </summary>
         /// <param name="array">The array of decimal.</param>
-        public static decimal Mode(this IEnumerable<decimal> array)
+        public static double Mode(this IEnumerable<double> array)
         {
             return array.GroupBy(v => v).OrderByDescending(g => g.Count()).First().Key;
         }

--- a/src/UglyToad.PdfPig/DocumentLayoutAnalysis/TextEdgesExtractor.cs
+++ b/src/UglyToad.PdfPig/DocumentLayoutAnalysis/TextEdgesExtractor.cs
@@ -17,11 +17,11 @@ namespace UglyToad.PdfPig.DocumentLayoutAnalysis
         /// <summary>
         /// Functions used to define left, middle and right edges.
         /// </summary>
-        private static readonly Tuple<EdgeType, Func<PdfRectangle, decimal>>[] edgesFuncs = new Tuple<EdgeType, Func<PdfRectangle, decimal>>[]
+        private static readonly Tuple<EdgeType, Func<PdfRectangle, double>>[] edgesFuncs = new Tuple<EdgeType, Func<PdfRectangle, double>>[]
         {
-            Tuple.Create<EdgeType, Func<PdfRectangle, decimal>>(EdgeType.Left,   x => Math.Round(x.Left, 0)),                // use BoundingBox's left coordinate
-            Tuple.Create<EdgeType, Func<PdfRectangle, decimal>>(EdgeType.Mid, x => Math.Round(x.Left + x.Width / 2, 0)),     // use BoundingBox's mid coordinate
-            Tuple.Create<EdgeType, Func<PdfRectangle, decimal>>(EdgeType.Right,  x => Math.Round(x.Right, 0))                // use BoundingBox's right coordinate
+            Tuple.Create<EdgeType, Func<PdfRectangle, double>>(EdgeType.Left,   x => Math.Round(x.Left, 0)),                // use BoundingBox's left coordinate
+            Tuple.Create<EdgeType, Func<PdfRectangle, double>>(EdgeType.Mid, x => Math.Round(x.Left + x.Width / 2, 0)),     // use BoundingBox's mid coordinate
+            Tuple.Create<EdgeType, Func<PdfRectangle, double>>(EdgeType.Right,  x => Math.Round(x.Right, 0))                // use BoundingBox's right coordinate
         };
 
         /// <summary>
@@ -53,11 +53,11 @@ namespace UglyToad.PdfPig.DocumentLayoutAnalysis
             return dictionary.ToDictionary(x => x.Key, x => x.Value);
         }
 
-        private static List<PdfLine> GetVerticalEdges(IEnumerable<Word> pageWords, Func<PdfRectangle, decimal> func, int minimumElements)
+        private static List<PdfLine> GetVerticalEdges(IEnumerable<Word> pageWords, Func<PdfRectangle, double> func, int minimumElements)
         {
-            Dictionary<decimal, List<Word>> edges = pageWords.GroupBy(x => func(x.BoundingBox))
+            Dictionary<double, List<Word>> edges = pageWords.GroupBy(x => func(x.BoundingBox))
                 .Where(x => x.Count() >= minimumElements).ToDictionary(gdc => gdc.Key, gdc => gdc.ToList());
-            Dictionary<decimal, List<List<Word>>> cleanEdges = new Dictionary<decimal, List<List<Word>>>();
+            Dictionary<double, List<List<Word>>> cleanEdges = new Dictionary<double, List<List<Word>>>();
 
             foreach (var edge in edges)
             {

--- a/src/UglyToad.PdfPig/DocumentLayoutAnalysis/XYLeaf.cs
+++ b/src/UglyToad.PdfPig/DocumentLayoutAnalysis/XYLeaf.cs
@@ -24,7 +24,7 @@ namespace UglyToad.PdfPig.DocumentLayoutAnalysis
         /// <summary>
         /// The number of words in the leaf.
         /// </summary>
-        public override int CountWords() => Words == null ? 0 : Words.Count;
+        public override int CountWords() => Words?.Count ?? 0;
 
         /// <summary>
         /// Returns null as a leaf doesn't have leafs.
@@ -60,14 +60,14 @@ namespace UglyToad.PdfPig.DocumentLayoutAnalysis
         {
             if (words == null)
             {
-                throw new ArgumentException("XYLeaf(): The words contained in the leaf cannot be null.", "words");
+                throw new ArgumentException("XYLeaf(): The words contained in the leaf cannot be null.", nameof(words));
             }
 
-            decimal left = words.Min(b => b.BoundingBox.Left);
-            decimal right = words.Max(b => b.BoundingBox.Right);
+            double left = words.Min(b => b.BoundingBox.Left);
+            double right = words.Max(b => b.BoundingBox.Right);
 
-            decimal bottom = words.Min(b => b.BoundingBox.Bottom);
-            decimal top = words.Max(b => b.BoundingBox.Top);
+            double bottom = words.Min(b => b.BoundingBox.Bottom);
+            double top = words.Max(b => b.BoundingBox.Top);
 
             BoundingBox = new PdfRectangle(left, bottom, right, top);
             Words = words.ToArray();

--- a/src/UglyToad.PdfPig/DocumentLayoutAnalysis/XYNode.cs
+++ b/src/UglyToad.PdfPig/DocumentLayoutAnalysis/XYNode.cs
@@ -44,10 +44,10 @@ namespace UglyToad.PdfPig.DocumentLayoutAnalysis
             if (children != null && children.Count() != 0)
             {
                 Children = children.ToArray();
-                decimal left = children.Min(b => b.BoundingBox.Left);
-                decimal right = children.Max(b => b.BoundingBox.Right);
-                decimal bottom = children.Min(b => b.BoundingBox.Bottom);
-                decimal top = children.Max(b => b.BoundingBox.Top);
+                double left = children.Min(b => b.BoundingBox.Left);
+                double right = children.Max(b => b.BoundingBox.Right);
+                double bottom = children.Min(b => b.BoundingBox.Bottom);
+                double top = children.Max(b => b.BoundingBox.Top);
                 BoundingBox = new PdfRectangle(left, bottom, right, top);
             }
             else

--- a/src/UglyToad.PdfPig/Export/AltoXmlTextExporter.cs
+++ b/src/UglyToad.PdfPig/Export/AltoXmlTextExporter.cs
@@ -21,7 +21,7 @@
         private readonly IPageSegmenter pageSegmenter;
         private readonly IWordExtractor wordExtractor;
 
-        private readonly decimal scale;
+        private readonly double scale;
         private readonly string indentChar;
 
         private int pageCount;
@@ -41,7 +41,7 @@
         /// <param name="pageSegmenter">Segmenter used to split page into blocks.</param>
         /// <param name="scale">Scale multiplier to apply to output document, defaults to 1.</param>
         /// <param name="indent">Character to use for indentation, defaults to tab.</param>
-        public AltoXmlTextExporter(IWordExtractor wordExtractor, IPageSegmenter pageSegmenter, decimal scale = 1.0m, string indent = "\t")
+        public AltoXmlTextExporter(IWordExtractor wordExtractor, IPageSegmenter pageSegmenter, double scale = 1, string indent = "\t")
         {
             this.wordExtractor = wordExtractor ?? throw new ArgumentNullException(nameof(wordExtractor));
             this.pageSegmenter = pageSegmenter ?? throw new ArgumentNullException(nameof(pageSegmenter));
@@ -125,7 +125,7 @@
                 Processing = null,
                 ProcessingRefs = null,
                 StyleRefs = null,
-                PrintSpace = new AltoDocument.AltoPageSpace()
+                PrintSpace = new AltoDocument.AltoPageSpace
                 {
                     Height = (float)Math.Round(page.Height * scale),    // TBD
                     Width = (float)Math.Round(page.Width * scale),      // TBD
@@ -158,7 +158,7 @@
             return altoPage;
         }
 
-        private AltoDocument.AltoGraphicalElement ToAltoGraphicalElement(PdfPath pdfPath, decimal height)
+        private AltoDocument.AltoGraphicalElement ToAltoGraphicalElement(PdfPath pdfPath, double height)
         {
             graphicalElementCount++;
 
@@ -182,7 +182,7 @@
             return null;
         }
 
-        private AltoDocument.AltoIllustration ToAltoIllustration(IPdfImage pdfImage, decimal height)
+        private AltoDocument.AltoIllustration ToAltoIllustration(IPdfImage pdfImage, double height)
         {
             illustrationCount++;
             var rectangle = pdfImage.Bounds;
@@ -199,7 +199,7 @@
             };
         }
 
-        private AltoDocument.AltoTextBlock ToAltoTextBlock(TextBlock textBlock, decimal height)
+        private AltoDocument.AltoTextBlock ToAltoTextBlock(TextBlock textBlock, double height)
         {
             textBlockCount++;
 
@@ -219,7 +219,7 @@
             };
         }
 
-        private AltoDocument.AltoTextBlockTextLine ToAltoTextLine(TextLine textLine, decimal height)
+        private AltoDocument.AltoTextBlockTextLine ToAltoTextLine(TextLine textLine, double height)
         {
             textLineCount++;
             var strings = textLine.Words
@@ -240,7 +240,7 @@
                 Id = "P" + pageCount + "_TL" + textLineCount.ToString("#00000")
             };
         }
-        private AltoDocument.AltoString ToAltoString(Word word, decimal height)
+        private AltoDocument.AltoString ToAltoString(Word word, double height)
         {
             stringCount++;
             var glyphs = word.Letters.Select(l => ToAltoGlyph(l, height)).ToArray();
@@ -263,7 +263,7 @@
             };
         }
 
-        private AltoDocument.AltoGlyph ToAltoGlyph(Letter letter, decimal height)
+        private AltoDocument.AltoGlyph ToAltoGlyph(Letter letter, double height)
         {
             glyphCount++;
             return new AltoDocument.AltoGlyph

--- a/src/UglyToad.PdfPig/Export/HOcrTextExporter.cs
+++ b/src/UglyToad.PdfPig/Export/HOcrTextExporter.cs
@@ -13,37 +13,33 @@ namespace UglyToad.PdfPig.Export
     /// </summary>
     public class HOcrTextExporter : ITextExporter
     {
-        private const string xmlHeader = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<!DOCTYPE html PUBLIC \"-//W3C//DTD XHTML 1.0 Transitional//EN\"\n\t\"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd\">\n";
-        private const string hocrjs = "<script src='https://unpkg.com/hocrjs'></script>\n";
+        private const string XmlHeader = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<!DOCTYPE html PUBLIC \"-//W3C//DTD XHTML 1.0 Transitional//EN\"\n\t\"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd\">\n";
+        private const string Hocrjs = "<script src='https://unpkg.com/hocrjs'></script>\n";
 
-        private IPageSegmenter pageSegmenter;
-        private IWordExtractor wordExtractor;
+        private readonly IPageSegmenter pageSegmenter;
+        private readonly IWordExtractor wordExtractor;
 
-        private decimal scale;
-        private string indentChar;
+        private readonly double scale;
+        private readonly string indentChar;
 
-        private int pageCount = 0;
-        private int areaCount = 0;
-        private int lineCount = 0;
-        private int wordCount = 0;
-        private int pathCount = 0;
-        private int paraCount = 0;
-        private int imageCount = 0;
+        private int pageCount;
+        private int areaCount;
+        private int lineCount;
+        private int wordCount;
+        private int pathCount;
+        private int paraCount;
+        private int imageCount;
 
         /// <summary>
         /// hOCR v1.2 (HTML)
         /// <para>See http://kba.cloud/hocr-spec/1.2/ </para>
         /// </summary>
-        /// <param name="wordExtractor"></param>
-        /// <param name="pageSegmenter"></param>
-        /// <param name="scale"></param>
-        /// <param name="indent">Indent character.</param>
         public HOcrTextExporter(IWordExtractor wordExtractor, IPageSegmenter pageSegmenter, double scale = 1.0, string indent = "\t")
         {
             this.wordExtractor = wordExtractor;
             this.pageSegmenter = pageSegmenter;
-            this.scale = (decimal)scale;
-            this.indentChar = indent;
+            this.scale = scale;
+            indentChar = indent;
         }
 
         /// <summary>
@@ -63,9 +59,9 @@ namespace UglyToad.PdfPig.Export
                 hocr += GetCode(page, includePaths) + "\n";
             }
 
-            if (useHocrjs) hocr += indentChar + indentChar + hocrjs;
+            if (useHocrjs) hocr += indentChar + indentChar + Hocrjs;
             hocr += indentChar + "</body>";
-            hocr = xmlHeader + AddHtmlHeader(hocr);
+            hocr = XmlHeader + AddHtmlHeader(hocr);
             return hocr;
         }
 
@@ -91,9 +87,9 @@ namespace UglyToad.PdfPig.Export
 
             hocr += GetCode(page, includePaths, imageName) + "\n";
 
-            if (useHocrjs) hocr += indentChar + indentChar + hocrjs;
+            if (useHocrjs) hocr += indentChar + indentChar + Hocrjs;
             hocr += indentChar + "</body>";
-            hocr = xmlHeader + AddHtmlHeader(hocr);
+            hocr = XmlHeader + AddHtmlHeader(hocr);
             return hocr;
         }
 
@@ -179,7 +175,7 @@ namespace UglyToad.PdfPig.Export
         /// <param name="pageHeight"></param>
         /// <param name="subPaths"></param>
         /// <param name="level">The indent level.</param>
-        private string GetCode(PdfPath path, decimal pageHeight, bool subPaths, int level)
+        private string GetCode(PdfPath path, double pageHeight, bool subPaths, int level)
         {
             if (path == null) return string.Empty;
 
@@ -220,7 +216,7 @@ namespace UglyToad.PdfPig.Export
             return hocr;
         }
 
-        private string GetCode(IPdfImage pdfImage, decimal pageHeight, int level)
+        private string GetCode(IPdfImage pdfImage, double pageHeight, int level)
         {
             imageCount++;
             var bbox = pdfImage.Bounds;
@@ -235,7 +231,7 @@ namespace UglyToad.PdfPig.Export
         /// <param name="block">The text area.</param>
         /// <param name="pageHeight"></param>
         /// <param name="level">The indent level.</param>
-        private string GetCodeArea(TextBlock block, decimal pageHeight, int level)
+        private string GetCodeArea(TextBlock block, double pageHeight, int level)
         {
             areaCount++;
 
@@ -255,7 +251,7 @@ namespace UglyToad.PdfPig.Export
         /// <param name="block">The paragraph.</param>
         /// <param name="pageHeight"></param>
         /// <param name="level">The indent level.</param>
-        private string GetCodeParagraph(TextBlock block, decimal pageHeight, int level)
+        private string GetCodeParagraph(TextBlock block, double pageHeight, int level)
         {
             paraCount++;
             string hocr = "\n" + GetIndent(level) + @"<p class='ocr_par' id='par_" + pageCount + "_"
@@ -277,7 +273,7 @@ namespace UglyToad.PdfPig.Export
         /// <param name="line"></param>
         /// <param name="pageHeight"></param>
         /// <param name="level">The indent level.</param>
-        private string GetCode(TextLine line, decimal pageHeight, int level)
+        private string GetCode(TextLine line, double pageHeight, int level)
         {
             lineCount++;
             double angle = 0;
@@ -305,7 +301,7 @@ namespace UglyToad.PdfPig.Export
         /// <param name="word"></param>
         /// <param name="pageHeight"></param>
         /// <param name="level">The indent level.</param>
-        private string GetCode(Word word, decimal pageHeight, int level)
+        private string GetCode(Word word, double pageHeight, int level)
         {
             wordCount++;
             string hocr = GetIndent(level) +
@@ -335,7 +331,7 @@ namespace UglyToad.PdfPig.Export
         /// </summary>
         /// <param name="rectangle"></param>
         /// <param name="pageHeight"></param>
-        private string GetCode(PdfRectangle rectangle, decimal pageHeight)
+        private string GetCode(PdfRectangle rectangle, double pageHeight)
         {
             // the values are with reference to the the top-left 
             // corner of the document image and measured in pixels

--- a/src/UglyToad.PdfPig/Export/PageXmlTextExporter.cs
+++ b/src/UglyToad.PdfPig/Export/PageXmlTextExporter.cs
@@ -23,7 +23,7 @@ namespace UglyToad.PdfPig.Export
         private IPageSegmenter pageSegmenter;
         private IWordExtractor wordExtractor;
 
-        private decimal scale;
+        private double scale;
         private string indentChar;
 
         int lineCount = 0;
@@ -43,8 +43,8 @@ namespace UglyToad.PdfPig.Export
         {
             this.wordExtractor = wordExtractor;
             this.pageSegmenter = pageSegmenter;
-            this.scale = (decimal)scale;
-            this.indentChar = indent;
+            this.scale = scale;
+            indentChar = indent;
         }
 
         /// <summary>
@@ -90,24 +90,24 @@ namespace UglyToad.PdfPig.Export
             return Serialize(pageXmlDocument);
         }
 
-        private string PointToString(PdfPoint point, decimal height)
+        private string PointToString(PdfPoint point, double height)
         {
-            decimal x = Math.Round(point.X * scale);
-            decimal y = Math.Round((height - point.Y) * scale);
+            double x = Math.Round(point.X * scale);
+            double y = Math.Round((height - point.Y) * scale);
             return (x > 0 ? x : 0).ToString("0") + "," + (y > 0 ? y : 0).ToString("0");
         }
 
-        private string ToPoints(IEnumerable<PdfPoint> points, decimal height)
+        private string ToPoints(IEnumerable<PdfPoint> points, double height)
         {
             return string.Join(" ", points.Select(p => PointToString(p, height)));
         }
 
-        private string ToPoints(PdfRectangle pdfRectangle, decimal height)
+        private string ToPoints(PdfRectangle pdfRectangle, double height)
         {
             return ToPoints(new[] { pdfRectangle.BottomLeft, pdfRectangle.TopLeft, pdfRectangle.TopRight, pdfRectangle.BottomRight }, height);
         }
 
-        private PageXmlDocument.PageXmlCoords ToCoords(PdfRectangle pdfRectangle, decimal height)
+        private PageXmlDocument.PageXmlCoords ToCoords(PdfRectangle pdfRectangle, double height)
         {
             return new PageXmlDocument.PageXmlCoords()
             {
@@ -168,7 +168,7 @@ namespace UglyToad.PdfPig.Export
             return pageXmlPage;
         }
 
-        private PageXmlDocument.PageXmlLineDrawingRegion ToPageXmlLineDrawingRegion(PdfPath pdfPath, decimal height)
+        private PageXmlDocument.PageXmlLineDrawingRegion ToPageXmlLineDrawingRegion(PdfPath pdfPath, double height)
         {
             var bbox = pdfPath.GetBoundingRectangle();
             if (bbox.HasValue)
@@ -183,7 +183,7 @@ namespace UglyToad.PdfPig.Export
             return null;
         }
 
-        private PageXmlDocument.PageXmlImageRegion ToPageXmlImageRegion(IPdfImage pdfImage, decimal height)
+        private PageXmlDocument.PageXmlImageRegion ToPageXmlImageRegion(IPdfImage pdfImage, double height)
         {
             regionCount++;
             var bbox = pdfImage.Bounds;
@@ -194,7 +194,7 @@ namespace UglyToad.PdfPig.Export
             };
         }
 
-        private PageXmlDocument.PageXmlTextRegion ToPageXmlTextRegion(TextBlock textBlock, decimal height)
+        private PageXmlDocument.PageXmlTextRegion ToPageXmlTextRegion(TextBlock textBlock, double height)
         {
             regionCount++;
             return new PageXmlDocument.PageXmlTextRegion()
@@ -206,7 +206,7 @@ namespace UglyToad.PdfPig.Export
             };
         }
 
-        private PageXmlDocument.PageXmlTextLine ToPageXmlTextLine(TextLine textLine, decimal height)
+        private PageXmlDocument.PageXmlTextLine ToPageXmlTextLine(TextLine textLine, double height)
         {
             lineCount++;
             return new PageXmlDocument.PageXmlTextLine()
@@ -219,7 +219,7 @@ namespace UglyToad.PdfPig.Export
             };
         }
 
-        private PageXmlDocument.PageXmlWord ToPageXmlWord(Word word, decimal height)
+        private PageXmlDocument.PageXmlWord ToPageXmlWord(Word word, double height)
         {
             wordCount++;
             return new PageXmlDocument.PageXmlWord()
@@ -231,7 +231,7 @@ namespace UglyToad.PdfPig.Export
             };
         }
 
-        private PageXmlDocument.PageXmlGlyph ToPageXmlGlyph(Letter letter, decimal height)
+        private PageXmlDocument.PageXmlGlyph ToPageXmlGlyph(Letter letter, double height)
         {
             glyphCount++;
             return new PageXmlDocument.PageXmlGlyph()
@@ -7839,8 +7839,8 @@ namespace UglyToad.PdfPig.Export
                 /// <summary>
                 /// Examples: "123.456", "+1234.456", "-1234.456", "-.456", "-456"
                 /// </summary>
-                [XmlEnumAttribute("xsd:decimal")]
-                XsdDecimal,
+                [XmlEnumAttribute("xsd:double")]
+                Xsddouble,
 
                 /// <summary>
                 /// Examples: "123.456", "+1234.456", "-1.2344e56", "-.45E-6", "INF", "-INF", "NaN"

--- a/src/UglyToad.PdfPig/Fonts/CharStringStack.cs
+++ b/src/UglyToad.PdfPig/Fonts/CharStringStack.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.Collections.Generic;
+    using System.Globalization;
     using System.Linq;
 
     /// <summary>
@@ -9,7 +10,7 @@
     /// </summary>
     internal class CharStringStack
     {
-        private readonly List<decimal> stack = new List<decimal>();
+        private readonly List<double> stack = new List<double>();
 
         /// <summary>
         /// The current size of the stack.
@@ -25,7 +26,7 @@
         /// Remove and return the value from the top of the stack.
         /// </summary>
         /// <returns>The value from the top of the stack.</returns>
-        public decimal PopTop()
+        public double PopTop()
         {
             if (stack.Count == 0)
             {
@@ -41,7 +42,7 @@
         /// Remove and return the value from the bottom of the stack.
         /// </summary>
         /// <returns>The value from the bottom of the stack.</returns>
-        public decimal PopBottom()
+        public double PopBottom()
         {
             if (stack.Count == 0)
             {
@@ -57,12 +58,12 @@
         /// Adds the value to the top of the stack.
         /// </summary>
         /// <param name="value">The value to add.</param>
-        public void Push(decimal value)
+        public void Push(double value)
         {
             stack.Add(value);
         }
 
-        public decimal CopyElementAt(int index)
+        public double CopyElementAt(int index)
         {
             if (index < 0)
             {
@@ -82,7 +83,7 @@
 
         public override string ToString()
         {
-            return string.Join(" ", stack.Select(x => x.ToString()));
+            return string.Join(" ", stack.Select(x => x.ToString(CultureInfo.InvariantCulture)));
         }
     }
 }

--- a/src/UglyToad.PdfPig/Fonts/CharacterBoundingBox.cs
+++ b/src/UglyToad.PdfPig/Fonts/CharacterBoundingBox.cs
@@ -6,9 +6,9 @@
     {
         public PdfRectangle GlyphBounds { get; }
 
-        public decimal Width { get; }
+        public double Width { get; }
 
-        public CharacterBoundingBox(PdfRectangle glyphBounds, decimal width)
+        public CharacterBoundingBox(PdfRectangle glyphBounds, double width)
         {
             GlyphBounds = glyphBounds;
             Width = width;

--- a/src/UglyToad.PdfPig/Fonts/CharacterWidth.cs
+++ b/src/UglyToad.PdfPig/Fonts/CharacterWidth.cs
@@ -6,11 +6,11 @@
     /// </summary>
     internal class CharacterWidth
     {
-        public decimal X { get; }
+        public double X { get; }
 
-        public decimal Y { get; }
+        public double Y { get; }
 
-        public CharacterWidth(decimal x, decimal y)
+        public CharacterWidth(double x, double y)
         {
             X = x;
             Y = y;

--- a/src/UglyToad.PdfPig/Fonts/CidFonts/ICidFont.cs
+++ b/src/UglyToad.PdfPig/Fonts/CidFonts/ICidFont.cs
@@ -40,9 +40,9 @@
 
         FontDescriptor Descriptor { get; }
 
-        decimal GetWidthFromDictionary(int cid);
+        double GetWidthFromDictionary(int cid);
 
-        decimal GetWidthFromFont(int characterIdentifier);
+        double GetWidthFromFont(int characterIdentifier);
 
         PdfRectangle GetBoundingBox(int characterIdentifier);
 

--- a/src/UglyToad.PdfPig/Fonts/CidFonts/ICidFontProgram.cs
+++ b/src/UglyToad.PdfPig/Fonts/CidFonts/ICidFontProgram.cs
@@ -12,9 +12,9 @@
 
         bool TryGetBoundingBox(int characterIdentifier, Func<int, int?> characterCodeToGlyphId, out PdfRectangle boundingBox);
 
-        bool TryGetBoundingAdvancedWidth(int characterIdentifier, Func<int, int?> characterCodeToGlyphId, out decimal width);
+        bool TryGetBoundingAdvancedWidth(int characterIdentifier, Func<int, int?> characterCodeToGlyphId, out double width);
 
-        bool TryGetBoundingAdvancedWidth(int characterIdentifier, out decimal width);
+        bool TryGetBoundingAdvancedWidth(int characterIdentifier, out double width);
 
         int GetFontMatrixMultiplier();
     }

--- a/src/UglyToad.PdfPig/Fonts/CidFonts/Type0CidFont.cs
+++ b/src/UglyToad.PdfPig/Fonts/CidFonts/Type0CidFont.cs
@@ -15,7 +15,7 @@
     {
         private readonly ICidFontProgram fontProgram;
         private readonly VerticalWritingMetrics verticalWritingMetrics;
-        private readonly decimal? defaultWidth;
+        private readonly double? defaultWidth;
 
         public NameToken Type { get; }
 
@@ -31,14 +31,14 @@
 
         public FontDescriptor Descriptor { get; }
 
-        public IReadOnlyDictionary<int, decimal> Widths { get; }
+        public IReadOnlyDictionary<int, double> Widths { get; }
 
         public Type0CidFont(ICidFontProgram fontProgram, NameToken type, NameToken subType, NameToken baseFont,
             CharacterIdentifierSystemInfo systemInfo,
             FontDescriptor descriptor, 
             VerticalWritingMetrics verticalWritingMetrics, 
-            IReadOnlyDictionary<int, decimal> widths,
-            decimal? defaultWidth)
+            IReadOnlyDictionary<int, double> widths,
+            double? defaultWidth)
         {
             this.fontProgram = fontProgram;
             this.verticalWritingMetrics = verticalWritingMetrics;
@@ -47,18 +47,18 @@
             SubType = subType;
             BaseFont = baseFont;
             SystemInfo = systemInfo;
-            var scale = 1 / (decimal)(fontProgram?.GetFontMatrixMultiplier() ?? 1000);
+            var scale = 1 / (double)(fontProgram?.GetFontMatrixMultiplier() ?? 1000);
             FontMatrix = TransformationMatrix.FromValues(scale, 0, 0, scale, 0, 0);
             Descriptor = descriptor;
             Widths = widths;
         }
 
-        public decimal GetWidthFromFont(int characterCode)
+        public double GetWidthFromFont(int characterCode)
         {
             return GetWidthFromDictionary(characterCode);
         }
 
-        public decimal GetWidthFromDictionary(int cid)
+        public double GetWidthFromDictionary(int cid)
         {
             if (cid < 0)
             {
@@ -80,7 +80,7 @@
                 return 1000;
             }
 
-            return Descriptor.MissingWidth;
+            return (double)Descriptor.MissingWidth;
         }
 
         public PdfRectangle GetBoundingBox(int characterIdentifier)

--- a/src/UglyToad.PdfPig/Fonts/CidFonts/Type2CidFont.cs
+++ b/src/UglyToad.PdfPig/Fonts/CidFonts/Type2CidFont.cs
@@ -14,8 +14,8 @@
     {
         private readonly ICidFontProgram fontProgram;
         private readonly VerticalWritingMetrics verticalWritingMetrics;
-        private readonly IReadOnlyDictionary<int, decimal> widths;
-        private readonly decimal? defaultWidth;
+        private readonly IReadOnlyDictionary<int, double> widths;
+        private readonly double? defaultWidth;
         private readonly CharacterIdentifierToGlyphIndexMap cidToGid;
 
         public NameToken Type { get; }
@@ -35,8 +35,8 @@
         public Type2CidFont(NameToken type, NameToken subType, NameToken baseFont, CharacterIdentifierSystemInfo systemInfo,
             FontDescriptor descriptor, ICidFontProgram fontProgram,
             VerticalWritingMetrics verticalWritingMetrics,
-            IReadOnlyDictionary<int, decimal> widths, 
-            decimal? defaultWidth,
+            IReadOnlyDictionary<int, double> widths,
+            double? defaultWidth,
             CharacterIdentifierToGlyphIndexMap cidToGid)
         {
             Type = type;
@@ -51,11 +51,11 @@
             this.cidToGid = cidToGid;
 
             // TODO: This should maybe take units per em into account?
-            var scale = 1 / (decimal)(fontProgram?.GetFontMatrixMultiplier() ?? 1000);
+            var scale = 1 / (double)(fontProgram?.GetFontMatrixMultiplier() ?? 1000);
             FontMatrix = TransformationMatrix.FromValues(scale, 0, 0, scale, 0, 0);
         }
 
-        public decimal GetWidthFromFont(int characterIdentifier)
+        public double GetWidthFromFont(int characterIdentifier)
         {
             if (fontProgram == null)
             {
@@ -70,7 +70,7 @@
             return GetWidthFromDictionary(characterIdentifier);
         }
 
-        public decimal GetWidthFromDictionary(int characterIdentifier)
+        public double GetWidthFromDictionary(int characterIdentifier)
         {
             if (widths.TryGetValue(characterIdentifier, out var width))
             {
@@ -82,7 +82,7 @@
                 return defaultWidth.Value;
             }
 
-            return Descriptor?.MissingWidth ?? 1000m;
+            return (double)(Descriptor?.MissingWidth ?? 1000);
         }
 
         public PdfRectangle GetBoundingBox(int characterIdentifier)

--- a/src/UglyToad.PdfPig/Fonts/CidFonts/VerticalVectorComponents.cs
+++ b/src/UglyToad.PdfPig/Fonts/CidFonts/VerticalVectorComponents.cs
@@ -21,7 +21,7 @@
         /// (w0/2, Position)
         /// Where w0 is the width of the given glyph.
         /// </remarks>
-        public decimal Position { get; }
+        public double Position { get; }
         
         /// <summary>
         /// The vertical component of the displacement vector.
@@ -30,12 +30,12 @@
         /// The full displacement vector is:
         /// (0, Displacement)
         /// </remarks>
-        public decimal Displacement { get; }
+        public double Displacement { get; }
 
         /// <summary>
         /// Create a new <see cref="VerticalVectorComponents"/>.
         /// </summary>
-        public VerticalVectorComponents(decimal position, decimal displacement)
+        public VerticalVectorComponents(double position, double displacement)
         {
             Position = position;
             Displacement = displacement;
@@ -44,7 +44,7 @@
         /// <summary>
         /// Get the full position vector for a given glyph.
         /// </summary>
-        public PdfVector GetPositionVector(decimal glyphWidth) => new PdfVector(glyphWidth / 2m, Position);
+        public PdfVector GetPositionVector(double glyphWidth) => new PdfVector(glyphWidth / 2.0, Position);
 
         /// <summary>
         /// Get the full displacement vector.

--- a/src/UglyToad.PdfPig/Fonts/CidFonts/VerticalWritingMetrics.cs
+++ b/src/UglyToad.PdfPig/Fonts/CidFonts/VerticalWritingMetrics.cs
@@ -20,7 +20,7 @@
         /// Overrides displacement vector y components for glyphs specified by CID code.
         /// </summary>
         [NotNull]
-        public IReadOnlyDictionary<int, decimal> IndividualVerticalWritingDisplacements { get; }
+        public IReadOnlyDictionary<int, double> IndividualVerticalWritingDisplacements { get; }
 
         /// <summary>
         /// Overrides position vector (x and y) components for glyphs specified by CID code.
@@ -32,12 +32,12 @@
         /// Create new <see cref="VerticalWritingMetrics"/>.
         /// </summary>
         public VerticalWritingMetrics(VerticalVectorComponents defaultVerticalWritingMetrics, 
-            [CanBeNull] IReadOnlyDictionary<int, decimal> individualVerticalWritingDisplacements, 
+            [CanBeNull] IReadOnlyDictionary<int, double> individualVerticalWritingDisplacements, 
             [CanBeNull] IReadOnlyDictionary<int, PdfVector> individualVerticalWritingPositions)
         {
             DefaultVerticalWritingMetrics = defaultVerticalWritingMetrics;
             IndividualVerticalWritingDisplacements = individualVerticalWritingDisplacements
-                                                     ?? new Dictionary<int, decimal>(0);
+                                                     ?? new Dictionary<int, double>(0);
             IndividualVerticalWritingPositions = individualVerticalWritingPositions
                                                  ?? new Dictionary<int, PdfVector>(0);
         }
@@ -45,7 +45,7 @@
         /// <summary>
         /// Get the position vector used to convert horizontal glyph origin to vertical origin.
         /// </summary>
-        public PdfVector GetPositionVector(int characterIdentifier, decimal glyphWidth)
+        public PdfVector GetPositionVector(int characterIdentifier, double glyphWidth)
         {
             if (IndividualVerticalWritingPositions.TryGetValue(characterIdentifier, out var vector))
             {

--- a/src/UglyToad.PdfPig/Fonts/CompactFontFormat/CharStrings/Type2BuildCharContext.cs
+++ b/src/UglyToad.PdfPig/Fonts/CompactFontFormat/CharStrings/Type2BuildCharContext.cs
@@ -8,7 +8,7 @@
     /// </summary>
     internal class Type2BuildCharContext
     {
-        private readonly Dictionary<int, decimal> transientArray = new Dictionary<int, decimal>();
+        private readonly Dictionary<int, double> transientArray = new Dictionary<int, double>();
 
         /// <summary>
         /// The numbers currently on the Type 2 Build Char stack.
@@ -29,19 +29,19 @@
         ///  If the charstring has a width other than that of defaultWidthX it must be specified as the first
         ///  number in the charstring, and encoded as the difference from nominalWidthX.
         /// </summary>
-        public decimal? Width { get; set; }
+        public double? Width { get; set; }
 
-        public void AddRelativeHorizontalLine(decimal dx)
+        public void AddRelativeHorizontalLine(double dx)
         {
             AddRelativeLine(dx, 0);
         }
 
-        public void AddRelativeVerticalLine(decimal dy)
+        public void AddRelativeVerticalLine(double dy)
         {
             AddRelativeLine(0, dy);
         }
 
-        public void AddRelativeBezierCurve(decimal dx1, decimal dy1, decimal dx2, decimal dy2, decimal dx3, decimal dy3)
+        public void AddRelativeBezierCurve(double dx1, double dy1, double dx2, double dy2, double dx3, double dy3)
         {
             var x1 = CurrentLocation.X + dx1;
             var y1 = CurrentLocation.Y + dy1;
@@ -56,7 +56,7 @@
             CurrentLocation = new PdfPoint(x3, y3);
         }
 
-        public void AddRelativeLine(decimal dx, decimal dy)
+        public void AddRelativeLine(double dx, double dy)
         {
             var dest = new PdfPoint(CurrentLocation.X + dx, CurrentLocation.Y + dy);
 
@@ -64,20 +64,20 @@
             CurrentLocation = dest;
         }
 
-        public void AddVerticalStemHints(IReadOnlyList<(decimal start, decimal end)> hints)
+        public void AddVerticalStemHints(IReadOnlyList<(double start, double end)> hints)
         {
         }
 
-        public void AddHorizontalStemHints(IReadOnlyList<(decimal start, decimal end)> hints)
+        public void AddHorizontalStemHints(IReadOnlyList<(double start, double end)> hints)
         {
         }
 
-        public void AddToTransientArray(decimal value, int location)
+        public void AddToTransientArray(double value, int location)
         {
             transientArray[location] = value;
         }
 
-        public decimal GetFromTransientArray(int location)
+        public double GetFromTransientArray(int location)
         {
             var result = transientArray[location];
             transientArray.Remove(location);

--- a/src/UglyToad.PdfPig/Fonts/CompactFontFormat/CharStrings/Type2CharStringParser.cs
+++ b/src/UglyToad.PdfPig/Fonts/CompactFontFormat/CharStrings/Type2CharStringParser.cs
@@ -32,7 +32,7 @@
             { 1,  new LazyType2Command("hstem", ctx =>
                 {
                     var numberOfEdgeHints = ctx.Stack.Length / 2;
-                    var hints = new (decimal, decimal)[numberOfEdgeHints];
+                    var hints = new (double, double)[numberOfEdgeHints];
 
                     var firstStartY = ctx.Stack.PopBottom();
                     var endY = firstStartY + ctx.Stack.PopBottom();
@@ -59,7 +59,7 @@
                 3,  new LazyType2Command("vstem", ctx =>
                 {
                     var numberOfEdgeHints = ctx.Stack.Length / 2;
-                    var hints = new (decimal, decimal)[numberOfEdgeHints];
+                    var hints = new (double, double)[numberOfEdgeHints];
 
                     var firstStartX = ctx.Stack.PopBottom();
                     var endX = firstStartX + ctx.Stack.PopBottom();
@@ -201,7 +201,7 @@
                 {
                     // Same as vstem except the charstring contains hintmask
                     var numberOfEdgeHints = ctx.Stack.Length / 2;
-                    var hints = new (decimal, decimal)[numberOfEdgeHints];
+                    var hints = new (double, double)[numberOfEdgeHints];
 
                     var firstStartY = ctx.Stack.PopBottom();
                     var endY = firstStartY + ctx.Stack.PopBottom();
@@ -268,7 +268,7 @@
                 {
                     // Same as vstem except the charstring contains hintmask
                     var numberOfEdgeHints = ctx.Stack.Length / 2;
-                    var hints = new (decimal, decimal)[numberOfEdgeHints];
+                    var hints = new (double, double)[numberOfEdgeHints];
 
                     var firstStartX = ctx.Stack.PopBottom();
                     var endX = firstStartX + ctx.Stack.PopBottom();
@@ -334,7 +334,7 @@
                     var numberOfCurves = ctx.Stack.Length / 4;
                     for (var i = 0; i < numberOfCurves; i++)
                     {
-                        var dx1 = 0m;
+                        var dx1 = 0.0;
                         if (i == 0 && hasDeltaXFirstCurve)
                         {
                             dx1 = ctx.Stack.PopBottom();
@@ -410,7 +410,7 @@
                                 var dx2 = ctx.Stack.PopBottom();
                                 var dy2 = ctx.Stack.PopBottom();
                                 var dy3 = ctx.Stack.PopBottom();
-                                var dx3 = 0m;
+                                var dx3 = 0.0;
 
                                 if (i == numberOfCurves - 1 && remainder == 1)
                                 {
@@ -451,7 +451,7 @@
                                 var dx2 = ctx.Stack.PopBottom();
                                 var dy2 = ctx.Stack.PopBottom();
                                 var dx3 = ctx.Stack.PopBottom();
-                                var dy3 = 0m;
+                                var dy3 = 0.0;
 
                                 if (i == numberOfCurves - 1 && remainder == 5)
                                 {
@@ -497,7 +497,7 @@
                                 var dx2 = ctx.Stack.PopBottom();
                                 var dy2 = ctx.Stack.PopBottom();
                                 var dx3 = ctx.Stack.PopBottom();
-                                var dy3 = 0m;
+                                var dy3 = 0.0;
 
                                 if (i == numberOfCurves - 1 && remainder == 1)
                                 {
@@ -538,7 +538,7 @@
                                 var dx2 = ctx.Stack.PopBottom();
                                 var dy2 = ctx.Stack.PopBottom();
                                 var dy3 = ctx.Stack.PopBottom();
-                                var dx3 = 0m;
+                                var dx3 = 0.0;
 
                                 if (i == numberOfCurves - 1 && remainder == 5)
                                 {
@@ -588,9 +588,9 @@
             { 21,  new LazyType2Command("get", ctx => ctx.Stack.Push(ctx.GetFromTransientArray((int)ctx.Stack.PopTop())))},
             { 22,  new LazyType2Command("ifelse", x => { })},
             // TODO: Random, do we want to support this?
-            { 23,  new LazyType2Command("random", ctx => ctx.Stack.Push(0.5m))},
+            { 23,  new LazyType2Command("random", ctx => ctx.Stack.Push(0.5))},
             { 24,  new LazyType2Command("mul", ctx => ctx.Stack.Push(ctx.Stack.PopTop() * ctx.Stack.PopTop()))},
-            { 26,  new LazyType2Command("sqrt", ctx => ctx.Stack.Push((decimal)Math.Sqrt((double)ctx.Stack.PopTop())))},
+            { 26,  new LazyType2Command("sqrt", ctx => ctx.Stack.Push(Math.Sqrt(ctx.Stack.PopTop())))},
             {
                 27,  new LazyType2Command("dup", ctx =>
                 {
@@ -708,11 +708,11 @@
             return new Type2CharStrings(charStrings);
         }
 
-        private static IReadOnlyList<Union<decimal, LazyType2Command>> ParseSingle(List<byte> bytes,
+        private static IReadOnlyList<Union<double, LazyType2Command>> ParseSingle(List<byte> bytes,
             CompactFontFormatIndex localSubroutines,
             CompactFontFormatIndex globalSubroutines)
         {
-            var instructions = new List<Union<decimal, LazyType2Command>>();
+            var instructions = new List<Union<double, LazyType2Command>>();
             for (var i = 0; i < bytes.Count; i++)
             {
                 var b = bytes[i];
@@ -721,13 +721,13 @@
                     var command = GetCommand(b, bytes, instructions, localSubroutines, globalSubroutines, ref i);
                     if (command != null)
                     {
-                        instructions.Add(Union<decimal, LazyType2Command>.Two(command));
+                        instructions.Add(Union<double, LazyType2Command>.Two(command));
                     }
                 }
                 else
                 {
                     var number = InterpretNumber(b, bytes, ref i);
-                    instructions.Add(Union<decimal, LazyType2Command>.One(number));
+                    instructions.Add(Union<double, LazyType2Command>.One(number));
                 }
             }
 
@@ -738,7 +738,7 @@
         /// The Type 2 interpretation of a number with an initial byte value of 255 differs from how it is interpreted in the Type 1 format
         /// and 28 has a special meaning.
         /// </summary>
-        private static decimal InterpretNumber(byte b, IReadOnlyList<byte> bytes, ref int i)
+        private static double InterpretNumber(byte b, IReadOnlyList<byte> bytes, ref int i)
         {
             if (b == 28)
             {
@@ -771,11 +771,11 @@
             var lead = bytes[++i] << 8 | bytes[++i];
             var fractionalPart = bytes[++i] << 8 | bytes[++i];
 
-            return lead + (fractionalPart / 65535m);
+            return lead + (fractionalPart / 65535.0);
         }
 
         private static LazyType2Command GetCommand(byte b, List<byte> bytes,
-            List<Union<decimal, LazyType2Command>> precedingCommands,
+            List<Union<double, LazyType2Command>> precedingCommands,
             CompactFontFormatIndex localSubroutines,
             CompactFontFormatIndex globalSubroutines, ref int i)
         {
@@ -832,7 +832,7 @@
             return new LazyType2Command($"unknown: {b}", x => { });
         }
 
-        private static int CalculatePrecedingHintBytes(IReadOnlyList<Union<decimal, LazyType2Command>> precedingCommands)
+        private static int CalculatePrecedingHintBytes(IReadOnlyList<Union<double, LazyType2Command>> precedingCommands)
         {
             int SafeStemCount(int counts)
             {

--- a/src/UglyToad.PdfPig/Fonts/CompactFontFormat/CharStrings/Type2CharStringParser.cs
+++ b/src/UglyToad.PdfPig/Fonts/CompactFontFormat/CharStrings/Type2CharStringParser.cs
@@ -19,17 +19,24 @@ namespace UglyToad.PdfPig.Fonts.CompactFontFormat.CharStrings
     /// </remarks>
     internal class Type2CharStringParser
     {
+        private const byte HstemByte = 1;
+        private const byte VstemByte = 3;
+        private const byte HstemhmByte = 18;
+        private const byte HintmaskByte = 19;
+        private const byte CntrmaskByte = 20;
+        private const byte VstemhmByte = 23;
+
         private static readonly HashSet<byte> HintingCommandBytes = new HashSet<byte>
         {
-            1,
-            3,
-            18,
-            23
+            HstemByte,
+            VstemByte,
+            HstemhmByte,
+            VstemhmByte
         };
 
         private static readonly IReadOnlyDictionary<byte, LazyType2Command> SingleByteCommandStore = new Dictionary<byte, LazyType2Command>
         {
-            { 1,  new LazyType2Command("hstem", ctx =>
+            { HstemByte,  new LazyType2Command("hstem", ctx =>
                 {
                     var numberOfEdgeHints = ctx.Stack.Length / 2;
                     var hints = new (double, double)[numberOfEdgeHints];
@@ -56,7 +63,7 @@ namespace UglyToad.PdfPig.Fonts.CompactFontFormat.CharStrings
                 })
             },
             {
-                3,  new LazyType2Command("vstem", ctx =>
+                VstemByte,  new LazyType2Command("vstem", ctx =>
                 {
                     var numberOfEdgeHints = ctx.Stack.Length / 2;
                     var hints = new (double, double)[numberOfEdgeHints];
@@ -197,7 +204,7 @@ namespace UglyToad.PdfPig.Fonts.CompactFontFormat.CharStrings
                     ctx.Stack.Clear();
                 })
             },
-            { 18,  new LazyType2Command("hstemhm", ctx =>
+            { HstemhmByte,  new LazyType2Command("hstemhm", ctx =>
                 {
                     // Same as vstem except the charstring contains hintmask
                     var numberOfEdgeHints = ctx.Stack.Length / 2;
@@ -225,14 +232,14 @@ namespace UglyToad.PdfPig.Fonts.CompactFontFormat.CharStrings
                 })
             },
             {
-                19,  new LazyType2Command("hintmask", ctx =>
+                HintmaskByte,  new LazyType2Command("hintmask", ctx =>
                 {
                     // TODO: record this mask somewhere
                     ctx.Stack.Clear();
                 })
             },
             {
-                20,  new LazyType2Command("cntrmask", ctx =>
+                CntrmaskByte,  new LazyType2Command("cntrmask", ctx =>
                 {
                     // TODO: record this mask somewhere
                     ctx.Stack.Clear();
@@ -264,7 +271,7 @@ namespace UglyToad.PdfPig.Fonts.CompactFontFormat.CharStrings
                     ctx.Stack.Clear();
                 })
             },
-            { 23,  new LazyType2Command("vstemhm", ctx =>
+            { VstemhmByte,  new LazyType2Command("vstemhm", ctx =>
                 {
                     // Same as vstem except the charstring contains hintmask
                     var numberOfEdgeHints = ctx.Stack.Length / 2;
@@ -865,10 +872,7 @@ namespace UglyToad.PdfPig.Fonts.CompactFontFormat.CharStrings
 
                 return (counts - 1) / 2;
             }
-
-            const byte hintmaskByte = 19;
-            const byte cntrmaskByte = 20;
-
+            
             /*
              * The hintmask operator is followed by one or more data bytes that specify the stem hints which are to be active for the
              * subsequent path construction. The number of data bytes must be exactly the number needed to represent the number of
@@ -889,7 +893,7 @@ namespace UglyToad.PdfPig.Fonts.CompactFontFormat.CharStrings
                 foreach (var identifier in precedingCommands.Where(x => x.CommandIndex == i + 1))
                 {
                     if (!identifier.IsMultiByteCommand
-                        && (identifier.CommandId == hintmaskByte || identifier.CommandId == cntrmaskByte)
+                        && (identifier.CommandId == HintmaskByte || identifier.CommandId == CntrmaskByte)
                         && !hasEncounteredInitialHintMask)
                     {
                         hasEncounteredInitialHintMask = true;

--- a/src/UglyToad.PdfPig/Fonts/CompactFontFormat/CharStrings/Type2CharStrings.cs
+++ b/src/UglyToad.PdfPig/Fonts/CompactFontFormat/CharStrings/Type2CharStrings.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.Collections.Generic;
+    using System.Text;
     using Geometry;
     using Util.JetBrains.Annotations;
 
@@ -76,9 +77,9 @@
                     context.Stack.Push(value);
                 }
 
-                foreach (var command in sequence.GetCommandsAt(i + 1))
+                foreach (var commandIdentifier in sequence.GetCommandsAt(i + 1))
                 {
-                    var x = Type2CharStringParser.GetCommand(command);
+                    var command = Type2CharStringParser.GetCommand(commandIdentifier);
 
                     var isOnlyCommand = sequence.Values.Count + sequence.CommandIdentifiers.Count == 1;
 
@@ -89,7 +90,7 @@
                         * rmoveto, or endchar, takes an additional argument — the width (as described earlier), which may be expressed as zero or one numeric argument.
                         */
                         hasRunStackClearingCommand = true;
-                        switch (x.Name)
+                        switch (command.Name)
                         {
                             case "hstem":
                             case "hstemhm":
@@ -131,7 +132,7 @@
                         }
                     }
 
-                    x.Run(context);
+                    command.Run(context);
                 }
             }
 
@@ -172,9 +173,25 @@
                 }
             }
 
+            /// <inheritdoc />
             public override string ToString()
             {
-                return string.Empty;
+                var stringBuilder = new StringBuilder();
+                for (var i = -1; i < Values.Count; i++)
+                {
+                    if (i >= 0)
+                    {
+                        var value = Values[i];
+                        stringBuilder.AppendLine(value.ToString("N"));
+                    }
+
+                    foreach (var identifier in GetCommandsAt(i + 1))
+                    {
+                        stringBuilder.AppendLine(Type2CharStringParser.GetCommand(identifier).Name);
+                    }
+                }
+
+                return stringBuilder.ToString();
             }
 
             public struct CommandIdentifier

--- a/src/UglyToad.PdfPig/Fonts/CompactFontFormat/CharStrings/Type2CharStrings.cs
+++ b/src/UglyToad.PdfPig/Fonts/CompactFontFormat/CharStrings/Type2CharStrings.cs
@@ -35,7 +35,7 @@
         /// <param name="defaultWidthX">The default width for the glyph from the font's private dictionary.</param>
         /// <param name="nominalWidthX">The nominal width which individual glyph widths are encoded as the difference from.</param>
         /// <returns>A <see cref="PdfPath"/> for the glyph.</returns>
-        public Type2Glyph Generate(string name, decimal defaultWidthX, decimal nominalWidthX)
+        public Type2Glyph Generate(string name, double defaultWidthX, double nominalWidthX)
         {
             Type2Glyph glyph;
             lock (locker)
@@ -65,7 +65,7 @@
             return glyph;
         }
 
-        private static Type2Glyph Run(CommandSequence sequence, decimal defaultWidthX, decimal nominalWidthX)
+        private static Type2Glyph Run(CommandSequence sequence, double defaultWidthX, double nominalWidthX)
         {
             var context = new Type2BuildCharContext();
             
@@ -135,7 +135,7 @@
             return new Type2Glyph(context.Path, context.Width);
         }
 
-        private static void SetWidthFromArgumentsIfPresent(Type2BuildCharContext context, decimal nomimalWidthX, int expectedArgumentLength)
+        private static void SetWidthFromArgumentsIfPresent(Type2BuildCharContext context, double nomimalWidthX, int expectedArgumentLength)
         {
             if (context.Stack.Length > expectedArgumentLength)
             {
@@ -148,9 +148,9 @@
             /// <summary>
             /// The ordered list of numbers and commands for a Type 2 charstring or subroutine.
             /// </summary>
-            public IReadOnlyList<Union<decimal, LazyType2Command>> Commands { get; }
+            public IReadOnlyList<Union<double, LazyType2Command>> Commands { get; }
 
-            public CommandSequence(IReadOnlyList<Union<decimal, LazyType2Command>> commands)
+            public CommandSequence(IReadOnlyList<Union<double, LazyType2Command>> commands)
             {
                 Commands = commands ?? throw new ArgumentNullException(nameof(commands));
             }
@@ -177,12 +177,12 @@
         /// <summary>
         /// The width of the glyph as a difference from the nominal width X for the font. Optional.
         /// </summary>
-        public decimal? Width { get; }
+        public double? Width { get; }
 
         /// <summary>
         /// Create a new <see cref="Type2Glyph"/>.
         /// </summary>
-        public Type2Glyph(PdfPath path, decimal? width)
+        public Type2Glyph(PdfPath path, double? width)
         {
             Path = path ?? throw new ArgumentNullException(nameof(path));
             Width = width;

--- a/src/UglyToad.PdfPig/Fonts/CompactFontFormat/CompactFontFormatFont.cs
+++ b/src/UglyToad.PdfPig/Fonts/CompactFontFormat/CompactFontFormatFont.cs
@@ -37,7 +37,7 @@
             var result = CharStrings.Match(x => throw new NotImplementedException("Type 1 CharStrings in a CFF font are currently unsupported."),
                 x =>
                 {
-                    var glyph = x.Generate(characterName, defaultWidthX, nominalWidthX);
+                    var glyph = x.Generate(characterName, (double)defaultWidthX, (double)nominalWidthX);
                     var rectangle = glyph.Path.GetBoundingRectangle();
                     if (rectangle.HasValue)
                     {

--- a/src/UglyToad.PdfPig/Fonts/CompactFontFormat/CompactFontFormatFontProgram.cs
+++ b/src/UglyToad.PdfPig/Fonts/CompactFontFormat/CompactFontFormatFontProgram.cs
@@ -76,12 +76,12 @@
             throw new NotImplementedException();
         }
 
-        public bool TryGetBoundingAdvancedWidth(int characterIdentifier, Func<int, int?> characterCodeToGlyphId, out decimal width)
+        public bool TryGetBoundingAdvancedWidth(int characterIdentifier, Func<int, int?> characterCodeToGlyphId, out double width)
         {
             throw new NotImplementedException();
         }
 
-        public bool TryGetBoundingAdvancedWidth(int characterIdentifier, out decimal width)
+        public bool TryGetBoundingAdvancedWidth(int characterIdentifier, out double width)
         {
             throw new NotImplementedException();
         }

--- a/src/UglyToad.PdfPig/Fonts/CompactFontFormat/Dictionaries/CompactFontFormatDictionaryReader.cs
+++ b/src/UglyToad.PdfPig/Fonts/CompactFontFormat/Dictionaries/CompactFontFormatDictionaryReader.cs
@@ -213,8 +213,8 @@
                 return new PdfRectangle();
             }
 
-            return new PdfRectangle(operands[0].Decimal, operands[1].Decimal,
-                operands[2].Decimal, operands[3].Decimal);
+            return new PdfRectangle((double)operands[0].Decimal, (double)operands[1].Decimal,
+                (double)operands[2].Decimal, (double)operands[3].Decimal);
         }
 
         protected static decimal[] ToArray(List<Operand> operands)

--- a/src/UglyToad.PdfPig/Fonts/CompactFontFormat/Dictionaries/CompactFontFormatTopLevelDictionary.cs
+++ b/src/UglyToad.PdfPig/Fonts/CompactFontFormat/Dictionaries/CompactFontFormatTopLevelDictionary.cs
@@ -31,7 +31,7 @@
 
         public CompactFontFormatCharStringType CharStringType { get; set; } = CompactFontFormatCharStringType.Type2;
 
-        public TransformationMatrix FontMatrix { get; set; } = TransformationMatrix.FromValues(0.001m, 0m, 0, 0.001m, 0, 0);
+        public TransformationMatrix FontMatrix { get; set; } = TransformationMatrix.FromValues(0.001, 0, 0, 0.001, 0, 0);
 
         public decimal StrokeWidth { get; set; }
 

--- a/src/UglyToad.PdfPig/Fonts/Composite/Type0Font.cs
+++ b/src/UglyToad.PdfPig/Fonts/Composite/Type0Font.cs
@@ -116,14 +116,14 @@
         {
             var characterIdentifier = CMap.ConvertToCid(characterCode);
 
-            return CidFont.GetPositionVector(characterIdentifier).Scale(-1 / 1000m);
+            return CidFont.GetPositionVector(characterIdentifier).Scale(-1 / 1000.0);
         }
 
         public PdfVector GetDisplacementVector(int characterCode)
         {
             var characterIdentifier = CMap.ConvertToCid(characterCode);
 
-            return CidFont.GetDisplacementVector(characterIdentifier).Scale(1 / 1000m);
+            return CidFont.GetDisplacementVector(characterIdentifier).Scale(1 / 1000.0);
         }
     }
 }

--- a/src/UglyToad.PdfPig/Fonts/FontMetricsBuilder.cs
+++ b/src/UglyToad.PdfPig/Fonts/FontMetricsBuilder.cs
@@ -127,17 +127,17 @@
             Comments = new List<string>();
         }
 
-        public void SetBoundingBox(decimal x1, decimal y1, decimal x2, decimal y2)
+        public void SetBoundingBox(double x1, double y1, double x2, double y2)
         {
             PdfBoundingBox = new PdfRectangle(x1, y1, x2, y2);
         }
 
-        public void SetCharacterWidth(decimal x, decimal y)
+        public void SetCharacterWidth(double x, double y)
         {
             CharacterWidth = new CharacterWidth(x, y);
         }
 
-        public void SetVVector(decimal x, decimal y)
+        public void SetVVector(double x, double y)
         {
             VVector = new PdfVector(x, y);
         }

--- a/src/UglyToad.PdfPig/Fonts/IndividualCharacterMetric.cs
+++ b/src/UglyToad.PdfPig/Fonts/IndividualCharacterMetric.cs
@@ -7,14 +7,14 @@
     {
         public int CharacterCode { get; set; }
 
-        public decimal WidthX { get; set; }
-        public decimal WidthY { get; set; }
+        public double WidthX { get; set; }
+        public double WidthY { get; set; }
 
-        public decimal WidthXDirection0 { get; set; }
-        public decimal WidthYDirection0 { get; set; }
+        public double WidthXDirection0 { get; set; }
+        public double WidthYDirection0 { get; set; }
 
-        public decimal WidthXDirection1 { get; set; }
-        public decimal WidthYDirection1 { get; set; }
+        public double WidthXDirection1 { get; set; }
+        public double WidthYDirection1 { get; set; }
 
         public string Name { get; set; }
 

--- a/src/UglyToad.PdfPig/Fonts/Parser/AdobeFontMetricsParser.cs
+++ b/src/UglyToad.PdfPig/Fonts/Parser/AdobeFontMetricsParser.cs
@@ -362,8 +362,8 @@
                         builder.IsFixedPitch = ReadBool(bytes, stringBuilder);
                         break;
                     case FontBbox:
-                        builder.SetBoundingBox(ReadDecimal(bytes, stringBuilder), ReadDecimal(bytes, stringBuilder),
-                            ReadDecimal(bytes, stringBuilder), ReadDecimal(bytes, stringBuilder));
+                        builder.SetBoundingBox(ReadDouble(bytes, stringBuilder), ReadDouble(bytes, stringBuilder),
+                            ReadDouble(bytes, stringBuilder), ReadDouble(bytes, stringBuilder));
                         break;
                     case UnderlinePosition:
                         builder.UnderlinePosition = ReadDecimal(bytes, stringBuilder);
@@ -414,10 +414,10 @@
                         builder.StdVw = ReadDecimal(bytes, stringBuilder);
                         break;
                     case CharWidth:
-                        builder.SetCharacterWidth(ReadDecimal(bytes, stringBuilder), ReadDecimal(bytes, stringBuilder));
+                        builder.SetCharacterWidth(ReadDouble(bytes, stringBuilder), ReadDouble(bytes, stringBuilder));
                         break;
                     case VVector:
-                        builder.SetVVector(ReadDecimal(bytes, stringBuilder), ReadDecimal(bytes, stringBuilder));
+                        builder.SetVVector(ReadDouble(bytes, stringBuilder), ReadDouble(bytes, stringBuilder));
                         break;
                     case IsFixedV:
                         builder.IsFixedV = ReadBool(bytes, stringBuilder);
@@ -450,6 +450,12 @@
             var str = ReadString(input, stringBuilder);
 
             return decimal.Parse(str, CultureInfo.InvariantCulture);
+        }
+
+        private static double ReadDouble(IInputBytes input, StringBuilder stringBuilder)
+        {
+            var dec = ReadDecimal(input, stringBuilder);
+            return (double) dec;
         }
 
         private static bool ReadBool(IInputBytes input, StringBuilder stringBuilder)
@@ -536,55 +542,55 @@
                         }
                     case CharmetricsWx:
                         {
-                            metric.WidthX = decimal.Parse(parts[1], CultureInfo.InvariantCulture);
+                            metric.WidthX = double.Parse(parts[1], CultureInfo.InvariantCulture);
                             break;
                         }
                     case CharmetricsW0X:
                         {
-                            metric.WidthXDirection0 = decimal.Parse(parts[1], CultureInfo.InvariantCulture);
+                            metric.WidthXDirection0 = double.Parse(parts[1], CultureInfo.InvariantCulture);
                             break;
                         }
                     case CharmetricsW1X:
                         {
-                            metric.WidthXDirection1 = decimal.Parse(parts[1], CultureInfo.InvariantCulture);
+                            metric.WidthXDirection1 = double.Parse(parts[1], CultureInfo.InvariantCulture);
                             break;
                         }
                     case CharmetricsWy:
                         {
-                            metric.WidthY = decimal.Parse(parts[1], CultureInfo.InvariantCulture);
+                            metric.WidthY = double.Parse(parts[1], CultureInfo.InvariantCulture);
                             break;
                         }
                     case CharmetricsW0Y:
                         {
-                            metric.WidthYDirection0 = decimal.Parse(parts[1], CultureInfo.InvariantCulture);
+                            metric.WidthYDirection0 = double.Parse(parts[1], CultureInfo.InvariantCulture);
                             break;
                         }
                     case CharmetricsW1Y:
                         {
-                            metric.WidthYDirection1 = decimal.Parse(parts[1], CultureInfo.InvariantCulture);
+                            metric.WidthYDirection1 = double.Parse(parts[1], CultureInfo.InvariantCulture);
                             break;
                         }
                     case CharmetricsW:
                         {
-                            metric.WidthX = decimal.Parse(parts[1], CultureInfo.InvariantCulture);
-                            metric.WidthY = decimal.Parse(parts[2], CultureInfo.InvariantCulture);
+                            metric.WidthX = double.Parse(parts[1], CultureInfo.InvariantCulture);
+                            metric.WidthY = double.Parse(parts[2], CultureInfo.InvariantCulture);
                             break;
                         }
                     case CharmetricsW0:
                         {
-                            metric.WidthXDirection0 = decimal.Parse(parts[1], CultureInfo.InvariantCulture);
-                            metric.WidthYDirection0 = decimal.Parse(parts[2], CultureInfo.InvariantCulture);
+                            metric.WidthXDirection0 = double.Parse(parts[1], CultureInfo.InvariantCulture);
+                            metric.WidthYDirection0 = double.Parse(parts[2], CultureInfo.InvariantCulture);
                             break;
                         }
                     case CharmetricsW1:
                         {
-                            metric.WidthXDirection1 = decimal.Parse(parts[1], CultureInfo.InvariantCulture);
-                            metric.WidthYDirection1 = decimal.Parse(parts[2], CultureInfo.InvariantCulture);
+                            metric.WidthXDirection1 = double.Parse(parts[1], CultureInfo.InvariantCulture);
+                            metric.WidthYDirection1 = double.Parse(parts[2], CultureInfo.InvariantCulture);
                             break;
                         }
                     case CharmetricsVv:
                         {
-                            metric.VVector = new PdfVector(decimal.Parse(parts[1], CultureInfo.InvariantCulture), decimal.Parse(parts[2], CultureInfo.InvariantCulture));
+                            metric.VVector = new PdfVector(double.Parse(parts[1], CultureInfo.InvariantCulture), double.Parse(parts[2], CultureInfo.InvariantCulture));
                             break;
                         }
                     case CharmetricsN:
@@ -594,10 +600,10 @@
                         }
                     case CharmetricsB:
                         {
-                            metric.BoundingBox = new PdfRectangle(decimal.Parse(parts[1], CultureInfo.InvariantCulture),
-                                decimal.Parse(parts[2], CultureInfo.InvariantCulture),
-                                decimal.Parse(parts[3], CultureInfo.InvariantCulture),
-                                decimal.Parse(parts[4], CultureInfo.InvariantCulture));
+                            metric.BoundingBox = new PdfRectangle(double.Parse(parts[1], CultureInfo.InvariantCulture),
+                                double.Parse(parts[2], CultureInfo.InvariantCulture),
+                                double.Parse(parts[3], CultureInfo.InvariantCulture),
+                                double.Parse(parts[4], CultureInfo.InvariantCulture));
                             break;
                         }
                     case CharmetricsL:

--- a/src/UglyToad.PdfPig/Fonts/Parser/FontDictionaryAccessHelper.cs
+++ b/src/UglyToad.PdfPig/Fonts/Parser/FontDictionaryAccessHelper.cs
@@ -28,7 +28,7 @@
             return number.Int;
         }
 
-        public static decimal[] GetWidths(IPdfTokenScanner pdfScanner, DictionaryToken dictionary, bool isLenientParsing)
+        public static double[] GetWidths(IPdfTokenScanner pdfScanner, DictionaryToken dictionary, bool isLenientParsing)
         {
             if (!dictionary.TryGet(NameToken.Widths, out var token))
             {
@@ -37,7 +37,7 @@
 
             var widthArray = DirectObjectFinder.Get<ArrayToken>(token, pdfScanner);
 
-            var result = new decimal[widthArray.Data.Count];
+            var result = new double[widthArray.Data.Count];
             for (int i = 0; i < widthArray.Data.Count; i++)
             {
                 var arrayToken = widthArray.Data[i];
@@ -47,7 +47,7 @@
                     throw new InvalidFontFormatException($"Token which was not a number found in the widths array: {arrayToken}.");
                 }
 
-                result[i] = number.Data;
+                result[i] = number.Double;
             }
 
             return result;

--- a/src/UglyToad.PdfPig/Fonts/Parser/Handlers/TrueTypeFontHandler.cs
+++ b/src/UglyToad.PdfPig/Fonts/Parser/Handlers/TrueTypeFontHandler.cs
@@ -73,7 +73,7 @@
                 }
 
                 int? firstChar = null;
-                decimal[] widthsOverride = null;
+                double[] widthsOverride = null;
 
                 if (dictionary.TryGet(NameToken.FirstChar, pdfScanner, out firstCharacterToken))
                 {
@@ -83,7 +83,7 @@
                 if (dictionary.TryGet(NameToken.Widths, pdfScanner, out ArrayToken widthsArray))
                 {
                     widthsOverride = widthsArray.Data.OfType<NumericToken>()
-                        .Select(x => x.Data).ToArray();
+                        .Select(x => x.Double).ToArray();
                 }
 
                 return new TrueTypeStandard14FallbackSimpleFont(baseFont, standard14Font, thisEncoding, fileSystemFont,

--- a/src/UglyToad.PdfPig/Fonts/Parser/Handlers/Type3FontHandler.cs
+++ b/src/UglyToad.PdfPig/Fonts/Parser/Handlers/Type3FontHandler.cs
@@ -65,9 +65,9 @@
 
             var matrixArray = DirectObjectFinder.Get<ArrayToken>(matrixObject, scanner);
             
-            return TransformationMatrix.FromValues(matrixArray.GetNumeric(0).Data, matrixArray.GetNumeric(1).Data,
-                matrixArray.GetNumeric(2).Data, matrixArray.GetNumeric(3).Data, matrixArray.GetNumeric(4).Data,
-                matrixArray.GetNumeric(5).Data);
+            return TransformationMatrix.FromValues(matrixArray.GetNumeric(0).Double, matrixArray.GetNumeric(1).Double,
+                matrixArray.GetNumeric(2).Double, matrixArray.GetNumeric(3).Double, matrixArray.GetNumeric(4).Double,
+                matrixArray.GetNumeric(5).Double);
         }
         
         private static PdfRectangle GetBoundingBox(DictionaryToken dictionary)
@@ -79,8 +79,8 @@
 
             if (bboxObject is ArrayToken bboxArray)
             {
-                return new PdfRectangle(bboxArray.GetNumeric(0).Data, bboxArray.GetNumeric(1).Data,
-                    bboxArray.GetNumeric(2).Data, bboxArray.GetNumeric(3).Data);
+                return new PdfRectangle(bboxArray.GetNumeric(0).Double, bboxArray.GetNumeric(1).Double,
+                    bboxArray.GetNumeric(2).Double, bboxArray.GetNumeric(3).Double);
             }
 
             return new PdfRectangle(0, 0, 0, 0);

--- a/src/UglyToad.PdfPig/Fonts/Parser/Parts/CidFontFactory.cs
+++ b/src/UglyToad.PdfPig/Fonts/Parser/Parts/CidFontFactory.cs
@@ -46,10 +46,10 @@
 
             var widths = ReadWidths(dictionary);
 
-            var defaultWidth = default(decimal?);
+            var defaultWidth = default(double?);
             if (dictionary.TryGet(NameToken.Dw, pdfScanner, out NumericToken defaultWidthToken))
             {
-                defaultWidth = defaultWidthToken.Data;
+                defaultWidth = defaultWidthToken.Double;
             }
 
             var verticalWritingMetrics = ReadVerticalDisplacements(dictionary);
@@ -155,9 +155,9 @@
             }
         }
 
-        private IReadOnlyDictionary<int, decimal> ReadWidths(DictionaryToken dict)
+        private IReadOnlyDictionary<int, double> ReadWidths(DictionaryToken dict)
         {
-            var widths = new Dictionary<int, decimal>();
+            var widths = new Dictionary<int, double>();
 
             if (!dict.TryGet(NameToken.W, out var widthsItem) || !(widthsItem is ArrayToken widthArray))
             {
@@ -178,7 +178,7 @@
                     for (var i = 0; i < arraySize; i++)
                     {
                         var width = (NumericToken)array.Data[i];
-                        widths[startRange + i] = width.Data;
+                        widths[startRange + i] = width.Double;
                     }
                 }
                 else
@@ -187,7 +187,7 @@
                     var rangeWidth = (NumericToken)widthArray.Data[counter++];
                     var startRange = firstCode.Int;
                     var endRange = secondCode.Int;
-                    var width = rangeWidth.Data;
+                    var width = rangeWidth.Double;
                     for (var i = startRange; i <= endRange; i++)
                     {
                         widths[i] = width;
@@ -200,7 +200,7 @@
 
         private static VerticalWritingMetrics ReadVerticalDisplacements(DictionaryToken dict)
         {
-            var verticalDisplacements = new Dictionary<int, decimal>();
+            var verticalDisplacements = new Dictionary<int, double>();
             var positionVectors = new Dictionary<int, PdfVector>();
 
             // The default position vector and displacement vector are specified by the DW2 entry.
@@ -211,8 +211,8 @@
             }
             else
             {
-                var position = ((NumericToken)arrayVerticalComponents.Data[0]).Data;
-                var displacement = ((NumericToken)arrayVerticalComponents.Data[1]).Data;
+                var position = ((NumericToken)arrayVerticalComponents.Data[0]).Double;
+                var displacement = ((NumericToken)arrayVerticalComponents.Data[1]).Double;
 
                 dw2 = new VerticalVectorComponents(position, displacement);
             }
@@ -235,9 +235,9 @@
                             var v1x = (NumericToken)array.Data[++j];
                             var v1y = (NumericToken)array.Data[++j];
 
-                            verticalDisplacements[cid] = w1y.Data;
+                            verticalDisplacements[cid] = w1y.Double;
 
-                            positionVectors[cid] = new PdfVector(v1x.Data, v1y.Data);
+                            positionVectors[cid] = new PdfVector(v1x.Double, v1y.Double);
                         }
                     }
                     else
@@ -251,9 +251,9 @@
 
                         for (var cid = first; cid <= last; cid++)
                         {
-                            verticalDisplacements[cid] = w1y.Data;
+                            verticalDisplacements[cid] = w1y.Double;
 
-                            positionVectors[cid] = new PdfVector(v1x.Data, v1y.Data);
+                            positionVectors[cid] = new PdfVector(v1x.Double, v1y.Double);
                         }
                     }
                 }

--- a/src/UglyToad.PdfPig/Fonts/Simple/TrueTypeSimpleFont.cs
+++ b/src/UglyToad.PdfPig/Fonts/Simple/TrueTypeSimpleFont.cs
@@ -15,7 +15,7 @@
     internal class TrueTypeSimpleFont : IFont
     {
         private static readonly TransformationMatrix DefaultTransformation =
-            TransformationMatrix.FromValues(1m / 1000m, 0, 0, 1m / 1000m, 0, 0);
+            TransformationMatrix.FromValues(1 / 1000.0, 0, 0, 1 / 1000.0, 0, 0);
 
         private readonly FontDescriptor descriptor;
 
@@ -30,7 +30,7 @@
 
         private readonly int firstCharacter;
 
-        private readonly decimal[] widths;
+        private readonly double[] widths;
 
         public NameToken Name { get; }
 
@@ -45,7 +45,7 @@
             [CanBeNull] Encoding encoding,
             [CanBeNull] TrueTypeFontProgram fontProgram,
             int firstCharacter,
-            decimal[] widths)
+            double[] widths)
         {
             this.descriptor = descriptor;
             this.encoding = encoding;
@@ -134,7 +134,7 @@
                 boundingBox = DefaultTransformation.Transform(boundingBox);
             }
 
-            decimal width;
+            double width;
 
             var index = characterCode - firstCharacter;
             if (widths != null && index >= 0 && index < widths.Length)
@@ -172,14 +172,14 @@
 
         public TransformationMatrix GetFontMatrix()
         {
-            var scale = 1000m;
+            var scale = 1000.0;
 
             if (fontProgram?.TableRegister.HeaderTable != null)
             {
                 scale = fontProgram.GetFontMatrixMultiplier();
             }
 
-            return TransformationMatrix.FromValues(1m / scale, 0, 0, 1m / scale, 0, 0);
+            return TransformationMatrix.FromValues(1 / scale, 0, 0, 1 / scale, 0, 0);
         }
 
         private PdfRectangle GetBoundingBoxInGlyphSpace(int characterCode, out bool fromFont)
@@ -303,13 +303,13 @@
             return null;
         }
 
-        private decimal GetWidth(int characterCode)
+        private double GetWidth(int characterCode)
         {
             var index = characterCode - firstCharacter;
 
             if (index < 0 || index >= widths.Length)
             {
-                return descriptor.MissingWidth;
+                return (double)descriptor.MissingWidth;
             }
 
             return widths[index];

--- a/src/UglyToad.PdfPig/Fonts/Simple/TrueTypeStandard14FallbackSimpleFont.cs
+++ b/src/UglyToad.PdfPig/Fonts/Simple/TrueTypeStandard14FallbackSimpleFont.cs
@@ -14,7 +14,7 @@
     internal class TrueTypeStandard14FallbackSimpleFont : IFont
     {
         private static readonly TransformationMatrix DefaultTransformation =
-            TransformationMatrix.FromValues(1m / 1000m, 0, 0, 1m / 1000m, 0, 0);
+            TransformationMatrix.FromValues(1 / 1000.0, 0, 0, 1 / 1000.0, 0, 0);
 
         private readonly FontMetrics fontMetrics;
         private readonly Encoding encoding;
@@ -65,7 +65,7 @@
 
         public CharacterBoundingBox GetBoundingBox(int characterCode)
         {
-            var width = 0m;
+            var width = 0.0;
 
             var fontMatrix = GetFontMatrix();
 
@@ -106,7 +106,7 @@
         {
             if (font?.TableRegister.HeaderTable != null)
             {
-                var scale = (decimal)font.GetFontMatrixMultiplier();
+                var scale = (double)font.GetFontMatrixMultiplier();
 
                 return TransformationMatrix.FromValues(1 / scale, 0, 0, 1 / scale, 0, 0);
             }
@@ -118,11 +118,11 @@
         {
             public int? FirstCharacterCode { get; }
 
-            public IReadOnlyList<decimal> Widths { get; }
+            public IReadOnlyList<double> Widths { get; }
 
             public bool HasOverriddenMetrics { get; }
 
-            public MetricOverrides(int? firstCharacterCode, IReadOnlyList<decimal> widths)
+            public MetricOverrides(int? firstCharacterCode, IReadOnlyList<double> widths)
             {
                 FirstCharacterCode = firstCharacterCode;
                 Widths = widths;
@@ -130,7 +130,7 @@
                     && Widths.Count > 0;
             }
 
-            public bool TryGetWidth(int characterCode, out decimal width)
+            public bool TryGetWidth(int characterCode, out double width)
             {
                 width = 0;
 

--- a/src/UglyToad.PdfPig/Fonts/Simple/Type1FontSimple.cs
+++ b/src/UglyToad.PdfPig/Fonts/Simple/Type1FontSimple.cs
@@ -24,7 +24,7 @@
 
         private readonly int lastChar;
 
-        private readonly decimal[] widths;
+        private readonly double[] widths;
 
         private readonly FontDescriptor fontDescriptor;
 
@@ -41,7 +41,7 @@
 
         public bool IsVertical { get; } = false;
 
-        public Type1FontSimple(NameToken name, int firstChar, int lastChar, decimal[] widths, FontDescriptor fontDescriptor, Encoding encoding, 
+        public Type1FontSimple(NameToken name, int firstChar, int lastChar, double[] widths, FontDescriptor fontDescriptor, Encoding encoding, 
             CMap toUnicodeCMap,
             Union<Type1FontProgram, CompactFontFormatFontProgram> fontProgram)
         {
@@ -53,7 +53,7 @@
             this.fontProgram = fontProgram;
             this.toUnicodeCMap = new ToUnicodeCMap(toUnicodeCMap);
 
-            var matrix = TransformationMatrix.FromValues(0.001m, 0, 0, 0.001m, 0, 0);
+            var matrix = TransformationMatrix.FromValues(0.001, 0, 0, 0.001, 0, 0);
             fontProgram?.Match(x => matrix = x.GetFontTransformationMatrix(), x => { matrix = x.GetFontTransformationMatrix(); });
 
             fontMatrix = matrix;
@@ -135,7 +135,7 @@
             return result;
         }
 
-        private decimal GetWidth(int characterCode, PdfRectangle boundingBox)
+        private double GetWidth(int characterCode, PdfRectangle boundingBox)
         {
             var widthIndex = characterCode - firstChar;
 
@@ -146,7 +146,7 @@
 
             if (fontDescriptor?.MissingWidth != null)
             {
-                return fontDescriptor.MissingWidth;
+                return (double)fontDescriptor.MissingWidth;
             }
 
             return boundingBox.Width;

--- a/src/UglyToad.PdfPig/Fonts/Simple/Type1Standard14Font.cs
+++ b/src/UglyToad.PdfPig/Fonts/Simple/Type1Standard14Font.cs
@@ -18,7 +18,7 @@
         public NameToken Name { get; }
         public bool IsVertical { get; }
 
-        private readonly TransformationMatrix fontMatrix = TransformationMatrix.FromValues(0.001m, 0, 0, 0.001m, 0, 0);
+        private readonly TransformationMatrix fontMatrix = TransformationMatrix.FromValues(0.001, 0, 0, 0.001, 0, 0);
 
         public Type1Standard14Font(FontMetrics standardFontMetrics, Encoding overrideEncoding = null)
         {

--- a/src/UglyToad.PdfPig/Fonts/Simple/Type3Font.cs
+++ b/src/UglyToad.PdfPig/Fonts/Simple/Type3Font.cs
@@ -16,7 +16,7 @@
         private readonly Encoding encoding;
         private readonly int firstChar;
         private readonly int lastChar;
-        private readonly decimal[] widths;
+        private readonly double[] widths;
         private readonly ToUnicodeCMap toUnicodeCMap;
 
         /// <summary>
@@ -27,7 +27,7 @@
         public bool IsVertical { get; } = false;
 
         public Type3Font(NameToken name, PdfRectangle boundingBox, TransformationMatrix fontMatrix,
-            Encoding encoding, int firstChar, int lastChar, decimal[] widths,
+            Encoding encoding, int firstChar, int lastChar, double[] widths,
             CMap toUnicodeCMap)
         {
             Name = name;

--- a/src/UglyToad.PdfPig/Fonts/TrueType/Glyphs/Glyph.cs
+++ b/src/UglyToad.PdfPig/Fonts/TrueType/Glyphs/Glyph.cs
@@ -107,11 +107,11 @@
             {
                 var point = Points[i];
 
-                var scaled = matrix.ScaleAndRotate(point.Point);
+                var scaled = matrix.ScaleAndRotate(new PdfPoint(point.X, point.Y));
 
                 scaled = matrix.Translate(scaled);
 
-                newPoints[i] = new GlyphPoint(scaled, point.IsOnCurve);
+                newPoints[i] = new GlyphPoint((short)scaled.X, (short)scaled.Y, point.IsOnCurve);
             }
 
             return new Glyph(IsSimple, Instructions, EndPointsOfContours, newPoints, Bounds);

--- a/src/UglyToad.PdfPig/Fonts/TrueType/Glyphs/GlyphPoint.cs
+++ b/src/UglyToad.PdfPig/Fonts/TrueType/Glyphs/GlyphPoint.cs
@@ -1,23 +1,23 @@
 ﻿namespace UglyToad.PdfPig.Fonts.TrueType.Glyphs
 {
-    using Geometry;
-
     internal struct GlyphPoint
     {
-        public PdfPoint Point { get; }
+        public short X { get; }
+
+        public short Y { get; }
 
         public bool IsOnCurve { get; }
 
-        public GlyphPoint(decimal x, decimal y, bool isOnCurve) : this(new PdfPoint(x, y), isOnCurve) { }
-        public GlyphPoint(PdfPoint point, bool isOnCurve)
+        public GlyphPoint(short x, short y, bool isOnCurve) 
         {
-            Point = point;
+            X = x;
+            Y = y;
             IsOnCurve = isOnCurve;
         }
 
         public override string ToString()
         {
-            return $"{Point} | {IsOnCurve}";
+            return $"({X}, {Y}) | {IsOnCurve}";
         }
     }
 }

--- a/src/UglyToad.PdfPig/Fonts/TrueType/Parser/HorizontalHeaderTableParser.cs
+++ b/src/UglyToad.PdfPig/Fonts/TrueType/Parser/HorizontalHeaderTableParser.cs
@@ -1,0 +1,55 @@
+﻿namespace UglyToad.PdfPig.Fonts.TrueType.Parser
+{
+    using System;
+    using Tables;
+
+    internal class HorizontalHeaderTableParser : ITrueTypeTableParser<HorizontalHeaderTable>
+    {
+        public HorizontalHeaderTable Parse(TrueTypeHeaderTable header, TrueTypeDataBytes data, TableRegister.Builder register)
+        {
+            data.Seek(header.Offset);
+            var majorVersion = data.ReadUnsignedShort();
+            var minorVersion = data.ReadUnsignedShort();
+
+            var ascender = data.ReadSignedShort();
+            var descender = data.ReadSignedShort();
+            var lineGap = data.ReadSignedShort();
+
+            var advancedWidthMax = data.ReadUnsignedShort();
+
+            var minLeftSideBearing = data.ReadSignedShort();
+            var minRightSideBearing = data.ReadSignedShort();
+            var xMaxExtent = data.ReadSignedShort();
+
+            var caretSlopeRise = data.ReadSignedShort();
+            var caretSlopeRun = data.ReadSignedShort();
+            var caretOffset = data.ReadSignedShort();
+
+            // Reserved section
+            data.ReadSignedShort();
+            data.ReadSignedShort();
+            data.ReadSignedShort();
+            data.ReadSignedShort();
+
+            var metricDataFormat = data.ReadSignedShort();
+
+            if (metricDataFormat != 0)
+            {
+                throw new NotSupportedException("The metric data format for a horizontal header table should be 0.");
+            }
+
+            var numberOfHeaderMetrics = data.ReadUnsignedShort();
+
+            return new HorizontalHeaderTable(header, majorVersion, minorVersion, ascender,
+                descender, lineGap, advancedWidthMax,
+                minLeftSideBearing,
+                minRightSideBearing,
+                xMaxExtent,
+                caretSlopeRise,
+                caretSlopeRun,
+                caretOffset,
+                metricDataFormat,
+                numberOfHeaderMetrics);
+        }
+    }
+}

--- a/src/UglyToad.PdfPig/Fonts/TrueType/Parser/HorizontalMetricsTableParser.cs
+++ b/src/UglyToad.PdfPig/Fonts/TrueType/Parser/HorizontalMetricsTableParser.cs
@@ -12,33 +12,36 @@
             data.Seek(header.Offset);
             var bytesRead = 0;
 
-            // The number of entries in the left side bearing field per entry is number of glyphs - number of metrics
-            var additionalLeftSideBearingLength = glyphCount - metricCount;
 
-            var advancedWidths = new int[metricCount];
+            var horizontalMetrics = new HorizontalMetricsTable.HorizontalMetric[metricCount];
 
-            // For bearings over the metric count, the width is the same as the last width in advanced widths.
-            var leftSideBearings = new short[glyphCount];
 
             for (var i = 0; i < metricCount; i++)
             {
-                advancedWidths[i] = data.ReadUnsignedShort();
-                leftSideBearings[i] = data.ReadSignedShort();
+                var width = data.ReadUnsignedShort();
+                var lsb = data.ReadSignedShort();
+
+                horizontalMetrics[i] = new HorizontalMetricsTable.HorizontalMetric(width, lsb);
+
                 bytesRead += 4;
             }
+            
+            // The number of entries in the left side bearing field per entry is number of glyphs - number of metrics
+            // For bearings over the metric count, the width is the same as the last width in advanced widths.
+            var additionalLeftSideBearings = new short[glyphCount - metricCount];
 
-            for (var i = 0; i < additionalLeftSideBearingLength; i++)
+            for (var i = 0; i < additionalLeftSideBearings.Length; i++)
             {
                 if (bytesRead >= header.Length)
                 {
                     break;
                 }
 
-                leftSideBearings[metricCount + i] = data.ReadSignedShort();
+                additionalLeftSideBearings[i] = data.ReadSignedShort();
                 bytesRead += 2;
             }
 
-            return new HorizontalMetricsTable(header, advancedWidths, leftSideBearings, metricCount);
+            return new HorizontalMetricsTable(header, horizontalMetrics, additionalLeftSideBearings);
         }
     }
 }

--- a/src/UglyToad.PdfPig/Fonts/TrueType/Parser/NameTableParser.cs
+++ b/src/UglyToad.PdfPig/Fonts/TrueType/Parser/NameTableParser.cs
@@ -1,62 +1,10 @@
 ﻿namespace UglyToad.PdfPig.Fonts.TrueType.Parser
 {
-    using System;
     using System.Text;
     using Names;
     using Tables;
     using Util;
     using Util.JetBrains.Annotations;
-
-    internal class HorizontalHeaderTableParser : ITrueTypeTableParser<HorizontalHeaderTable>
-    {
-        public HorizontalHeaderTable Parse(TrueTypeHeaderTable header, TrueTypeDataBytes data, TableRegister.Builder register)
-        {
-            data.Seek(header.Offset);
-            var majorVersion = data.ReadUnsignedShort();
-            var minorVersion = data.ReadUnsignedShort();
-
-            var ascender = data.ReadSignedShort();
-            var descender = data.ReadSignedShort();
-            var lineGap = data.ReadSignedShort();
-
-            var advancedWidthMax = data.ReadUnsignedShort();
-
-            var minLeftSideBearing = data.ReadSignedShort();
-            var minRightSideBearing = data.ReadSignedShort();
-            var xMaxExtent = data.ReadSignedShort();
-
-            var caretSlopeRise = data.ReadSignedShort();
-            var caretSlopeRun = data.ReadSignedShort();
-            var caretOffset = data.ReadSignedShort();
-
-            // Reserved section
-            data.ReadSignedShort();
-            data.ReadSignedShort();
-            data.ReadSignedShort();
-            data.ReadSignedShort();
-
-            var metricDataFormat = data.ReadSignedShort();
-
-            if (metricDataFormat != 0)
-            {
-                throw new NotSupportedException("The metric data format for a horizontal header table should be 0.");
-            }
-
-            var numberOfHeaderMetrics = data.ReadUnsignedShort();
-
-            return new HorizontalHeaderTable(header, majorVersion, minorVersion, ascender,
-                descender, lineGap, advancedWidthMax,
-                minLeftSideBearing,
-                minRightSideBearing,
-                xMaxExtent,
-                caretSlopeRise,
-                caretSlopeRun,
-                caretOffset,
-                metricDataFormat,
-                numberOfHeaderMetrics);
-
-        }
-    }
 
     internal class NameTableParser : ITrueTypeTableParser<NameTable>
     {

--- a/src/UglyToad.PdfPig/Fonts/TrueType/Parser/TrueTypeFontParser.cs
+++ b/src/UglyToad.PdfPig/Fonts/TrueType/Parser/TrueTypeFontParser.cs
@@ -10,14 +10,14 @@
     {
         public TrueTypeFontProgram Parse(TrueTypeDataBytes data)
         {
-            var version = (decimal)data.Read32Fixed();
+            var version = data.Read32Fixed();
             int numberOfTables = data.ReadUnsignedShort();
 
             // Read these data points to move to the correct data location.
             // ReSharper disable UnusedVariable
-            int searchRange = data.ReadUnsignedShort();
-            int entrySelector = data.ReadUnsignedShort();
-            int rangeShift = data.ReadUnsignedShort();
+            var searchRange = data.ReadUnsignedShort();
+            var entrySelector = data.ReadUnsignedShort();
+            var rangeShift = data.ReadUnsignedShort();
             // ReSharper restore UnusedVariable
 
             var tables = new Dictionary<string, TrueTypeHeaderTable>(StringComparer.OrdinalIgnoreCase);
@@ -54,7 +54,7 @@
             return new TrueTypeHeaderTable(tag, checksum, offset, length);
         }
 
-        private static TrueTypeFontProgram ParseTables(decimal version, IReadOnlyDictionary<string, TrueTypeHeaderTable> tables, TrueTypeDataBytes data)
+        private static TrueTypeFontProgram ParseTables(float version, IReadOnlyDictionary<string, TrueTypeHeaderTable> tables, TrueTypeDataBytes data)
         {
             var isPostScript = tables.ContainsKey(TrueTypeHeaderTable.Cff);
 

--- a/src/UglyToad.PdfPig/Fonts/TrueType/Tables/GlyphDataTable.cs
+++ b/src/UglyToad.PdfPig/Fonts/TrueType/Tables/GlyphDataTable.cs
@@ -163,10 +163,10 @@
                     arg2 = data.ReadByte();
                 }
 
-                decimal xscale = 1;
-                decimal scale01 = 0;
-                decimal scale10 = 0;
-                decimal yscale = 1;
+                double xscale = 1;
+                double scale01 = 0;
+                double scale10 = 0;
+                double yscale = 1;
 
                 if (HasFlag(flags, CompositeGlyphFlags.WeHaveAScale))
                 {
@@ -276,9 +276,9 @@
             return xs;
         }
 
-        private static decimal ReadTwoFourteenFormat(TrueTypeDataBytes data)
+        private static double ReadTwoFourteenFormat(TrueTypeDataBytes data)
         {
-            const decimal divisor = 1 << 14;
+            const double divisor = 1 << 14;
 
             return data.ReadSignedShort() / divisor;
         }

--- a/src/UglyToad.PdfPig/Fonts/TrueType/Tables/GlyphDataTable.cs
+++ b/src/UglyToad.PdfPig/Fonts/TrueType/Tables/GlyphDataTable.cs
@@ -246,19 +246,25 @@
 
         private static short[] ReadCoordinates(TrueTypeDataBytes data, int pointCount, SimpleGlyphFlags[] flags, SimpleGlyphFlags isByte, SimpleGlyphFlags signOrSame)
         {
+            bool HasFlag(SimpleGlyphFlags value, SimpleGlyphFlags target)
+            {
+                return (value & target) == target;
+            }
+
             var xs = new short[pointCount];
             var x = 0;
             for (var i = 0; i < pointCount; i++)
             {
+                var flag = flags[i];
                 int dx;
-                if (flags[i].HasFlag(isByte))
+                if (HasFlag(flag, isByte))
                 {
                     var b = data.ReadByte();
-                    dx = flags[i].HasFlag(signOrSame) ? b : -b;
+                    dx = HasFlag(flag, signOrSame) ? b : -b;
                 }
                 else
                 {
-                    if (flags[i].HasFlag(signOrSame))
+                    if (HasFlag(flag, signOrSame))
                     {
                         dx = 0;
                     }
@@ -294,7 +300,7 @@
             /// </summary>
             public long Position { get; }
             
-            public PdfRectangle Bounds { get; set; }
+            public PdfRectangle Bounds { get; }
             
             public TemporaryCompositeLocation(long position, PdfRectangle bounds, short contourCount)
             {

--- a/src/UglyToad.PdfPig/Fonts/TrueType/Tables/HeaderTable.cs
+++ b/src/UglyToad.PdfPig/Fonts/TrueType/Tables/HeaderTable.cs
@@ -14,17 +14,17 @@
         
         public TrueTypeHeaderTable DirectoryTable { get; }
 
-        public decimal Version { get; }
+        public float Version { get; }
 
-        public decimal Revision { get; }
+        public float Revision { get; }
 
         public long CheckSumAdjustment { get; }
 
         public long MagicNumber { get; }
 
-        public int Flags { get; }
+        public ushort Flags { get; }
 
-        public int UnitsPerEm { get; }
+        public ushort UnitsPerEm { get; }
 
         public DateTime Created { get; }
 
@@ -37,7 +37,7 @@
         /// <summary>
         /// Smallest readable size in pixels.
         /// </summary>
-        public int LowestRecommendedPpem { get; }
+        public ushort LowestRecommendedPpem { get; }
 
         public FontDirection FontDirectionHint { get; }
 
@@ -51,13 +51,13 @@
         /// </summary>
         public short GlyphDataFormat { get; }
 
-        public HeaderTable(TrueTypeHeaderTable directoryTable, decimal version, decimal revision, long checkSumAdjustment, 
-            long magicNumber, int flags, int unitsPerEm, 
+        public HeaderTable(TrueTypeHeaderTable directoryTable, float version, float revision, long checkSumAdjustment, 
+            long magicNumber, ushort flags, ushort unitsPerEm, 
             DateTime created, DateTime modified, 
             short xMin, short yMin, 
             short xMax, short yMax, 
-            int macStyle, 
-            int lowestRecommendedPpem, 
+            ushort macStyle, 
+            ushort lowestRecommendedPpem, 
             short fontDirectionHint, 
             short indexToLocFormat, 
             short glyphDataFormat)
@@ -130,7 +130,7 @@
             var indexToLocFormat = data.ReadSignedShort();
             var glyphDataFormat = data.ReadSignedShort();
 
-            return new HeaderTable(table, (decimal)version, (decimal)fontRevision, checkSumAdjustment,
+            return new HeaderTable(table, version, fontRevision, checkSumAdjustment,
                 magicNumber, flags, unitsPerEm, created, modified,
                 xMin, yMin, xMax, yMax, macStyle, lowestRecPpem,
                 fontDirectionHint, indexToLocFormat, glyphDataFormat);

--- a/src/UglyToad.PdfPig/Fonts/TrueType/Tables/HorizontalHeaderTable.cs
+++ b/src/UglyToad.PdfPig/Fonts/TrueType/Tables/HorizontalHeaderTable.cs
@@ -1,7 +1,5 @@
 ﻿namespace UglyToad.PdfPig.Fonts.TrueType.Tables
 {
-    using System;
-
     /// <summary>
     /// The 'hhea' table contains information needed to layout fonts whose characters are written horizontally, that is, either left to right or right to left. 
     /// This table contains information that is general to the font as a whole.
@@ -25,12 +23,12 @@
         /// <summary>
         /// Distance from baseline to highest ascender.
         /// </summary>
-        public short Ascender { get; }
+        public short Ascent { get; }
 
         /// <summary>
         /// Distance from baseline to lower descender.
         /// </summary>
-        public short Descender { get; }
+        public short Descent { get; }
 
         /// <summary>
         /// The typographic line gap.
@@ -40,7 +38,7 @@
         /// <summary>
         /// The maximum advance width value as given by the Horizontal Metrics table.
         /// </summary>
-        public int AdvanceWidthMaximum { get; }
+        public ushort AdvanceWidthMaximum { get; }
 
         /// <summary>
         /// The minimum left side bearing as given by the Horizontal Metrics table.
@@ -80,15 +78,20 @@
         /// <summary>
         /// Number of horizontal metrics in the Horizontal Metrics table.
         /// </summary>
-        public int NumberOfHeaderMetrics { get; }
+        public ushort NumberOfHeaderMetrics { get; }
 
-        public HorizontalHeaderTable(TrueTypeHeaderTable directoryTable, int majorVersion, int minorVersion, short ascender, short descender, short lineGap, int advanceWidthMaximum, short minimumLeftSideBearing, short minimumRightSideBearing, short xMaxExtent, short caretSlopeRise, short caretSlopeRun, short caretOffset, short metricDataFormat, int numberOfHeaderMetrics)
+        public HorizontalHeaderTable(TrueTypeHeaderTable directoryTable, int majorVersion, int minorVersion, short ascent, short descent, 
+            short lineGap, ushort advanceWidthMaximum, 
+            short minimumLeftSideBearing, short minimumRightSideBearing,
+            short xMaxExtent, short caretSlopeRise, 
+            short caretSlopeRun, short caretOffset, 
+            short metricDataFormat, ushort numberOfHeaderMetrics)
         {
             DirectoryTable = directoryTable;
             MajorVersion = majorVersion;
             MinorVersion = minorVersion;
-            Ascender = ascender;
-            Descender = descender;
+            Ascent = ascent;
+            Descent = descent;
             LineGap = lineGap;
             AdvanceWidthMaximum = advanceWidthMaximum;
             MinimumLeftSideBearing = minimumLeftSideBearing;

--- a/src/UglyToad.PdfPig/Fonts/TrueType/Tables/HorizontalMetricsTable.cs
+++ b/src/UglyToad.PdfPig/Fonts/TrueType/Tables/HorizontalMetricsTable.cs
@@ -1,42 +1,66 @@
 ﻿namespace UglyToad.PdfPig.Fonts.TrueType.Tables
 {
     using System.Collections.Generic;
-    using Parser;
 
     /// <summary>
     /// The 'hmtx' table contains metric information for the horizontal layout each of the glyphs in the font.
     /// </summary>
     internal class HorizontalMetricsTable : ITable
     {
-        private readonly short[] leftSideBearings;
-
-        private readonly int metricCount;
-
         public string Tag => TrueTypeHeaderTable.Hmtx;
 
         public TrueTypeHeaderTable DirectoryTable { get; }
 
-        public IReadOnlyList<int> AdvancedWidths { get; }
+        public IReadOnlyList<HorizontalMetric> HorizontalMetrics { get; }
 
-        public HorizontalMetricsTable(TrueTypeHeaderTable directoryTable, int[] advancedWidths, short[] leftSideBearings, int metricCount)
+        /// <summary>
+        /// Some fonts may have an array of left side bearings following the <see cref="HorizontalMetrics"/>. 
+        /// Generally, this array of left side bearings is used for a run of monospaced glyphs. 
+        /// For example, it might be used for a Kanji font or for Courier. 
+        /// The corresponding glyphs are assumed to have the same advance width as that found in the last entry in the <see cref="HorizontalMetrics"/>.
+        /// </summary>
+        public IReadOnlyList<short> AdditionalLeftSideBearings { get; }
+
+        public HorizontalMetricsTable(TrueTypeHeaderTable directoryTable, 
+            IReadOnlyList<HorizontalMetric> horizontalMetrics,
+            IReadOnlyList<short> additionalLeftSideBearings)
         {
-            AdvancedWidths = advancedWidths;
-            this.leftSideBearings = leftSideBearings;
-            this.metricCount = metricCount;
-
             DirectoryTable = directoryTable;
+            HorizontalMetrics = horizontalMetrics;
+            AdditionalLeftSideBearings = additionalLeftSideBearings;
         }
 
-        public int GetAdvanceWidth(int index)
+        public ushort GetAdvanceWidth(int index)
         {
-            if (index < metricCount)
+            if (index < HorizontalMetrics.Count)
             {
-                return AdvancedWidths[index];
+                return HorizontalMetrics[index].AdvanceWidth;
             }
 
-            // monospaced fonts may not have a width for every glyph
-            // the last one is for subsequent glyphs
-            return AdvancedWidths[AdvancedWidths.Count - 1];
+            // Monospaced fonts may not have a width for every glyph, the last metric is for subsequent glyphs.
+            return HorizontalMetrics[HorizontalMetrics.Count - 1].AdvanceWidth;
+        }
+
+        /// <summary>
+        /// The pair of horizontal metrics for an individual glyph.
+        /// </summary>
+        public struct HorizontalMetric
+        {
+            /// <summary>
+            /// The advance width.
+            /// </summary>
+            public ushort AdvanceWidth { get; }
+
+            /// <summary>
+            /// The left side bearing.
+            /// </summary>
+            public short LeftSideBearing { get; }
+            
+            internal HorizontalMetric(ushort advanceWidth, short leftSideBearing)
+            {
+                AdvanceWidth = advanceWidth;
+                LeftSideBearing = leftSideBearing;
+            }
         }
     }
 }

--- a/src/UglyToad.PdfPig/Fonts/TrueType/Tables/PostScriptTable.cs
+++ b/src/UglyToad.PdfPig/Fonts/TrueType/Tables/PostScriptTable.cs
@@ -179,7 +179,7 @@
 
                 for (var i = 0; i < namesLength; i++)
                 {
-                    var numberOfCharacters = data.ReadUnsignedByte();
+                    var numberOfCharacters = data.ReadByte();
                     nameArray[i] = data.ReadString(numberOfCharacters, Encoding.UTF8);
                 }
             }

--- a/src/UglyToad.PdfPig/Fonts/TrueType/TrueTypeDataBytes.cs
+++ b/src/UglyToad.PdfPig/Fonts/TrueType/TrueTypeDataBytes.cs
@@ -38,15 +38,7 @@
 
             return (ushort)((internalBuffer[0] << 8) + (internalBuffer[1] << 0));
         }
-
-        public int ReadUnsignedByte()
-        {
-            ReadBuffered(internalBuffer, 1);
-
-            // TODO: the cast from int -> byte -> int here suggest we are treating data incorrectly.
-            return internalBuffer[0];
-        }
-
+        
         private void ReadBuffered(byte[] buffer, int length)
         {
             var numberRead = 0;

--- a/src/UglyToad.PdfPig/Fonts/TrueType/TrueTypeFontProgram.cs
+++ b/src/UglyToad.PdfPig/Fonts/TrueType/TrueTypeFontProgram.cs
@@ -10,7 +10,7 @@
 
     internal class TrueTypeFontProgram : ICidFontProgram
     {
-        public decimal Version { get; }
+        public float Version { get; }
 
         public IReadOnlyDictionary<string, TrueTypeHeaderTable> TableHeaders { get; }
 
@@ -26,7 +26,7 @@
 
         public ICMapSubTable WindowsSymbolCMap { get; }
 
-        public TrueTypeFontProgram(decimal version, IReadOnlyDictionary<string, TrueTypeHeaderTable> tableHeaders, TableRegister tableRegister)
+        public TrueTypeFontProgram(float version, IReadOnlyDictionary<string, TrueTypeHeaderTable> tableHeaders, TableRegister tableRegister)
         {
             Version = version;
             TableHeaders = tableHeaders;

--- a/src/UglyToad.PdfPig/Fonts/TrueType/TrueTypeFontProgram.cs
+++ b/src/UglyToad.PdfPig/Fonts/TrueType/TrueTypeFontProgram.cs
@@ -60,7 +60,6 @@
                     }
                 }
             }
-
         }
 
         public bool TryGetBoundingBox(int characterIdentifier, out PdfRectangle boundingBox) => TryGetBoundingBox(characterIdentifier, null, out boundingBox);
@@ -93,10 +92,10 @@
             return true;
         }
 
-        public bool TryGetBoundingAdvancedWidth(int characterIdentifier, out decimal width) => TryGetBoundingAdvancedWidth(characterIdentifier, null, out width);
-        public bool TryGetBoundingAdvancedWidth(int characterIdentifier, Func<int, int?> characterCodeToGlyphId, out decimal width)
+        public bool TryGetBoundingAdvancedWidth(int characterIdentifier, out double width) => TryGetBoundingAdvancedWidth(characterIdentifier, null, out width);
+        public bool TryGetBoundingAdvancedWidth(int characterIdentifier, Func<int, int?> characterCodeToGlyphId, out double width)
         {
-            width = 0m;
+            width = 0.0;
 
             if (!TryGetGlyphIndex(characterIdentifier, characterCodeToGlyphId, out var index))
             {
@@ -111,7 +110,7 @@
             return TableRegister.HeaderTable.UnitsPerEm;
         }
 
-        private bool TryGetBoundingAdvancedWidthByIndex(int index, out decimal width)
+        private bool TryGetBoundingAdvancedWidthByIndex(int index, out double width)
         {
             width = 0;
 

--- a/src/UglyToad.PdfPig/Fonts/Type1/CharStrings/Commands/Arithmetic/CallOtherSubrCommand.cs
+++ b/src/UglyToad.PdfPig/Fonts/Type1/CharStrings/Commands/Arithmetic/CallOtherSubrCommand.cs
@@ -32,7 +32,7 @@
             
             // What it should do
             var numberOfArguments = (int)context.Stack.PopTop();
-            var otherSubroutineArguments = new List<decimal>(numberOfArguments);
+            var otherSubroutineArguments = new List<double>(numberOfArguments);
             for (int j = 0; j < numberOfArguments; j++)
             {
                 otherSubroutineArguments.Add(context.Stack.PopTop());

--- a/src/UglyToad.PdfPig/Fonts/Type1/CharStrings/Commands/Type1BuildCharContext.cs
+++ b/src/UglyToad.PdfPig/Fonts/Type1/CharStrings/Commands/Type1BuildCharContext.cs
@@ -11,13 +11,13 @@
         private readonly Func<string, PdfPath> characterByNameFactory;
         public IReadOnlyDictionary<int, Type1CharStrings.CommandSequence> Subroutines { get; }
 
-        public decimal WidthX { get; set; }
+        public double WidthX { get; set; }
 
-        public decimal WidthY { get; set; }
+        public double WidthY { get; set; }
 
-        public decimal LeftSideBearingX { get; set; }
+        public double LeftSideBearingX { get; set; }
 
-        public decimal LeftSideBearingY { get; set; }
+        public double LeftSideBearingY { get; set; }
 
         public bool IsFlexing { get; set; }
 

--- a/src/UglyToad.PdfPig/Fonts/Type1/CharStrings/Type1CharStringParser.cs
+++ b/src/UglyToad.PdfPig/Fonts/Type1/CharStrings/Type1CharStringParser.cs
@@ -69,9 +69,9 @@
             return new Type1CharStrings(charStringResults, charStringIndexToName, subroutineResults);
         }
 
-        private static IReadOnlyList<Union<decimal, LazyType1Command>> ParseSingle(IReadOnlyList<byte> charStringBytes)
+        private static IReadOnlyList<Union<double, LazyType1Command>> ParseSingle(IReadOnlyList<byte> charStringBytes)
         {
-            var interpreted = new List<Union<decimal, LazyType1Command>>();
+            var interpreted = new List<Union<double, LazyType1Command>>();
 
             for (var i = 0; i < charStringBytes.Count; i++)
             {
@@ -87,13 +87,13 @@
                         continue;
                     }
 
-                    interpreted.Add(new Union<decimal, LazyType1Command>.Case2(command));
+                    interpreted.Add(new Union<double, LazyType1Command>.Case2(command));
                 }
                 else
                 {
                     var val = InterpretNumber(b, charStringBytes, ref i);
 
-                    interpreted.Add(new Union<decimal, LazyType1Command>.Case1(val));
+                    interpreted.Add(new Union<double, LazyType1Command>.Case1(val));
                 }
             }
 

--- a/src/UglyToad.PdfPig/Fonts/Type1/CharStrings/Type1CharStrings.cs
+++ b/src/UglyToad.PdfPig/Fonts/Type1/CharStrings/Type1CharStrings.cs
@@ -105,9 +105,9 @@
             /// <summary>
             /// The ordered list of numbers and commands for a Type 1 charstring or subroutine.
             /// </summary>
-            public IReadOnlyList<Union<decimal, LazyType1Command>> Commands { get; }
+            public IReadOnlyList<Union<double, LazyType1Command>> Commands { get; }
 
-            public CommandSequence(IReadOnlyList<Union<decimal, LazyType1Command>> commands)
+            public CommandSequence(IReadOnlyList<Union<double, LazyType1Command>> commands)
             {
                 Commands = commands ?? throw new ArgumentNullException(nameof(commands));
             }

--- a/src/UglyToad.PdfPig/Fonts/Type1/Parser/Type1FontParser.cs
+++ b/src/UglyToad.PdfPig/Fonts/Type1/Parser/Type1FontParser.cs
@@ -413,7 +413,7 @@
                     var x2 = (NumericToken)array.Data[2];
                     var y2 = (NumericToken)array.Data[3];
 
-                    return new PdfRectangle(x1.Data, y1.Data, x2.Data, y2.Data);
+                    return new PdfRectangle(x1.Double, y1.Double, x2.Double, y2.Double);
                 }
             }
 

--- a/src/UglyToad.PdfPig/Fonts/Type1/Type1FontProgram.cs
+++ b/src/UglyToad.PdfPig/Fonts/Type1/Type1FontProgram.cs
@@ -80,15 +80,15 @@
         {
             if (FontMatrix == null || FontMatrix.Data.Count != 6)
             {
-                return TransformationMatrix.FromValues(0.001m, 0, 0, 0.001m, 0, 0);
+                return TransformationMatrix.FromValues(0.001, 0, 0, 0.001, 0, 0);
             }
 
-            var a = ((NumericToken) FontMatrix.Data[0]).Data;
-            var b = ((NumericToken) FontMatrix.Data[1]).Data;
-            var c = ((NumericToken) FontMatrix.Data[2]).Data;
-            var d = ((NumericToken) FontMatrix.Data[3]).Data;
-            var e = ((NumericToken) FontMatrix.Data[4]).Data;
-            var f = ((NumericToken) FontMatrix.Data[5]).Data;
+            var a = ((NumericToken) FontMatrix.Data[0]).Double;
+            var b = ((NumericToken) FontMatrix.Data[1]).Double;
+            var c = ((NumericToken) FontMatrix.Data[2]).Double;
+            var d = ((NumericToken) FontMatrix.Data[3]).Double;
+            var e = ((NumericToken) FontMatrix.Data[4]).Double;
+            var f = ((NumericToken) FontMatrix.Data[5]).Double;
 
             return TransformationMatrix.FromValues(a, b, c, d, e, f);
         }

--- a/src/UglyToad.PdfPig/Geometry/GeometryExtensions.cs
+++ b/src/UglyToad.PdfPig/Geometry/GeometryExtensions.cs
@@ -265,12 +265,12 @@ namespace UglyToad.PdfPig.Geometry
         /// </summary>
         /// <param name="bezierCurve">The original bezier curve.</param>
         /// <param name="tau">The t value were to split the curve, usually between 0 and 1, but not necessary.</param>
-        private static (BezierCurve, BezierCurve) Split(this BezierCurve bezierCurve, decimal tau)
+        private static (BezierCurve, BezierCurve) Split(this BezierCurve bezierCurve, double tau)
         {
             // De Casteljau Algorithm
             PdfPoint[][] points = new PdfPoint[4][];
 
-            points[0] = new PdfPoint[]
+            points[0] = new []
             {
                 bezierCurve.StartPoint,
                 bezierCurve.FirstControlPoint,
@@ -302,21 +302,21 @@ namespace UglyToad.PdfPig.Geometry
         public static PdfPoint[] Intersect(this BezierCurve bezierCurve, PdfLine line)
         {
             var ts = FindIntersectionT(bezierCurve, line);
-            if (ts.Count() == 0) return null;
+            if (!ts.Any()) return null;
 
             List<PdfPoint> points = new List<PdfPoint>();
             foreach (var t in ts)
             {
                 PdfPoint point = new PdfPoint(
-                    BezierCurve.ValueWithT((double)bezierCurve.StartPoint.X,
-                                           (double)bezierCurve.FirstControlPoint.X,
-                                           (double)bezierCurve.SecondControlPoint.X,
-                                           (double)bezierCurve.EndPoint.X,
+                    BezierCurve.ValueWithT(bezierCurve.StartPoint.X,
+                                           bezierCurve.FirstControlPoint.X,
+                                           bezierCurve.SecondControlPoint.X,
+                                           bezierCurve.EndPoint.X,
                                            t),
-                    BezierCurve.ValueWithT((double)bezierCurve.StartPoint.Y,
-                                           (double)bezierCurve.FirstControlPoint.Y,
-                                           (double)bezierCurve.SecondControlPoint.Y,
-                                           (double)bezierCurve.EndPoint.Y,
+                    BezierCurve.ValueWithT(bezierCurve.StartPoint.Y,
+                                           bezierCurve.FirstControlPoint.Y,
+                                           bezierCurve.SecondControlPoint.Y,
+                                           bezierCurve.EndPoint.Y,
                                            t));
                 points.Add(point);
             }

--- a/src/UglyToad.PdfPig/Geometry/PdfLine.cs
+++ b/src/UglyToad.PdfPig/Geometry/PdfLine.cs
@@ -15,13 +15,13 @@ namespace UglyToad.PdfPig.Geometry
         /// <summary>
         /// Length of the line.
         /// </summary>
-        public decimal Length
+        public double Length
         {
             get
             {
                 var l = (Point1.X - Point2.X) * (Point1.X - Point2.X) + 
                     (Point1.Y - Point2.Y) * (Point1.Y - Point2.Y);
-                return (decimal)System.Math.Sqrt((double)l);
+                return Math.Sqrt(l);
             }
         }
 
@@ -42,7 +42,7 @@ namespace UglyToad.PdfPig.Geometry
         /// <param name="y1">The y coordinate of the first point on the line.</param>
         /// <param name="x2">The x coordinate of the second point on the line.</param>
         /// <param name="y2">The y coordinate of the second point on the line.</param>
-        public PdfLine(decimal x1, decimal y1, decimal x2, decimal y2) : this(new PdfPoint(x1, y1), new PdfPoint(x2, y2)) { }
+        public PdfLine(double x1, double y1, double x2, double y2) : this(new PdfPoint(x1, y1), new PdfPoint(x2, y2)) { }
 
         /// <summary>
         /// Create a new <see cref="PdfLine"/>.

--- a/src/UglyToad.PdfPig/Geometry/PdfMatrix3By2.cs
+++ b/src/UglyToad.PdfPig/Geometry/PdfMatrix3By2.cs
@@ -2,14 +2,14 @@
 {
     internal struct PdfMatrix3By2
     {
-        private readonly decimal r0c0;
-        private readonly decimal r0c1;
-        private readonly decimal r1c0;
-        private readonly decimal r1c1;
-        private readonly decimal r2c0;
-        private readonly decimal r2c1;
+        private readonly double r0c0;
+        private readonly double r0c1;
+        private readonly double r1c0;
+        private readonly double r1c1;
+        private readonly double r2c0;
+        private readonly double r2c1;
 
-        public PdfMatrix3By2(decimal r0C0, decimal r0C1, decimal r1C0, decimal r1C1, decimal r2C0, decimal r2C1)
+        public PdfMatrix3By2(double r0C0, double r0C1, double r1C0, double r1C1, double r2C0, double r2C1)
         {
             r0c0 = r0C0;
             r0c1 = r0C1;
@@ -21,9 +21,9 @@
 
         public static PdfMatrix3By2 Identity { get; } = new PdfMatrix3By2(1, 0, 0, 1, 0, 0);
         public static PdfMatrix3By2 CreateTranslation(PdfVector vector) => new PdfMatrix3By2(1, 0, 0, 1, vector.X, vector.Y);
-        public static PdfMatrix3By2 CreateTranslation(decimal x, decimal y) => new PdfMatrix3By2(1, 0, 0, 1, x, y);
+        public static PdfMatrix3By2 CreateTranslation(double x, double y) => new PdfMatrix3By2(1, 0, 0, 1, x, y);
 
-        public PdfMatrix3By2 WithTranslation(decimal x, decimal y)
+        public PdfMatrix3By2 WithTranslation(double x, double y)
         {
             return new PdfMatrix3By2(r0c0, r0c1, r1c0, r1c1, x, y);
         }

--- a/src/UglyToad.PdfPig/Geometry/PdfPoint.cs
+++ b/src/UglyToad.PdfPig/Geometry/PdfPoint.cs
@@ -20,12 +20,12 @@
         /// <summary>
         /// The X coordinate for this point. (Horizontal axis).
         /// </summary>
-        public decimal X { get; }
+        public double X { get; }
 
         /// <summary>
         /// The Y coordinate of this point. (Vertical axis).
         /// </summary>
-        public decimal Y { get; }
+        public double Y { get; }
 
         /// <summary>
         /// Create a new <see cref="PdfPoint"/> at this position.
@@ -33,8 +33,8 @@
         [DebuggerStepThrough]
         public PdfPoint(decimal x, decimal y)
         {
-            X = x;
-            Y = y;
+            X = (double)x;
+            Y = (double)y;
         }
 
         /// <summary>
@@ -53,8 +53,8 @@
         [DebuggerStepThrough]
         public PdfPoint(double x, double y)
         {
-            X = (decimal)x;
-            Y = (decimal)y;
+            X = x;
+            Y = y;
         }
 
         /// <summary>
@@ -62,7 +62,7 @@
         /// </summary>
         /// <param name="dx">The distance to move the point in the x direction relative to its current location.</param>
         /// <returns>A new point shifted on the x axis by the given delta value.</returns>
-        public PdfPoint MoveX(decimal dx)
+        public PdfPoint MoveX(double dx)
         {
             return new PdfPoint(X + dx, Y);
         }
@@ -72,7 +72,7 @@
         /// </summary>
         /// <param name="dy">The distance to move the point in the y direction relative to its current location.</param>
         /// <returns>A new point shifted on the y axis by the given delta value.</returns>
-        public PdfPoint MoveY(decimal dy)
+        public PdfPoint MoveY(double dy)
         {
             return new PdfPoint(X, Y + dy);
         }
@@ -83,7 +83,7 @@
         /// <param name="dx">The distance to move the point in the x direction relative to its current location.</param>
         /// <param name="dy">The distance to move the point in the y direction relative to its current location.</param>
         /// <returns>A new point shifted on the y axis by the given delta value.</returns>
-        public PdfPoint Translate(decimal dx, decimal dy)
+        public PdfPoint Translate(double dx, double dy)
         {
             return new PdfPoint(X + dx, Y + dy);
         }

--- a/src/UglyToad.PdfPig/Geometry/PdfRectangle.cs
+++ b/src/UglyToad.PdfPig/Geometry/PdfRectangle.cs
@@ -38,48 +38,48 @@
         /// <summary>
         /// Width of the rectangle.
         /// </summary>
-        public decimal Width => Right - Left;
+        public double Width => Right - Left;
 
         /// <summary>
         /// Height of the rectangle.
         /// </summary>
-        public decimal Height => Top - Bottom;
+        public double Height => Top - Bottom;
 
         /// <summary>
         /// Area of the rectangle.
         /// </summary>
-        public decimal Area => Width * Height;
+        public double Area => Width * Height;
 
         /// <summary>
         /// Left.
         /// </summary>
-        public decimal Left => TopLeft.X;
+        public double Left => TopLeft.X;
 
         /// <summary>
         /// Top.
         /// </summary>
-        public decimal Top => TopLeft.Y;
+        public double Top => TopLeft.Y;
 
         /// <summary>
         /// Right.
         /// </summary>
-        public decimal Right => BottomRight.X;
+        public double Right => BottomRight.X;
 
         /// <summary>
         /// Bottom.
         /// </summary>
-        public decimal Bottom => BottomRight.Y;
+        public double Bottom => BottomRight.Y;
 
         internal PdfRectangle(PdfPoint point1, PdfPoint point2) : this(point1.X, point1.Y, point2.X, point2.Y) { }
-        internal PdfRectangle(short x1, short y1, short x2, short y2) : this((decimal)x1, y1, x2, y2) { }
+        internal PdfRectangle(short x1, short y1, short x2, short y2) : this((double)x1, y1, x2, y2) { }
 
         /// <summary>
         /// Create a new <see cref="PdfRectangle"/>.
         /// </summary>
-        public PdfRectangle(decimal x1, decimal y1, decimal x2, decimal y2)
+        public PdfRectangle(double x1, double y1, double x2, double y2)
         {
-            decimal bottom;
-            decimal top;
+            double bottom;
+            double top;
 
             if (y1 <= y2)
             {
@@ -92,8 +92,8 @@
                 top = y1;
             }
 
-            decimal left;
-            decimal right;
+            double left;
+            double right;
             if (x1 <= x2)
             {
                 left = x1;
@@ -132,7 +132,7 @@
         /// <param name="dx">The distance to move the rectangle in the x direction relative to its current location.</param>
         /// <param name="dy">The distance to move the rectangle in the y direction relative to its current location.</param>
         /// <returns>A new rectangle shifted on the y axis by the given delta value.</returns>
-        public PdfRectangle Translate(decimal dx, decimal dy)
+        public PdfRectangle Translate(double dx, double dy)
         {
             return new PdfRectangle(BottomLeft.Translate(dx, dy), TopRight.Translate(dx, dy));
         }

--- a/src/UglyToad.PdfPig/Geometry/PdfVector.cs
+++ b/src/UglyToad.PdfPig/Geometry/PdfVector.cs
@@ -4,27 +4,27 @@ namespace UglyToad.PdfPig.Geometry
 {
     internal struct PdfVector
     {
-        public decimal X { get; }
+        public double X { get; }
 
-        public decimal Y { get; }
+        public double Y { get; }
 
-        public PdfVector(decimal x, decimal y)
+        public PdfVector(double x, double y)
         {
             X = x;
             Y = y;
         }
 
-        public PdfVector Scale(decimal scale)
+        public PdfVector Scale(double scale)
         {
             return new PdfVector(X * scale, Y * scale);
         }
 
-        public decimal GetMagnitude()
+        public double GetMagnitude()
         {
-            var doubleX = (double)X;
-            var doubleY = (double)Y;
+            var doubleX = X;
+            var doubleY = Y;
 
-            return (decimal)Math.Sqrt(doubleX * doubleX + doubleY * doubleY);
+            return Math.Sqrt(doubleX * doubleX + doubleY * doubleY);
         }
 
         public PdfVector Subtract(PdfVector vector)

--- a/src/UglyToad.PdfPig/Graphics/ContentStreamProcessor.cs
+++ b/src/UglyToad.PdfPig/Graphics/ContentStreamProcessor.cs
@@ -150,7 +150,7 @@
             }
 
             var fontSize = currentState.FontState.FontSize;
-            var horizontalScaling = currentState.FontState.HorizontalScaling / 100m;
+            var horizontalScaling = currentState.FontState.HorizontalScaling / 100.0;
             var characterSpacing = currentState.FontState.CharacterSpacing;
             var rise = currentState.FontState.Rise;
 
@@ -161,7 +161,7 @@
 
             // TODO: this does not seem correct, produces the correct result for now but we need to revisit.
             // see: https://stackoverflow.com/questions/48010235/pdf-specification-get-font-size-in-points
-            var pointSize = decimal.Round(rotation.Rotate(transformationMatrix).Multiply(TextMatrices.TextMatrix).Multiply(fontSize).A, 2);
+            var pointSize = Math.Round(rotation.Rotate(transformationMatrix).Multiply(TextMatrices.TextMatrix).Multiply(fontSize).A, 2);
 
             while (bytes.MoveNext())
             {
@@ -176,7 +176,7 @@
                     unicode = new string((char)code, 1);
                 }
 
-                var wordSpacing = 0m;
+                var wordSpacing = 0.0;
                 if (code == ' ' && codeLength == 1)
                 {
                     wordSpacing += GetCurrentState().FontState.WordSpacing;
@@ -228,7 +228,7 @@
 
                 letters.Add(letter);
 
-                decimal tx, ty;
+                double tx, ty;
                 if (font.IsVertical)
                 {
                     var verticalFont = (IVerticalWritingSupported)font;
@@ -255,7 +255,7 @@
             var textState = currentState.FontState;
 
             var fontSize = textState.FontSize;
-            var horizontalScaling = textState.HorizontalScaling / 100m;
+            var horizontalScaling = textState.HorizontalScaling / 100.0;
             var font = resourceStore.GetFont(textState.FontName);
 
             var isVertical = font.IsVertical;
@@ -264,9 +264,9 @@
             {
                 if (token is NumericToken number)
                 {
-                    var positionAdjustment = number.Data;
+                    var positionAdjustment = (double)number.Data;
 
-                    decimal tx, ty;
+                    double tx, ty;
                     if (isVertical)
                     {
                         tx = 0;
@@ -353,7 +353,7 @@
             var formMatrix = TransformationMatrix.Identity;
             if (formStream.StreamDictionary.TryGet<ArrayToken>(NameToken.Matrix, pdfScanner, out var formMatrixToken))
             {
-                formMatrix = TransformationMatrix.FromArray(formMatrixToken.Data.OfType<NumericToken>().Select(x => x.Data).ToArray());
+                formMatrix = TransformationMatrix.FromArray(formMatrixToken.Data.OfType<NumericToken>().Select(x => (double)x.Data).ToArray());
             }
 
             // 2. Update current transformation matrix.
@@ -449,7 +449,7 @@
                 && fontArray.Data[0] is IndirectReferenceToken fontReference && fontArray.Data[1] is NumericToken sizeToken)
             {
                 currentGraphicsState.FontState.FromExtendedGraphicsState = true;
-                currentGraphicsState.FontState.FontSize = sizeToken.Data;
+                currentGraphicsState.FontState.FontSize = (double)sizeToken.Data;
                 activeExtendedGraphicsStateFont = resourceStore.GetFontDirectly(fontReference, isLenientParsing);
             }
         }
@@ -500,7 +500,7 @@
             inlineImageBuilder = null;
         }
 
-        private void AdjustTextMatrix(decimal tx, decimal ty)
+        private void AdjustTextMatrix(double tx, double ty)
         {
             var matrix = TransformationMatrix.GetTranslationMatrix(tx, ty);
 

--- a/src/UglyToad.PdfPig/Graphics/CurrentFontState.cs
+++ b/src/UglyToad.PdfPig/Graphics/CurrentFontState.cs
@@ -24,7 +24,7 @@ namespace UglyToad.PdfPig.Graphics
         /// In horizontal writing mode a positive value will expand the distance between letters/glyphs.
         /// Default value 0.
         /// </remarks>
-        public decimal CharacterSpacing { get; set; } = 0;
+        public double CharacterSpacing { get; set; } = 0;
 
         /// <summary>
         /// As for <see cref="CharacterSpacing"/> but applies only for the space character (32).
@@ -32,18 +32,18 @@ namespace UglyToad.PdfPig.Graphics
         /// <remarks>
         /// Default value 0.
         /// </remarks>
-        public decimal WordSpacing { get; set; } = 0;
+        public double WordSpacing { get; set; } = 0;
 
         /// <summary>
         /// Adjusts the width of glyphs/letters by stretching (or compressing) them horizontally.
         /// Value is a percentage of the normal width.
         /// </summary>
-        public decimal HorizontalScaling { get; set; } = 100;
+        public double HorizontalScaling { get; set; } = 100;
 
         /// <summary>
         /// The vertical distance in unscaled text space units between the baselines of lines of text.
         /// </summary>
-        public decimal Leading { get; set; }
+        public double Leading { get; set; }
 
         /// <summary>
         /// The name of the currently active font.
@@ -53,7 +53,7 @@ namespace UglyToad.PdfPig.Graphics
         /// <summary>
         /// The current font size.
         /// </summary>
-        public decimal FontSize { get; set; }
+        public double FontSize { get; set; }
 
         /// <summary>
         /// The <see cref="TextRenderingMode"/> for glyph outlines.
@@ -71,7 +71,7 @@ namespace UglyToad.PdfPig.Graphics
         /// <remarks>
         /// Always applies to the vertical coordinate irrespective or writing mode.
         /// </remarks>
-        public decimal Rise { get; set; }
+        public double Rise { get; set; }
 
         /// <summary>
         /// Are all glyphs in a text object treated as a single elementary object for the purpose of the transparent imaging model?

--- a/src/UglyToad.PdfPig/Graphics/Operations/PathConstruction/AppendDualControlPointBezierCurve.cs
+++ b/src/UglyToad.PdfPig/Graphics/Operations/PathConstruction/AppendDualControlPointBezierCurve.cs
@@ -2,7 +2,7 @@
 {
     using System.IO;
     using Geometry;
-    
+
     /// <inheritdoc />
     /// <summary>
     /// Append a cubic Bezier curve to the current path. 
@@ -19,19 +19,34 @@
         public string Operator => Symbol;
 
         /// <summary>
-        /// The first control point.
+        /// First control point x.
         /// </summary>
-        public PdfPoint ControlPoint1 { get; }
+        public decimal X1 { get; }
 
         /// <summary>
-        /// The second control point.
+        /// First control point y.
         /// </summary>
-        public PdfPoint ControlPoint2 { get; }
+        public decimal Y1 { get; }
 
         /// <summary>
-        /// The end point.
+        /// Second control point x.
         /// </summary>
-        public PdfPoint End { get; }
+        public decimal X2 { get; }
+
+        /// <summary>
+        /// Second control point y.
+        /// </summary>
+        public decimal Y2 { get; }
+
+        /// <summary>
+        /// End point x.
+        /// </summary>
+        public decimal X3 { get; }
+
+        /// <summary>
+        /// End point y.
+        /// </summary>
+        public decimal Y3 { get; }
 
         /// <summary>
         /// Create a new <see cref="AppendDualControlPointBezierCurve"/>.
@@ -44,17 +59,25 @@
         /// <param name="y3">End point y coordinate.</param>
         public AppendDualControlPointBezierCurve(decimal x1, decimal y1, decimal x2, decimal y2, decimal x3, decimal y3)
         {
-            ControlPoint1 = new PdfPoint(x1, y1);
-            ControlPoint2 = new PdfPoint(x2, y2);
-            End = new PdfPoint(x3, y3);
+            X1 = x1;
+            Y1 = y1;
+            X2 = x2;
+            Y2 = y2;
+            X3 = x3;
+            Y3 = y3;
+
         }
 
         /// <inheritdoc />
         public void Run(IOperationContext operationContext)
         {
-            var controlPoint1Transform = operationContext.CurrentTransformationMatrix.Transform(ControlPoint1);
-            var controlPoint2Transform = operationContext.CurrentTransformationMatrix.Transform(ControlPoint2);
-            var endTransform = operationContext.CurrentTransformationMatrix.Transform(End);
+            var controlPoint1 = new PdfPoint(X1, Y1);
+            var controlPoint2 = new PdfPoint(X2, Y2);
+            var end = new PdfPoint(X3, Y3);
+
+            var controlPoint1Transform = operationContext.CurrentTransformationMatrix.Transform(controlPoint1);
+            var controlPoint2Transform = operationContext.CurrentTransformationMatrix.Transform(controlPoint2);
+            var endTransform = operationContext.CurrentTransformationMatrix.Transform(end);
             operationContext.CurrentPath.BezierCurveTo(controlPoint1Transform.X, controlPoint1Transform.Y,
                 controlPoint2Transform.X, controlPoint2Transform.Y,
                 endTransform.X, endTransform.Y);
@@ -64,17 +87,17 @@
         /// <inheritdoc />
         public void Write(Stream stream)
         {
-            stream.WriteDecimal(ControlPoint1.X);
+            stream.WriteDecimal(X1);
             stream.WriteWhiteSpace();
-            stream.WriteDecimal(ControlPoint1.Y);
+            stream.WriteDecimal(Y1);
             stream.WriteWhiteSpace();
-            stream.WriteDecimal(ControlPoint2.X);
+            stream.WriteDecimal(X2);
             stream.WriteWhiteSpace();
-            stream.WriteDecimal(ControlPoint2.Y);
+            stream.WriteDecimal(Y2);
             stream.WriteWhiteSpace();
-            stream.WriteDecimal(End.X);
+            stream.WriteDecimal(X3);
             stream.WriteWhiteSpace();
-            stream.WriteDecimal(End.Y);
+            stream.WriteDecimal(Y3);
             stream.WriteWhiteSpace();
             stream.WriteText(Symbol);
             stream.WriteNewLine();
@@ -83,7 +106,7 @@
         /// <inheritdoc />
         public override string ToString()
         {
-            return $"{ControlPoint1.X} {ControlPoint1.Y} {ControlPoint2.X} {ControlPoint2.Y} {End.X} {End.Y} {Symbol}";
+            return $"{X1} {Y1} {X2} {Y2} {X3} {Y3} {Symbol}";
         }
     }
 }

--- a/src/UglyToad.PdfPig/Graphics/Operations/PathConstruction/AppendEndControlPointBezierCurve.cs
+++ b/src/UglyToad.PdfPig/Graphics/Operations/PathConstruction/AppendEndControlPointBezierCurve.cs
@@ -10,6 +10,7 @@
     /// </summary>
     public class AppendEndControlPointBezierCurve : IGraphicsStateOperation
     {
+
         /// <summary>
         /// The symbol for this operation in a stream.
         /// </summary>
@@ -19,15 +20,25 @@
         public string Operator => Symbol;
 
         /// <summary>
-        /// The first control point.
+        /// The x coordinate of the first control point.
         /// </summary>
-        public PdfPoint ControlPoint1 { get; }
+        public decimal X1 { get; }
 
         /// <summary>
-        /// The end point and second control point.
+        /// The y coordinate of the first control point.
         /// </summary>
-        public PdfPoint End { get; }
+        public decimal Y1 { get; }
 
+        /// <summary>
+        /// The x coordinate of the end point.
+        /// </summary>
+        public decimal X3 { get; }
+
+        /// <summary>
+        /// The y coordinate of the end point.
+        /// </summary>
+        public decimal Y3 { get; }
+        
         /// <summary>
         /// Create a new <see cref="AppendEndControlPointBezierCurve"/>.
         /// </summary>
@@ -37,15 +48,19 @@
         /// <param name="y3">Control point 2/End y coordinate.</param>
         public AppendEndControlPointBezierCurve(decimal x1, decimal y1, decimal x3, decimal y3)
         {
-            ControlPoint1 = new PdfPoint(x1, y1);
-            End = new PdfPoint(x3, y3);
+            X1 = x1;
+            Y1 = y1;
+            X3 = x3;
+            Y3 = y3;
         }
-
+        
         /// <inheritdoc />
         public void Run(IOperationContext operationContext)
         {
-            var controlPoint1Transform = operationContext.CurrentTransformationMatrix.Transform(ControlPoint1);
-            var endTransform = operationContext.CurrentTransformationMatrix.Transform(End);
+            var controlPoint1 = new PdfPoint(X1, Y1);
+            var end = new PdfPoint(X3, Y3);
+            var controlPoint1Transform = operationContext.CurrentTransformationMatrix.Transform(controlPoint1);
+            var endTransform = operationContext.CurrentTransformationMatrix.Transform(end);
             operationContext.CurrentPath.BezierCurveTo(controlPoint1Transform.X, controlPoint1Transform.Y,
                 endTransform.X,
                 endTransform.Y,
@@ -57,13 +72,13 @@
         /// <inheritdoc />
         public void Write(Stream stream)
         {
-            stream.WriteDecimal(ControlPoint1.X);
+            stream.WriteDecimal(X1);
             stream.WriteWhiteSpace();
-            stream.WriteDecimal(ControlPoint1.Y);
+            stream.WriteDecimal(Y1);
             stream.WriteWhiteSpace();
-            stream.WriteDecimal(End.X);
+            stream.WriteDecimal(X3);
             stream.WriteWhiteSpace();
-            stream.WriteDecimal(End.Y);
+            stream.WriteDecimal(Y3);
             stream.WriteWhiteSpace();
             stream.WriteText(Symbol);
             stream.WriteNewLine();
@@ -72,7 +87,7 @@
         /// <inheritdoc />
         public override string ToString()
         {
-            return $"{ControlPoint1.X} {ControlPoint1.Y} {End.X} {End.Y} {Symbol}";
+            return $"{X1} {Y1} {X3} {Y3} {Symbol}";
         }
     }
 }

--- a/src/UglyToad.PdfPig/Graphics/Operations/PathConstruction/AppendRectangle.cs
+++ b/src/UglyToad.PdfPig/Graphics/Operations/PathConstruction/AppendRectangle.cs
@@ -18,9 +18,14 @@
         public string Operator => Symbol;
 
         /// <summary>
-        /// The lower left corner.
+        /// The x coordinate of the lower left corner.
         /// </summary>
-        public PdfPoint LowerLeft { get; }
+        public decimal LowerLeftX { get; }
+
+        /// <summary>
+        /// The y coordinate of the lower left corner.
+        /// </summary>
+        public decimal LowerLeftY { get; }
 
         /// <summary>
         /// The width of the rectangle.
@@ -41,7 +46,8 @@
         /// <param name="height">The height of the rectangle.</param>
         public AppendRectangle(decimal x, decimal y, decimal width, decimal height)
         {
-            LowerLeft = new PdfPoint(x, y);
+            LowerLeftX = x;
+            LowerLeftY = y;
 
             Width = width;
             Height = height;
@@ -50,17 +56,18 @@
         /// <inheritdoc />
         public void Run(IOperationContext operationContext)
         {
+            var lowerLeft = new PdfPoint(LowerLeftX, LowerLeftY);
             operationContext.BeginSubpath();
-            var lowerLeftTransform = operationContext.CurrentTransformationMatrix.Transform(LowerLeft);
-            operationContext.CurrentPath.Rectangle(lowerLeftTransform.X, lowerLeftTransform.Y, Width, Height);
+            var lowerLeftTransform = operationContext.CurrentTransformationMatrix.Transform(lowerLeft);
+            operationContext.CurrentPath.Rectangle(lowerLeftTransform.X, lowerLeftTransform.Y, (double)Width, (double)Height);
         }
 
         /// <inheritdoc />
         public void Write(Stream stream)
         {
-            stream.WriteDecimal(LowerLeft.X);
+            stream.WriteDecimal(LowerLeftX);
             stream.WriteWhiteSpace();
-            stream.WriteDecimal(LowerLeft.Y);
+            stream.WriteDecimal(LowerLeftY);
             stream.WriteWhiteSpace();
             stream.WriteDecimal(Width);
             stream.WriteWhiteSpace();
@@ -73,7 +80,7 @@
         /// <inheritdoc />
         public override string ToString()
         {
-            return $"{LowerLeft.X} {LowerLeft.Y} {Width} {Height} {Symbol}";
+            return $"{LowerLeftX} {LowerLeftY} {Width} {Height} {Symbol}";
         }
     }
 }

--- a/src/UglyToad.PdfPig/Graphics/Operations/PathConstruction/AppendStartControlPointBezierCurve.cs
+++ b/src/UglyToad.PdfPig/Graphics/Operations/PathConstruction/AppendStartControlPointBezierCurve.cs
@@ -17,16 +17,26 @@
 
         /// <inheritdoc />
         public string Operator => Symbol;
+        
+        /// <summary>
+        /// The x coordinate of the second control point.
+        /// </summary>
+        public decimal X2 { get; }
 
         /// <summary>
-        /// The second control point.
+        /// The y coordinate of the second control point.
         /// </summary>
-        public PdfPoint ControlPoint2 { get; }
+        public decimal Y2 { get; }
 
         /// <summary>
-        /// The last point on the curve.
+        /// The x coordinate of the end point of the curve.
         /// </summary>
-        public PdfPoint End { get; }
+        public decimal X3 { get; }
+
+        /// <summary>
+        /// The y coordinate of the end point of the curve.
+        /// </summary>
+        public decimal Y3 { get; }
 
         /// <summary>
         /// Create a new <see cref="AppendStartControlPointBezierCurve"/>.
@@ -37,15 +47,19 @@
         /// <param name="y3">The y coordinate of the end point.</param>
         public AppendStartControlPointBezierCurve(decimal x2, decimal y2, decimal x3, decimal y3)
         {
-            ControlPoint2 = new PdfPoint(x2, y2);
-            End = new PdfPoint(x3, y3);
+            X2 = x2;
+            Y2 = y2;
+            X3 = x3;
+            Y3 = y3;
         }
 
         /// <inheritdoc />
         public void Run(IOperationContext operationContext)
         {
-            var controlPoint2Transform = operationContext.CurrentTransformationMatrix.Transform(ControlPoint2);
-            var endTransform = operationContext.CurrentTransformationMatrix.Transform(End);
+            var controlPoint2 = new PdfPoint(X2, Y2);
+            var end = new PdfPoint(X3, Y3);
+            var controlPoint2Transform = operationContext.CurrentTransformationMatrix.Transform(controlPoint2);
+            var endTransform = operationContext.CurrentTransformationMatrix.Transform(end);
             operationContext.CurrentPath.BezierCurveTo(operationContext.CurrentPosition.X,
                 operationContext.CurrentPosition.Y,
                 controlPoint2Transform.X,
@@ -58,13 +72,13 @@
         /// <inheritdoc />
         public void Write(Stream stream)
         {
-            stream.WriteDecimal(ControlPoint2.X);
+            stream.WriteDecimal(X2);
             stream.WriteWhiteSpace();
-            stream.WriteDecimal(ControlPoint2.Y);
+            stream.WriteDecimal(Y2);
             stream.WriteWhiteSpace();
-            stream.WriteDecimal(End.X);
+            stream.WriteDecimal(X3);
             stream.WriteWhiteSpace();
-            stream.WriteDecimal(End.Y);
+            stream.WriteDecimal(Y3);
             stream.WriteWhiteSpace();
             stream.WriteText(Symbol);
             stream.WriteNewLine();
@@ -73,7 +87,7 @@
         /// <inheritdoc />
         public override string ToString()
         {
-            return $"{ControlPoint2.X} {ControlPoint2.Y} {End.X} {End.Y} {Symbol}";
+            return $"{X2} {Y2} {X3} {Y3} {Symbol}";
         }
     }
 }

--- a/src/UglyToad.PdfPig/Graphics/Operations/PathConstruction/AppendStraightLineSegment.cs
+++ b/src/UglyToad.PdfPig/Graphics/Operations/PathConstruction/AppendStraightLineSegment.cs
@@ -18,10 +18,15 @@
         public string Operator => Symbol;
 
         /// <summary>
-        /// The end point of the line.
+        /// The x coordinate of the end point of the line.
         /// </summary>
-        public PdfPoint End { get; }
+        public decimal X { get; }
 
+        /// <summary>
+        /// The y coordinate of the end point of the line.
+        /// </summary>
+        public decimal Y { get; }
+        
         /// <summary>
         /// Create a new <see cref="AppendStraightLineSegment"/>.
         /// </summary>
@@ -29,13 +34,14 @@
         /// <param name="y">The y coordinate of the line's end point.</param>
         public AppendStraightLineSegment(decimal x, decimal y)
         {
-            End = new PdfPoint(x, y);
+            X = x;
+            Y = y;
         }
 
         /// <inheritdoc />
         public void Run(IOperationContext operationContext)
         {
-            var endPoint = operationContext.CurrentTransformationMatrix.Transform(new PdfPoint(End.X, End.Y));
+            var endPoint = operationContext.CurrentTransformationMatrix.Transform(new PdfPoint(X, Y));
             operationContext.CurrentPath.LineTo(endPoint.X, endPoint.Y);
             operationContext.CurrentPosition = endPoint;
         }
@@ -43,9 +49,9 @@
         /// <inheritdoc />
         public void Write(Stream stream)
         {
-            stream.WriteDecimal(End.X);
+            stream.WriteDecimal(X);
             stream.WriteWhiteSpace();
-            stream.WriteDecimal(End.Y);
+            stream.WriteDecimal(Y);
             stream.WriteWhiteSpace();
             stream.WriteText(Symbol);
             stream.WriteWhiteSpace();
@@ -54,7 +60,7 @@
         /// <inheritdoc />
         public override string ToString()
         {
-            return $"{End.X} {End.Y} {Symbol}";
+            return $"{X} {Y} {Symbol}";
         }
     }
 }

--- a/src/UglyToad.PdfPig/Graphics/Operations/PathConstruction/BeginNewSubpath.cs
+++ b/src/UglyToad.PdfPig/Graphics/Operations/PathConstruction/BeginNewSubpath.cs
@@ -18,10 +18,15 @@
         public string Operator => Symbol;
 
         /// <summary>
-        /// The point to begin the new subpath at.
+        /// The x coordinate for the subpath to begin at.
         /// </summary>
-        public PdfPoint Point { get; }
+        public decimal X { get; }
 
+        /// <summary>
+        /// The y coordinate for the subpath to begin at.
+        /// </summary>
+        public decimal Y { get; }
+        
         /// <summary>
         /// Create a new <see cref="BeginNewSubpath"/>.
         /// </summary>
@@ -29,14 +34,16 @@
         /// <param name="y">The y coordinate.</param>
         public BeginNewSubpath(decimal x, decimal y)
         {
-            Point = new PdfPoint(x, y);
+            X = x;
+            Y = y;
         }
 
         /// <inheritdoc />
         public void Run(IOperationContext operationContext)
         {
+            var point = new PdfPoint(X, Y);
             operationContext.BeginSubpath();
-            var pointTransform = operationContext.CurrentTransformationMatrix.Transform(Point);
+            var pointTransform = operationContext.CurrentTransformationMatrix.Transform(point);
             operationContext.CurrentPosition = pointTransform;
             operationContext.CurrentPath.MoveTo(pointTransform.X, pointTransform.Y);
         }
@@ -44,9 +51,9 @@
         /// <inheritdoc />
         public void Write(Stream stream)
         {
-            stream.WriteDecimal(Point.X);
+            stream.WriteDecimal(X);
             stream.WriteWhiteSpace();
-            stream.WriteDecimal(Point.Y);
+            stream.WriteDecimal(Y);
             stream.WriteWhiteSpace();
             stream.WriteText(Symbol);
             stream.WriteNewLine();
@@ -55,7 +62,7 @@
         /// <inheritdoc />
         public override string ToString()
         {
-            return $"{Point.X} {Point.Y} {Symbol}";
+            return $"{X} {Y} {Symbol}";
         }
     }
 }

--- a/src/UglyToad.PdfPig/Graphics/Operations/TextPositioning/MoveToNextLine.cs
+++ b/src/UglyToad.PdfPig/Graphics/Operations/TextPositioning/MoveToNextLine.cs
@@ -32,7 +32,7 @@
         /// <inheritdoc />
         public void Run(IOperationContext operationContext)
         {
-            var tdOperation = new MoveToNextLineWithOffset(0, -1 * operationContext.GetCurrentState().FontState.Leading);
+            var tdOperation = new MoveToNextLineWithOffset(0, -1 * (decimal)operationContext.GetCurrentState().FontState.Leading);
 
             tdOperation.Run(operationContext);
         }

--- a/src/UglyToad.PdfPig/Graphics/Operations/TextPositioning/MoveToNextLineWithOffset.cs
+++ b/src/UglyToad.PdfPig/Graphics/Operations/TextPositioning/MoveToNextLineWithOffset.cs
@@ -49,7 +49,7 @@
         {
             var currentTextLineMatrix = operationContext.TextMatrices.TextLineMatrix;
             
-            var matrix = TransformationMatrix.FromValues(1, 0, 0, 1, Tx, Ty);
+            var matrix = TransformationMatrix.FromValues(1, 0, 0, 1, (double)Tx, (double)Ty);
 
             var transformed = matrix.Multiply(currentTextLineMatrix);
 

--- a/src/UglyToad.PdfPig/Graphics/Operations/TextState/SetCharacterSpacing.cs
+++ b/src/UglyToad.PdfPig/Graphics/Operations/TextState/SetCharacterSpacing.cs
@@ -36,7 +36,7 @@
         {
             var currentState = operationContext.GetCurrentState();
 
-            currentState.FontState.CharacterSpacing = Spacing;
+            currentState.FontState.CharacterSpacing = (double)Spacing;
         }
 
         /// <inheritdoc />

--- a/src/UglyToad.PdfPig/Graphics/Operations/TextState/SetFontAndSize.cs
+++ b/src/UglyToad.PdfPig/Graphics/Operations/TextState/SetFontAndSize.cs
@@ -49,7 +49,7 @@
         {
             var currentState = operationContext.GetCurrentState();
 
-            currentState.FontState.FontSize = Size;
+            currentState.FontState.FontSize = (double)Size;
             currentState.FontState.FontName = Font;
         }
 

--- a/src/UglyToad.PdfPig/Graphics/Operations/TextState/SetHorizontalScaling.cs
+++ b/src/UglyToad.PdfPig/Graphics/Operations/TextState/SetHorizontalScaling.cs
@@ -32,7 +32,7 @@
         {
             var currentState = operationContext.GetCurrentState();
 
-            currentState.FontState.HorizontalScaling = Scale;
+            currentState.FontState.HorizontalScaling = (double)Scale;
         }
 
         /// <inheritdoc />

--- a/src/UglyToad.PdfPig/Graphics/Operations/TextState/SetTextLeading.cs
+++ b/src/UglyToad.PdfPig/Graphics/Operations/TextState/SetTextLeading.cs
@@ -35,7 +35,7 @@
         {
             var currentState = operationContext.GetCurrentState();
 
-            currentState.FontState.Leading = Leading;
+            currentState.FontState.Leading = (double)Leading;
         }
 
         /// <inheritdoc />

--- a/src/UglyToad.PdfPig/Graphics/Operations/TextState/SetTextRise.cs
+++ b/src/UglyToad.PdfPig/Graphics/Operations/TextState/SetTextRise.cs
@@ -35,7 +35,7 @@
         {
             var currentState = operationContext.GetCurrentState();
 
-            currentState.FontState.Rise = Rise;
+            currentState.FontState.Rise = (double)Rise;
         }
 
         /// <inheritdoc />

--- a/src/UglyToad.PdfPig/Graphics/Operations/TextState/SetWordSpacing.cs
+++ b/src/UglyToad.PdfPig/Graphics/Operations/TextState/SetWordSpacing.cs
@@ -36,7 +36,7 @@
         {
             var currentState = operationContext.GetCurrentState();
 
-            currentState.FontState.WordSpacing = Spacing;
+            currentState.FontState.WordSpacing = (double)Spacing;
         }
 
         /// <inheritdoc />

--- a/src/UglyToad.PdfPig/Graphics/Operations/TextState/Type3SetGlyphWidthAndBoundingBox.cs
+++ b/src/UglyToad.PdfPig/Graphics/Operations/TextState/Type3SetGlyphWidthAndBoundingBox.cs
@@ -1,7 +1,6 @@
 ﻿namespace UglyToad.PdfPig.Graphics.Operations.TextState
 {
     using System.IO;
-    using Geometry;
 
     /// <inheritdoc />
     /// <summary>
@@ -29,10 +28,25 @@
         public decimal VerticalDisplacement { get; }
 
         /// <summary>
-        /// The glyph bounding box.
+        /// The lower left x coordinate of the glyph bounding box.
         /// </summary>
-        public PdfRectangle BoundingBox { get; }
+        public decimal LowerLeftX { get; }
 
+        /// <summary>
+        /// The lower left y coordinate of the glyph bounding box.
+        /// </summary>
+        public decimal LowerLeftY { get; }
+
+        /// <summary>
+        /// The upper right x coordinate of the glyph bounding box.
+        /// </summary>
+        public decimal UpperRightX { get; }
+
+        /// <summary>
+        /// The upper right y coordinate of the glyph bounding box.
+        /// </summary>
+        public decimal UpperRightY { get; }
+        
         /// <summary>
         /// Create a new <see cref="Type3SetGlyphWidthAndBoundingBox"/>.
         /// </summary>
@@ -50,7 +64,10 @@
         {
             HorizontalDisplacement = horizontalDisplacement;
             VerticalDisplacement = verticalDisplacement;
-            BoundingBox = new PdfRectangle(new PdfPoint(lowerLeftX, lowerLeftY), new PdfPoint(upperRightX, upperRightY));
+            LowerLeftX = lowerLeftX;
+            LowerLeftY = lowerLeftY;
+            UpperRightX = upperRightX;
+            UpperRightY = upperRightY;
         }
 
         /// <inheritdoc />
@@ -65,19 +82,19 @@
             stream.WriteWhiteSpace();
             stream.WriteDecimal(VerticalDisplacement);
             stream.WriteWhiteSpace();
-            stream.WriteDecimal(BoundingBox.Left);
+            stream.WriteDecimal(LowerLeftX);
             stream.WriteWhiteSpace();
-            stream.WriteDecimal(BoundingBox.Bottom);
+            stream.WriteDecimal(LowerLeftY);
             stream.WriteWhiteSpace();
-            stream.WriteDecimal(BoundingBox.Right);
+            stream.WriteDecimal(UpperRightX);
             stream.WriteWhiteSpace();
-            stream.WriteNumberText(BoundingBox.Top, Symbol);
+            stream.WriteNumberText(UpperRightY, Symbol);
         }
 
         /// <inheritdoc />
         public override string ToString()
         {
-            return $"{HorizontalDisplacement} {VerticalDisplacement} {BoundingBox.Left} {BoundingBox.Bottom} {BoundingBox.Right} {BoundingBox.Top} {Symbol}";
+            return $"{HorizontalDisplacement} {VerticalDisplacement} {LowerLeftX} {LowerLeftY} {UpperRightX} {UpperRightY} {Symbol}";
         }
     }
 }

--- a/src/UglyToad.PdfPig/IO/ByteArrayInputBytes.cs
+++ b/src/UglyToad.PdfPig/IO/ByteArrayInputBytes.cs
@@ -7,6 +7,7 @@
 
     internal class ByteArrayInputBytes : IInputBytes
     {
+        private readonly int upperBound;
         private readonly byte[] bytes;
 
         [DebuggerStepThrough]
@@ -26,6 +27,8 @@
                 this.bytes = bytes.ToArray();
             }
 
+            upperBound = this.bytes.Length - 1;
+
             currentOffset = -1;
         }
 
@@ -34,20 +37,21 @@
         {
             this.bytes = bytes ?? throw new ArgumentNullException(nameof(bytes));
             currentOffset = -1;
+            upperBound = bytes.Length - 1;
         }
 
-        private long currentOffset;
+        private int currentOffset;
         public long CurrentOffset => currentOffset + 1;
 
         public bool MoveNext()
         {
-            if (currentOffset == bytes.Length - 1)
+            if (currentOffset == upperBound)
             {
                 return false;
             }
 
             currentOffset++;
-            CurrentByte = bytes[(int)currentOffset];
+            CurrentByte = bytes[currentOffset];
             return true;
         }
 
@@ -57,23 +61,23 @@
 
         public byte? Peek()
         {
-            if (currentOffset == bytes.Length - 1)
+            if (currentOffset == upperBound)
             {
                 return null;
             }
 
-            return bytes[(int)currentOffset + 1];
+            return bytes[currentOffset + 1];
         }
 
         public bool IsAtEnd()
         {
-            return currentOffset == bytes.Length - 1;
+            return currentOffset == upperBound;
         }
 
         public void Seek(long position)
         {
             currentOffset = (int)position - 1;
-            CurrentByte = currentOffset < 0 ? (byte)0 : bytes[(int)currentOffset];
+            CurrentByte = currentOffset < 0 ? (byte)0 : bytes[currentOffset];
         }
 
         public int Read(byte[] buffer, int? length = null)
@@ -100,8 +104,8 @@
             }
 
             var viableLength = (bytes.Length - currentOffset - 1);
-            var readLength = (int)(viableLength < bytesToRead ? viableLength : bytesToRead);
-            var startFrom = (int)currentOffset + 1;
+            var readLength = viableLength < bytesToRead ? viableLength : bytesToRead;
+            var startFrom = currentOffset + 1;
 
             Array.Copy(bytes, startFrom, buffer, 0, readLength);
             

--- a/src/UglyToad.PdfPig/Parser/Parts/ReadHelper.cs
+++ b/src/UglyToad.PdfPig/Parser/Parts/ReadHelper.cs
@@ -110,10 +110,9 @@
         /// <remarks>
         /// These values are specified in table 1 (page 12) of ISO 32000-1:2008.
         /// </remarks>
-        public static bool IsWhitespace(int c)
+        public static bool IsWhitespace(byte c)
         {
-            return c == 0 || c == 9 || c == 12 || c == AsciiLineFeed
-                   || c == AsciiCarriageReturn || c == ' ';
+            return c == 0 || c == 32 || c == AsciiLineFeed || c == AsciiCarriageReturn || c == 9 || c == 12;
         }
 
         public static bool IsEndOfLine(char c) => IsEndOfLine((byte) c);

--- a/src/UglyToad.PdfPig/Tokenization/Scanner/CoreTokenScanner.cs
+++ b/src/UglyToad.PdfPig/Tokenization/Scanner/CoreTokenScanner.cs
@@ -11,13 +11,13 @@
     {
         private static readonly HexTokenizer HexTokenizer = new HexTokenizer();
         private static readonly StringTokenizer StringTokenizer = new StringTokenizer();
-        private static readonly NumericTokenizer NumericTokenizer = new NumericTokenizer();
         private static readonly NameTokenizer NameTokenizer = new NameTokenizer();
         private static readonly PlainTokenizer PlainTokenizer = new PlainTokenizer();
         private static readonly ArrayTokenizer ArrayTokenizer = new ArrayTokenizer();
         private static readonly DictionaryTokenizer DictionaryTokenizer = new DictionaryTokenizer();
         private static readonly CommentTokenizer CommentTokenizer = new CommentTokenizer();
 
+        private readonly NumericTokenizer numericTokenizer = new NumericTokenizer();
         private readonly ScannerScope scope;
         private readonly IInputBytes inputBytes;
         private readonly List<(byte firstByte, ITokenizer tokenizer)> customTokenizers = new List<(byte, ITokenizer)>();
@@ -83,7 +83,7 @@
 
                 if (tokenizer == null)
                 {
-                    if (IsEmpty(currentByte) || ReadHelper.IsWhitespace(currentByte))
+                    if (ReadHelper.IsWhitespace(currentByte))
                     {
                         isSkippingSymbol = false;
                         continue;
@@ -143,7 +143,7 @@
                         case '-':
                         case '+':
                         case '.':
-                            tokenizer = NumericTokenizer;
+                            tokenizer = numericTokenizer;
                             break;
                         default:
                             tokenizer = PlainTokenizer;
@@ -283,11 +283,6 @@
             }
 
             throw new PdfDocumentFormatException($"No end of inline image data (EI) was found for image data at position {startsAt}.");
-        }
-
-        private static bool IsEmpty(byte b)
-        {
-            return b == ' ' || b == '\r' || b == '\n' || b == 0;
         }
     }
 }

--- a/src/UglyToad.PdfPig/Tokens/NumericToken.cs
+++ b/src/UglyToad.PdfPig/Tokens/NumericToken.cs
@@ -10,6 +10,12 @@
     /// </summary>
     public class NumericToken : IDataToken<decimal>
     {
+        internal static readonly NumericToken Zero = new NumericToken(0);
+        internal static readonly NumericToken One = new NumericToken(1);
+        internal static readonly NumericToken Two = new NumericToken(2);
+        internal static readonly NumericToken Three = new NumericToken(3);
+        internal static readonly NumericToken Eight = new NumericToken(8);
+
         /// <inheritdoc />
         public decimal Data { get; }
 
@@ -21,17 +27,17 @@
         /// <summary>
         /// The value of this number as an <see langword="int"/>.
         /// </summary>
-        public int Int => (int) Data;
-        
+        public int Int => (int)Data;
+
         /// <summary>
         /// The value of this number as a <see langword="long"/>.
         /// </summary>
-        public long Long => (long) Data;
+        public long Long => (long)Data;
 
         /// <summary>
         /// The value of this number as a <see langword="double"/>.
         /// </summary>
-        public double Double => (double) Data;
+        public double Double => (double)Data;
 
         /// <summary>
         /// Create a <see cref="NumericToken"/>.
@@ -40,6 +46,12 @@
         public NumericToken(decimal value)
         {
             Data = value;
+        }
+
+        /// <inheritdoc />
+        public override int GetHashCode()
+        {
+            return Data.GetHashCode();
         }
 
         /// <inheritdoc />

--- a/src/UglyToad.PdfPig/Tokens/NumericToken.cs
+++ b/src/UglyToad.PdfPig/Tokens/NumericToken.cs
@@ -1,8 +1,8 @@
 ﻿namespace UglyToad.PdfPig.Tokens
 {
-    using System;
     using System.Globalization;
 
+    /// <inheritdoc />
     /// <summary>
     /// PDF supports integer and real numbers. Integer objects represent mathematical integers within a certain interval centered at 0. 
     /// Real objects  approximate mathematical real numbers, but with limited range and precision.
@@ -16,22 +16,17 @@
         /// <summary>
         /// Whether the number represented has a non-zero decimal part.
         /// </summary>
-        public bool HasDecimalPlaces { get; }
+        public bool HasDecimalPlaces => decimal.Floor(Data) != Data;
 
         /// <summary>
         /// The value of this number as an <see langword="int"/>.
         /// </summary>
-        public int Int { get; }
-
-        /// <summary>
-        /// Whether the number overflows an integer.
-        /// </summary>
-        public bool IsBiggerThanInt { get; }
-
+        public int Int => (int) Data;
+        
         /// <summary>
         /// The value of this number as a <see langword="long"/>.
         /// </summary>
-        public long Long { get; }
+        public long Long => (long) Data;
 
         /// <summary>
         /// The value of this number as a <see langword="double"/>.
@@ -45,17 +40,6 @@
         public NumericToken(decimal value)
         {
             Data = value;
-            HasDecimalPlaces = decimal.Floor(value) != value;
-            Long = (long) value;
-
-            try
-            {
-                Int = (int) value;
-            }
-            catch (OverflowException)
-            {
-                IsBiggerThanInt = true;
-            }
         }
 
         /// <inheritdoc />

--- a/src/UglyToad.PdfPig/Tokens/NumericToken.cs
+++ b/src/UglyToad.PdfPig/Tokens/NumericToken.cs
@@ -34,6 +34,11 @@
         public long Long { get; }
 
         /// <summary>
+        /// The value of this number as a <see langword="double"/>.
+        /// </summary>
+        public double Double => (double) Data;
+
+        /// <summary>
         /// Create a <see cref="NumericToken"/>.
         /// </summary>
         /// <param name="value">The number to represent.</param>

--- a/src/UglyToad.PdfPig/Tokens/OperatorToken.cs
+++ b/src/UglyToad.PdfPig/Tokens/OperatorToken.cs
@@ -7,18 +7,26 @@
         private static readonly object Lock = new object();
         private static readonly Dictionary<string, string> PooledNames = new Dictionary<string, string>();
 
-        public static readonly OperatorToken R = new OperatorToken("R");
-        public static readonly OperatorToken StartObject = new OperatorToken("obj");
-        public static readonly OperatorToken EndObject = new OperatorToken("endobj");
-        public static readonly OperatorToken StartStream = new OperatorToken("stream");
-        public static readonly OperatorToken EndStream = new OperatorToken("endstream");
-        public static readonly OperatorToken Eexec = new OperatorToken("eexec");
+        public static readonly OperatorToken Bt = new OperatorToken("BT");
         public static readonly OperatorToken Def = new OperatorToken("def");
         public static readonly OperatorToken Dict = new OperatorToken("dict");
-        public static readonly OperatorToken Readonly = new OperatorToken("readonly");
         public static readonly OperatorToken Dup = new OperatorToken("dup");
+        public static readonly OperatorToken Eexec = new OperatorToken("eexec");
+        public static readonly OperatorToken EndObject = new OperatorToken("endobj");
+        public static readonly OperatorToken EndStream = new OperatorToken("endstream");
+        public static readonly OperatorToken Et = new OperatorToken("ET");
         public static readonly OperatorToken For = new OperatorToken("for");
+        public static readonly OperatorToken N = new OperatorToken("n");
         public static readonly OperatorToken Put = new OperatorToken("put");
+        public static readonly OperatorToken QPop = new OperatorToken("Q");
+        public static readonly OperatorToken QPush = new OperatorToken("q");
+        public static readonly OperatorToken R = new OperatorToken("R");
+        public static readonly OperatorToken Re = new OperatorToken("re");
+        public static readonly OperatorToken Readonly = new OperatorToken("readonly");
+        public static readonly OperatorToken StartObject = new OperatorToken("obj");
+        public static readonly OperatorToken StartStream = new OperatorToken("stream");
+        public static readonly OperatorToken Tf = new OperatorToken("Tf");
+        public static readonly OperatorToken WStar = new OperatorToken("W*");
         public static readonly OperatorToken Xref = new OperatorToken("xref");
 
         public string Data { get; }
@@ -43,30 +51,46 @@
         {
             switch (data)
             {
-                case "R":
-                    return R;
-                case "obj":
-                    return StartObject;
-                case "endobj":
-                    return EndObject;
-                case "stream":
-                    return StartStream;
-                case "endstream":
-                    return EndStream;
+                case "BT":
+                    return Bt;
                 case "eexec":
                     return Eexec;
+                case "endobj":
+                    return EndObject;
+                case "endstream":
+                    return EndStream;
+                case "ET":
+                    return Et;
                 case "def":
                     return Def;
                 case "dict":
                     return Dict;
-                case "readonly":
-                    return Readonly;
-                case "dup":
-                    return Dup;
                 case "for":
                     return For;
+                case "dup":
+                    return Dup;
+                case "n":
+                    return N;
+                case "obj":
+                    return StartObject;
                 case "put":
                     return Put;
+                case "Q":
+                    return QPop;
+                case "q":
+                    return QPush;
+                case "R":
+                    return R;
+                case "re":
+                    return Re;
+                case "readonly":
+                    return Readonly;
+                case "stream":
+                    return StartStream;
+                case "Tf":
+                    return Tf;
+                case "W*":
+                    return WStar;
                 case "xref":
                     return Xref;
                 default:
@@ -74,6 +98,13 @@
             }
         }
 
+        /// <inheritdoc />
+        public override int GetHashCode()
+        {
+            return Data.GetHashCode();
+        }
+
+        /// <inheritdoc />
         public override string ToString()
         {
             return Data;

--- a/src/UglyToad.PdfPig/Util/DefaultWordExtractor.cs
+++ b/src/UglyToad.PdfPig/Util/DefaultWordExtractor.cs
@@ -21,8 +21,8 @@
 
             var lettersSoFar = new List<Letter>(10);
 
-            var y = default(decimal?);
-            var lastX = default(decimal?);
+            var y = default(double?);
+            var lastX = default(double?);
             var lastLetter = default(Letter);
             foreach (var letter in lettersOrder)
             {
@@ -48,7 +48,7 @@
                     continue;
                 }
 
-                if (letter.Location.Y > y.Value + 0.5m)
+                if (letter.Location.Y > y.Value + 0.5)
                 {
                     if (lettersSoFar.Count > 0)
                     {
@@ -70,10 +70,10 @@
 
                 var gap = letter.Location.X - (lastLetter.Location.X + lastLetter.Width);
                 var nextToLeft = letter.Location.X < lastX.Value - 1;
-                var nextBigSpace = gap > Math.Max(lastLetter.GlyphRectangle.Height, letter.GlyphRectangle.Height) * 0.39m;
+                var nextBigSpace = gap > Math.Max(lastLetter.GlyphRectangle.Height, letter.GlyphRectangle.Height) * 0.39;
                 var nextIsWhiteSpace = string.IsNullOrWhiteSpace(letter.Value);
-                var nextFontDiffers = !string.Equals(letter.FontName, lastLetter.FontName, StringComparison.OrdinalIgnoreCase) && gap > letter.Width * 0.1m;
-                var nextFontSizeDiffers = Math.Abs(letter.FontSize - lastLetter.FontSize) > 0.1m;
+                var nextFontDiffers = !string.Equals(letter.FontName, lastLetter.FontName, StringComparison.OrdinalIgnoreCase) && gap > letter.Width * 0.1;
+                var nextFontSizeDiffers = Math.Abs(letter.FontSize - lastLetter.FontSize) > 0.1;
                 var nextTextDirectionDiffers = letter.TextDirection != lastLetter.TextDirection;
 
                 if (nextToLeft || nextBigSpace || nextIsWhiteSpace || nextFontDiffers || nextFontSizeDiffers || nextTextDirectionDiffers)

--- a/src/UglyToad.PdfPig/Util/DictionaryTokenExtensions.cs
+++ b/src/UglyToad.PdfPig/Util/DictionaryTokenExtensions.cs
@@ -136,10 +136,10 @@
                 throw new PdfDocumentFormatException($"Cannot convert array to rectangle, expected 4 values instead got: {array}.");
             }
 
-            return new PdfRectangle(array.GetNumeric(0).Data,
-                array.GetNumeric(1).Data,
-                array.GetNumeric(2).Data,
-                array.GetNumeric(3).Data);
+            return new PdfRectangle(array.GetNumeric(0).Double,
+                array.GetNumeric(1).Double,
+                array.GetNumeric(2).Double,
+                array.GetNumeric(3).Double);
         }
 
         public static PdfRectangle ToIntRectangle(this ArrayToken array)

--- a/src/UglyToad.PdfPig/Writer/IWritingFont.cs
+++ b/src/UglyToad.PdfPig/Writer/IWritingFont.cs
@@ -13,7 +13,7 @@
 
         bool TryGetBoundingBox(char character, out PdfRectangle boundingBox);
 
-        bool TryGetAdvanceWidth(char character, out decimal width);
+        bool TryGetAdvanceWidth(char character, out double width);
 
         TransformationMatrix GetFontMatrix();
 

--- a/src/UglyToad.PdfPig/Writer/PdfDocumentBuilder.cs
+++ b/src/UglyToad.PdfPig/Writer/PdfDocumentBuilder.cs
@@ -309,10 +309,10 @@
         {
             return new ArrayToken(new[]
             {
-                new NumericToken(rectangle.BottomLeft.X),
-                new NumericToken(rectangle.BottomLeft.Y),
-                new NumericToken(rectangle.TopRight.X),
-                new NumericToken(rectangle.TopRight.Y)
+                new NumericToken((decimal)rectangle.BottomLeft.X),
+                new NumericToken((decimal)rectangle.BottomLeft.Y),
+                new NumericToken((decimal)rectangle.TopRight.X),
+                new NumericToken((decimal)rectangle.TopRight.Y)
             });
         }
 

--- a/src/UglyToad.PdfPig/Writer/PdfPageBuilder.cs
+++ b/src/UglyToad.PdfPig/Writer/PdfPageBuilder.cs
@@ -24,7 +24,7 @@
         private readonly List<IGraphicsStateOperation> operations = new List<IGraphicsStateOperation>();
 
         //a sequence number of ShowText operation to determine whether letters belong to same operation or not (letters that belong to different operations have less changes to belong to same word)
-        private static int textSequence = 0;
+        private int textSequence;
 
         internal IReadOnlyList<IGraphicsStateOperation> Operations => operations;
 
@@ -63,8 +63,8 @@
                 operations.Add(new SetLineWidth(lineWidth));
             }
 
-            operations.Add(new BeginNewSubpath(from.X, from.Y));
-            operations.Add(new AppendStraightLineSegment(to.X, to.Y));
+            operations.Add(new BeginNewSubpath((decimal)from.X, (decimal)from.Y));
+            operations.Add(new AppendStraightLineSegment((decimal)to.X, (decimal)to.Y));
             operations.Add(StrokePath.Value);
 
             if (lineWidth != 1)
@@ -87,7 +87,7 @@
                 operations.Add(new SetLineWidth(lineWidth));
             }
 
-            operations.Add(new AppendRectangle(position.X, position.Y, width, height));
+            operations.Add(new AppendRectangle((decimal)position.X, (decimal)position.Y, width, height));
             operations.Add(StrokePath.Value);
 
             if (lineWidth != 1)
@@ -226,23 +226,23 @@
 
             operations.Add(BeginText.Value);
             operations.Add(new SetFontAndSize(font.Name, fontSize));
-            operations.Add(new MoveToNextLineWithOffset(position.X, position.Y));
+            operations.Add(new MoveToNextLineWithOffset((decimal)position.X, (decimal)position.Y));
             operations.Add(new ShowText(text));
             operations.Add(EndText.Value);
 
             return letters;
         }
 
-        private static List<Letter> DrawLetters(string text, IWritingFont font, TransformationMatrix fontMatrix, decimal fontSize, TransformationMatrix textMatrix)
+        private List<Letter> DrawLetters(string text, IWritingFont font, TransformationMatrix fontMatrix, decimal fontSize, TransformationMatrix textMatrix)
         {
             var horizontalScaling = 1;
             var rise = 0;
             var letters = new List<Letter>();
 
             var renderingMatrix =
-                TransformationMatrix.FromValues(fontSize * horizontalScaling, 0, 0, fontSize, 0, rise);
+                TransformationMatrix.FromValues((double)fontSize * horizontalScaling, 0, 0, (double)fontSize, 0, rise);
 
-            var width = 0m;
+            var width = 0.0;
 
             textSequence++;
 
@@ -265,9 +265,9 @@
 
                 var documentSpace = textMatrix.Transform(renderingMatrix.Transform(fontMatrix.Transform(rect)));
 
-                var letter = new Letter(c.ToString(), documentSpace, advanceRect.BottomLeft, advanceRect.BottomRight, width, fontSize, font.Name,
-                    GrayColor.Black, 
-                    fontSize,
+                var letter = new Letter(c.ToString(), documentSpace, advanceRect.BottomLeft, advanceRect.BottomRight, width, (double)fontSize, font.Name,
+                    GrayColor.Black,
+                    (double)fontSize,
                     textSequence);
 
                 letters.Add(letter);

--- a/src/UglyToad.PdfPig/Writer/Standard14WritingFont.cs
+++ b/src/UglyToad.PdfPig/Writer/Standard14WritingFont.cs
@@ -37,7 +37,7 @@
             return true;
         }
 
-        public bool TryGetAdvanceWidth(char character, out decimal width)
+        public bool TryGetAdvanceWidth(char character, out double width)
         {
             width = 0;
             if (!TryGetBoundingBox(character, out var bbox))
@@ -52,7 +52,7 @@
 
         public TransformationMatrix GetFontMatrix()
         {
-            return TransformationMatrix.FromValues(1/1000m, 0, 0, 1/1000m, 0, 0);
+            return TransformationMatrix.FromValues(1/1000.0, 0, 0, 1/1000.0, 0, 0);
         }
 
         public ObjectToken WriteFont(NameToken fontKeyName, Stream outputStream, BuilderContext context)

--- a/src/UglyToad.PdfPig/Writer/TrueTypeWritingFont.cs
+++ b/src/UglyToad.PdfPig/Writer/TrueTypeWritingFont.cs
@@ -35,7 +35,7 @@
             return font.TryGetBoundingBox(character, out boundingBox);
         }
 
-        public bool TryGetAdvanceWidth(char character, out decimal width)
+        public bool TryGetAdvanceWidth(char character, out double width)
         {
             return font.TryGetBoundingAdvancedWidth(character, out width);
         }
@@ -43,7 +43,7 @@
         public TransformationMatrix GetFontMatrix()
         {
             var unitsPerEm = font.GetFontMatrixMultiplier();
-            return TransformationMatrix.FromValues(1m/unitsPerEm, 0, 0, 1m/unitsPerEm, 0, 0);
+            return TransformationMatrix.FromValues(1.0/unitsPerEm, 0, 0, 1.0/unitsPerEm, 0, 0);
         }
 
         public ObjectToken WriteFont(NameToken fontKeyName, Stream outputStream, BuilderContext context)
@@ -95,7 +95,7 @@
                 descriptorDictionary[NameToken.Xheight] = new NumericToken(twoPlus.XHeight);
             }
 
-            descriptorDictionary[NameToken.StemV] = new NumericToken(bbox.Width * scaling * 0.13m);
+            descriptorDictionary[NameToken.StemV] = new NumericToken(((decimal)bbox.Width) * scaling * 0.13m);
 
             var metrics = charCodeToGlyphId.GetMetrics(scaling);
 
@@ -137,10 +137,10 @@
         {
             return new ArrayToken(new[]
             {
-                new NumericToken(boundingBox.Left * scaling),
-                new NumericToken(boundingBox.Bottom * scaling),
-                new NumericToken(boundingBox.Right * scaling),
-                new NumericToken(boundingBox.Top * scaling)
+                new NumericToken((decimal)boundingBox.Left * scaling),
+                new NumericToken((decimal)boundingBox.Bottom * scaling),
+                new NumericToken((decimal)boundingBox.Right * scaling),
+                new NumericToken((decimal)boundingBox.Top * scaling)
             });
         }
 
@@ -184,7 +184,7 @@
                         width = font.TableRegister.HorizontalMetricsTable.AdvancedWidths[0];
                     }
 
-                    widths[pair.Key - firstCharacter] = new NumericToken(width * scaling);
+                    widths[pair.Key - firstCharacter] = new NumericToken((decimal)width * scaling);
                 }
 
                 return new FontDictionaryMetrics

--- a/src/UglyToad.PdfPig/Writer/TrueTypeWritingFont.cs
+++ b/src/UglyToad.PdfPig/Writer/TrueTypeWritingFont.cs
@@ -76,8 +76,8 @@
                 { NameToken.Flags, new NumericToken((int)FontDescriptorFlags.Symbolic) },
                 { NameToken.FontBbox, GetBoundingBox(bbox, scaling) },
                 { NameToken.ItalicAngle, new NumericToken(postscript.ItalicAngle) },
-                { NameToken.Ascent, new NumericToken(hhead.Ascender * scaling) },
-                { NameToken.Descent, new NumericToken(hhead.Descender * scaling) },
+                { NameToken.Ascent, new NumericToken(hhead.Ascent * scaling) },
+                { NameToken.Descent, new NumericToken(hhead.Descent * scaling) },
                 { NameToken.CapHeight, new NumericToken(90) },
                 { NameToken.StemV, new NumericToken(90) },
                 { NameToken.FontFile2, new IndirectReferenceToken(fileRef.Number) }
@@ -181,7 +181,7 @@
 
                     if (!font.TryGetBoundingAdvancedWidth(characterCode, out var width))
                     {
-                        width = font.TableRegister.HorizontalMetricsTable.AdvancedWidths[0];
+                        width = font.TableRegister.HorizontalMetricsTable.HorizontalMetrics[0].AdvanceWidth;
                     }
 
                     widths[pair.Key - firstCharacter] = new NumericToken((decimal)width * scaling);


### PR DESCRIPTION
for #47 it seems that decimals are still too slow after all other performance optimizations. this change aims to preserve decimals where the value being read is exactly representable (all numeric tokens in the document, font metrics files, some fonts and page content stream) but use doubles where the value is calculated, e.g. transformation matrices, etc.

One place where I'd like to maintain decimals is for `Page.Width` and `Page.Height` since these are exact, not calculated values.

The other outstanding performance optimization is to add parsing settings to control the amount of data retrieved on opening a page. Currently we populate the `Operations` array with all operations parsed from the content stream, but most users don't need access to these where they're just interested in text extraction (I assume).