### PR TITLE
Update PageXmlTextExporter.cs

### DIFF
--- a/src/UglyToad.PdfPig/Export/PageXmlTextExporter.cs
+++ b/src/UglyToad.PdfPig/Export/PageXmlTextExporter.cs
@@ -200,6 +200,7 @@ namespace UglyToad.PdfPig.Export
             return new PageXmlDocument.PageXmlTextRegion()
             {
                 Coords = ToCoords(textBlock.BoundingBox, height),
+                Type = PageXmlDocument.PageXmlTextSimpleType.Paragraph,
                 TextLines = textBlock.TextLines.Select(l => ToPageXmlTextLine(l, height)).ToArray(),
                 TextEquivs = new[] { new PageXmlDocument.PageXmlTextEquiv() { Unicode = textBlock.Text } },
                 Id = "r" + regionCount


### PR DESCRIPTION
Set the `PageXmlTextRegion` type to default `PageXmlTextSimpleType.Paragraph` to avoid a crash in [LayoutEvalGUI 1.9](https://www.primaresearch.org/tools/PerformanceEvaluation)