### PR TITLE
Update NearestNeighbourWordExtractor .cs

### DIFF
--- a/src/UglyToad.PdfPig/DocumentLayoutAnalysis/NearestNeighbourWordExtractor .cs
+++ b/src/UglyToad.PdfPig/DocumentLayoutAnalysis/NearestNeighbourWordExtractor .cs
@@ -117,7 +117,7 @@ namespace UglyToad.PdfPig.DocumentLayoutAnalysis
                 distMeasure, maxDistanceFunction,
                 l => l.EndBaseLine, l => l.StartBaseLine,
                 l => !string.IsNullOrWhiteSpace(l.Value),
-                (l1, l2) => string.Equals(l1.FontName, l2.FontName, StringComparison.OrdinalIgnoreCase) && !string.IsNullOrWhiteSpace(l2.Value),
+                (l1, l2) => !string.IsNullOrWhiteSpace(l2.Value),
                 maxDegreeOfParallelism).ToList();
 
             List<Word> words = new List<Word>();


### PR DESCRIPTION
Removing the font name check (`string.Equals(l1.FontName, l2.FontName, StringComparison.OrdinalIgnoreCase)`) because some special characters or ligatures may belong to different subsets.