### PR TITLE
Improve bounding box for word

### DIFF
--- a/src/UglyToad.PdfPig.Core/TransformationMatrix.cs
+++ b/src/UglyToad.PdfPig.Core/TransformationMatrix.cs
@@ -360,6 +360,30 @@
                 E * scalar, F * scalar, row3 * scalar);
         }
 
+                /// <summary>
+        /// 
+        /// </summary>
+        /// <returns></returns>
+        public TransformationMatrix Inverse()
+        {
+            var a = (D * row3 - row2 * F);
+            var c = -(C * row3 - row2 * E);
+            var e = (C * F - D * E);
+
+            var b = -(B * row3 - row1 * F);
+            var d = (A * row3 - row1 * E);
+            var f = -(A * F - B * E);
+
+            var r1 = (B * row2 - row1 * D);
+            var r2 = -(A * row2 - row1 * C);
+            var r3 = (A * D - B * C);
+            var det = A * a + B * c + row1 * e;
+
+            return new TransformationMatrix(a, b, r1, 
+                c, d, r2, 
+                e, f, r3).Multiply(1.0 / det);
+        }
+
         /// <summary>
         /// Get the X scaling component of the current matrix.
         /// </summary>

--- a/src/UglyToad.PdfPig.Core/TransformationMatrix.cs
+++ b/src/UglyToad.PdfPig.Core/TransformationMatrix.cs
@@ -360,10 +360,9 @@
                 E * scalar, F * scalar, row3 * scalar);
         }
 
-                /// <summary>
-        /// 
+        /// <summary>
+        /// Get the inverse of the current matrix.
         /// </summary>
-        /// <returns></returns>
         public TransformationMatrix Inverse()
         {
             var a = (D * row3 - row2 * F);
@@ -379,9 +378,9 @@
             var r3 = (A * D - B * C);
             var det = A * a + B * c + row1 * e;
 
-            return new TransformationMatrix(a, b, r1, 
-                c, d, r2, 
-                e, f, r3).Multiply(1.0 / det);
+            return new TransformationMatrix(a / det, b / det, r1 / det,
+                c / det, d / det, r2 / det,
+                e / det, f / det, r3 / det);
         }
 
         /// <summary>

--- a/src/UglyToad.PdfPig.Tests/Core/TransformationMatrixTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Core/TransformationMatrixTests.cs
@@ -86,5 +86,88 @@
 
             Assert.Equal(expectedMatrix, result);
         }
+
+        public static IEnumerable<object[]> InversionData => new[]
+        {
+            new object[]
+            {
+                new double[]
+                {
+                    0, 2, 2,
+                    1, 1, 1,
+                    0, 1, 2
+                },
+                new double[]
+                {
+                    -.5, 1,  0,
+                      1, 0, -1,
+                    -.5, 0,  1
+                }
+            },
+            new object[]
+            {
+                new double[]
+                {
+                    1, 1, 0,
+                    0, 1, 0,
+                    2, 1, 1
+                },
+                new double[]
+                {
+                     1, -1, 0,
+                     0,  1, 0,
+                    -2,  1, 1
+                }
+            },
+            new object[]
+            {
+                new double[]
+                {
+                    2, 0, 0,
+                    0, 2, 1,
+                    2, 0, 2
+                },
+                new double[]
+                {
+                     .5,   0,   0,
+                     .25, .5, -.25,
+                    -.5,   0,  .5
+                }
+            },
+            new object[]
+            {
+                new double[]
+                {
+                    -4.68,  2.47,  3.12,
+                     5.00, -6.19, -0.58,
+                     9.37, -7.11,  4.51
+                },
+                new double[]
+                {
+                    -0.212368047525923, -0.220866560683805,  0.118511242369019,
+                    -0.18548392709254,  -0.333665068307247,  0.0854066769202931,
+                     0.14880219150553,  -0.0671483286158035, 0.110153244324962
+                }
+            },
+        };
+
+        [Theory]
+        [MemberData(nameof(InversionData))]
+        public void InversesCorrectly(double[] a, double[] expected)
+        {
+            var matrixA = TransformationMatrix.FromArray(a);
+ 
+            var expectedMatrix = TransformationMatrix.FromArray(expected);
+
+            var result = matrixA.Inverse();
+
+            for (var i = 0; i < 3; i++)
+            {
+                for (var j = 0; j < 3; j++)
+                {
+                    Assert.Equal(expectedMatrix[i, j], result[i, j], 6);
+                }
+            }
+        }
     }
 }

--- a/src/UglyToad.PdfPig/Content/Word.cs
+++ b/src/UglyToad.PdfPig/Content/Word.cs
@@ -287,8 +287,9 @@
 
             for (int i = 0; i < baseLinePoints.Count; i++)
             {
-                var x_diff = baseLinePoints[i].X - x0;
-                var y_diff = baseLinePoints[i].Y - y0;
+                var point = baseLinePoints[i];
+                var x_diff = point.X - x0;
+                var y_diff = point.Y - y0;
                 sumProduct += x_diff * y_diff;
                 sumDiffSquaredX += x_diff * x_diff;
             }
@@ -303,7 +304,7 @@
             var transformation = new TransformationMatrix(
                 cos, -sin, 0,
                 sin, cos, 0,
-                (1 - cos) * x0 - sin * y0, sin * x0 - (1 - cos) * y0, 1);
+                (1.0 - cos) * x0 - sin * y0, sin * x0 - (1.0 - cos) * y0, 1);
 
             var transformedPoints = letters.SelectMany(r => new[]
             {

--- a/src/UglyToad.PdfPig/Geometry/GeometryExtensions.cs
+++ b/src/UglyToad.PdfPig/Geometry/GeometryExtensions.cs
@@ -166,7 +166,6 @@
         /// then rotating the points to obtain the axis-aligned bounding box (AABB), and then rotating back the AABB.
         /// </summary>
         /// <param name="points">The points.</param>
-        /// <returns></returns>
         internal static PdfRectangle OrientedBoundingBox(IReadOnlyList<PdfPoint> points)
         {
             if (points == null || points.Count < 2)

--- a/src/UglyToad.PdfPig/Geometry/GeometryExtensions.cs
+++ b/src/UglyToad.PdfPig/Geometry/GeometryExtensions.cs
@@ -174,25 +174,28 @@
                 throw new ArgumentException("OrientedBoundingBox(): points cannot be null and must contain at least two points.");
             }
 
+            // Fitting a line through the points
+            // to find the orientation (slope)
             double x0 = points.Average(p => p.X);
             double y0 = points.Average(p => p.Y);
-            double sum_prod = 0;
-            double sum_x_diff_squared = 0;
+            double sumProduct = 0;
+            double sumDiffSquaredX = 0;
 
             for (int i = 0; i < points.Count; i++)
             {
-                var x_diff = points[i].X - x0;
-                var y_diff = points[i].Y - y0;
-
-                sum_prod += x_diff * y_diff;
-                sum_x_diff_squared += x_diff * x_diff;
+                var point = points[i];
+                var x_diff = point.X - x0;
+                var y_diff = point.Y - y0;
+                sumProduct += x_diff * y_diff;
+                sumDiffSquaredX += x_diff * x_diff;
             }
 
-            var slope = sum_prod / sum_x_diff_squared;
-            var rad_angle = Math.Atan(slope);
+            var slope = sumProduct / sumDiffSquaredX;
 
-            var cos = Math.Cos(rad_angle);
-            var sin = Math.Sin(rad_angle);
+            // Rotate the points to build the axis-aligned bounding box (AABB)
+            var angleRad = Math.Atan(slope);
+            var cos = Math.Cos(angleRad);
+            var sin = Math.Sin(angleRad);
 
             var transformation = new TransformationMatrix(
                 cos, -sin, 0,
@@ -205,6 +208,7 @@
                                         transformedPoints.Max(p => p.X),
                                         transformedPoints.Max(p => p.Y));
 
+            // Rotate back the AABB to obtain to oriented bounding box (OBB)
             var obb = transformation.Inverse().Transform(aabb);
             return obb;
         }

--- a/src/UglyToad.PdfPig/Geometry/GeometryExtensions.cs
+++ b/src/UglyToad.PdfPig/Geometry/GeometryExtensions.cs
@@ -167,7 +167,7 @@
         /// </summary>
         /// <param name="points">The points.</param>
         /// <returns></returns>
-        public static PdfRectangle OrientedBoundingBox(IReadOnlyList<PdfPoint> points)
+        internal static PdfRectangle OrientedBoundingBox(IReadOnlyList<PdfPoint> points)
         {
             if (points == null || points.Count < 2)
             {


### PR DESCRIPTION
- Improve bounding box for `Word`. The new method works as follow:
       - fit a line through the base line's points to get the slope
       - rotate the points to obtain the axis-aligned bounding box (AABB)
       - rotate back the AABB to obtain the oriented bounding box (OBB)

__Results:__
In dark (light) red, the old (new) algo:

![image](https://user-images.githubusercontent.com/38405645/73562553-47744d00-4453-11ea-83cd-22f4ff54b29b.png)


- Implement the method above in `GeometryExtensions`
- Implement `TransformationMatrix.Inverse()`, needed in the above for the _rotate back_ step. Reference [here](https://en.wikipedia.org/wiki/Invertible_matrix#Inversion_of_3_%C3%97_3_matrices)

The new bounding box approach is inspired by https://arxiv.org/abs/1907.03892, in way much simpler:

![image](https://user-images.githubusercontent.com/38405645/73562738-a9cd4d80-4453-11ea-8456-d363ae83d0b0.png)
