### PR TITLE
Faster clustering with kd-tree

### DIFF
--- a/src/UglyToad.PdfPig.DocumentLayoutAnalysis/Distances.cs
+++ b/src/UglyToad.PdfPig.DocumentLayoutAnalysis/Distances.cs
@@ -130,7 +130,7 @@
         /// <param name="pivotPoint"></param>
         /// <param name="distanceMeasure">The distance measure to use.</param>
         /// <param name="distance">The distance between reference point, and its nearest neighbour.</param>
-        internal static int FindIndexNearest<T>(this T element, IReadOnlyList<T> candidates,
+        internal static int FindIndexNearest<T>(T element, IReadOnlyList<T> candidates,
             Func<T, PdfPoint> candidatesPoint, Func<T, PdfPoint> pivotPoint,
             Func<PdfPoint, PdfPoint, double> distanceMeasure, out double distance)
         {
@@ -172,7 +172,7 @@
         /// <param name="pivotLine"></param>
         /// <param name="distanceMeasure">The distance measure between two lines to use.</param>
         /// <param name="distance">The distance between reference line, and its nearest neighbour.</param>
-        internal static int FindIndexNearest<T>(this T element, IReadOnlyList<T> candidates,
+        internal static int FindIndexNearest<T>(T element, IReadOnlyList<T> candidates,
             Func<T, PdfLine> candidatesLine, Func<T, PdfLine> pivotLine,
             Func<PdfLine, PdfLine, double> distanceMeasure, out double distance)
         {

--- a/src/UglyToad.PdfPig.DocumentLayoutAnalysis/KdTree.cs
+++ b/src/UglyToad.PdfPig.DocumentLayoutAnalysis/KdTree.cs
@@ -1,0 +1,230 @@
+﻿namespace UglyToad.PdfPig.DocumentLayoutAnalysis
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using UglyToad.PdfPig.Core;
+
+    // for kd-tree with line segments, see https://stackoverflow.com/questions/14376679/how-to-represent-line-segments-in-kd-tree 
+
+    internal class KdTree : KdTree<PdfPoint>
+    {
+        public KdTree(PdfPoint[] candidates) : base(candidates, p => p)
+        { }
+
+        public PdfPoint FindNearestNeighbours(PdfPoint pivot, Func<PdfPoint, PdfPoint, double> distanceMeasure, out int index, out double distance)
+        {
+            return FindNearestNeighbours(pivot, p => p, distanceMeasure, out index, out distance);
+        }
+    }
+
+    internal class KdTree<T>
+    {
+        private KdTreeNode<T> Root;
+
+        public KdTree(IReadOnlyList<T> candidates, Func<T, PdfPoint> candidatesPointFunc)
+        {
+            var pointsIndex = Enumerable.Range(0, candidates.Count).Zip(candidates, (e, p) => (e, candidatesPointFunc(p), p)).ToList();
+            if (candidates != null && candidates.Count > 0)
+            {
+                Root = BuildTree(pointsIndex, 0);
+            }
+        }
+
+        private KdTreeNode<T> BuildTree(IReadOnlyList<(int, PdfPoint, T)> P, int depth)
+        {
+            var median = P.Count / 2;
+            if (depth % 2 == 0) // depth is even
+            {
+                P = P.OrderBy(p => p.Item2.X).ToArray();
+            }
+            else
+            {
+                P = P.OrderBy(p => p.Item2.Y).ToArray();
+            }
+
+            // left side
+            var P1 = P.Take(median).ToArray();
+            KdTreeNode<T> vLeft = null;
+            if (P1.Length == 1)
+            {
+                var item = P1[0];
+                vLeft = new KdTreeLeaf<T>(item.Item2, item.Item3, depth, item.Item1);
+            }
+            else if (P1.Length > 1)
+            {
+                vLeft = BuildTree(P1, depth + 1);
+            }
+
+            // right side
+            var P2 = P.Skip(median + 1).ToArray();
+            KdTreeNode<T> vRight = null;
+            if (P2.Length == 1)
+            {
+                var item = P2[0];
+                vRight = new KdTreeLeaf<T>(item.Item2, item.Item3, depth, item.Item1);
+            }
+            else if (P2.Length > 1)
+            {
+                vRight = BuildTree(P2, depth + 1);
+            }
+
+            var medianItem = P[median];
+            return new KdTreeNode<T>(vLeft, vRight, medianItem.Item2, medianItem.Item3, depth, medianItem.Item1);
+        }
+
+        #region NN
+        public T FindNearestNeighbours(T pivot, Func<T, PdfPoint> pivotPointFunc, Func<PdfPoint, PdfPoint, double> distanceMeasure, out int index, out double distance)
+        {
+            var result = FindNearestNeighbours(Root, pivot, pivotPointFunc, distanceMeasure);
+            index = result.Item1.Index;
+            distance = result.Item2.Value;
+            return result.Item1.Element;
+        }
+
+        private static (KdTreeNode<T>, double?) FindNearestNeighbours(KdTreeNode<T> node, T pivot, Func<T, PdfPoint> pivotPointFunc, Func<PdfPoint, PdfPoint, double> distance)
+        {
+            if (node == null)
+            {
+                return (null, null);
+            }
+            else if (node.IsLeaf)
+            {
+                if (node.Element.Equals(pivot))
+                {
+                    return (null, null);
+                }
+                return (node, distance(node.Value, pivotPointFunc(pivot)));
+            }
+            else
+            {
+                var point = pivotPointFunc(pivot);
+                var currentNearestNode = node;
+                var currentDistance = distance(node.Value, point);
+
+                KdTreeNode<T> newNode = null;
+                double? newDist = null;
+
+                var pointValue = node.Depth == 0 ? point.X : point.Y;
+
+                if (pointValue < node.L)
+                {
+                    // start left
+                    (newNode, newDist) = FindNearestNeighbours(node.LeftChild, pivot, pivotPointFunc, distance);
+
+                    if (newDist.HasValue && newDist <= currentDistance && !newNode.Element.Equals(pivot))
+                    {
+                        currentDistance = newDist.Value;
+                        currentNearestNode = newNode;
+                    }
+
+                    if (node.RightChild != null && pointValue + currentDistance >= node.L)
+                    {
+                        (newNode, newDist) = FindNearestNeighbours(node.RightChild, pivot, pivotPointFunc, distance);
+                    }
+                }
+                else
+                {
+                    // start right
+                    (newNode, newDist) = FindNearestNeighbours(node.RightChild, pivot, pivotPointFunc, distance);
+
+                    if (newDist.HasValue && newDist <= currentDistance && !newNode.Element.Equals(pivot))
+                    {
+                        currentDistance = newDist.Value;
+                        currentNearestNode = newNode;
+                    }
+
+                    if (node.LeftChild != null && pointValue - currentDistance <= node.L)
+                    {
+                        (newNode, newDist) = FindNearestNeighbours(node.LeftChild, pivot, pivotPointFunc, distance);
+                    }
+                }
+
+                if (newDist.HasValue && newDist <= currentDistance && !newNode.Element.Equals(pivot))
+                {
+                    currentDistance = newDist.Value;
+                    currentNearestNode = newNode;
+                }
+
+                return (currentNearestNode, currentDistance);
+            }
+        }
+        #endregion
+
+        private class KdTreeLeaf<Q> : KdTreeNode<Q>
+        {
+            public override bool IsLeaf => true;
+
+            public KdTreeLeaf(PdfPoint l, Q element, int depth, int index)
+                : base(null, null, l, element, depth, index)
+            { }
+
+            public override string ToString()
+            {
+                return "Leaf->" + Value.ToString();
+            }
+        }
+
+        private class KdTreeNode<Q>
+        {
+            /// <summary>
+            /// Split value.
+            /// </summary>
+            public double L => Depth == 0 ? Value.X : Value.Y;
+
+            public PdfPoint Value { get; }
+
+            public KdTreeNode<Q> LeftChild { get; internal set; }
+
+            public KdTreeNode<Q> RightChild { get; internal set; }
+
+            public Q Element { get; }
+
+            /// <summary>
+            /// 0 is even (x), 1 is odd (y).
+            /// </summary>
+            public int Depth { get; }
+
+            public virtual bool IsLeaf => false;
+
+            public int Index { get; }
+
+            public KdTreeNode(KdTreeNode<Q> leftChild, KdTreeNode<Q> rightChild, PdfPoint l, Q element, int depth, int index)
+            {
+                LeftChild = leftChild;
+                RightChild = rightChild;
+                Value = l;
+                Element = element;
+                Depth = depth % 2;
+                Index = index;
+            }
+
+            public IEnumerable<KdTreeLeaf<Q>> GetLeaves()
+            {
+                var leafs = new List<KdTreeLeaf<Q>>();
+                RecursiveGetLeaves(LeftChild, ref leafs);
+                RecursiveGetLeaves(RightChild, ref leafs);
+                return leafs;
+            }
+
+            private void RecursiveGetLeaves(KdTreeNode<Q> leaf, ref List<KdTreeLeaf<Q>> leafs)
+            {
+                if (leaf == null) return;
+                if (leaf is KdTreeLeaf<Q> lLeaf)
+                {
+                    leafs.Add(lLeaf);
+                }
+                else
+                {
+                    RecursiveGetLeaves(leaf.LeftChild, ref leafs);
+                    RecursiveGetLeaves(leaf.RightChild, ref leafs);
+                }
+            }
+
+            public override string ToString()
+            {
+                return "Node->" + Value.ToString();
+            }
+        }
+    }
+}

--- a/src/UglyToad.PdfPig.DocumentLayoutAnalysis/PageSegmenter/DocstrumBoundingBoxes.cs
+++ b/src/UglyToad.PdfPig.DocumentLayoutAnalysis/PageSegmenter/DocstrumBoundingBoxes.cs
@@ -230,7 +230,7 @@
                 return null;
             }
 
-            var closestWordIndex = pointR.FindIndexNearest(wordsWithinAngleBoundDistancePoints, p => p,
+            var closestWordIndex = Distances.FindIndexNearest(pointR, wordsWithinAngleBoundDistancePoints, p => p,
                 p => p, Distances.Euclidean, out _);
 
             if (closestWordIndex < 0 || closestWordIndex >= wordsWithinAngleBoundDistancePoints.Count)


### PR DESCRIPTION
Implement **kd-tree** data structure to make clustering faster. This will impact both `NearestNeighbourWordExtractor` and `DocstrumBoundingBoxes` classes as they use `ClusteringAlgorithms.ClusterNearestNeighbours(PdfPoint)`.

The kd-tree structure is only used in `ClusteringAlgorithms.ClusterNearestNeighbours(PdfPoint)` for the moment and not in `ClusteringAlgorithms.ClusterNearestNeighbours(PdfLine)`.

See the [wikipedia page](https://en.wikipedia.org/wiki/K-d_tree) for more informations on kd-trees:
- The cost of building the tree in is `O(n log n)` time in the best case. An algorithm that builds a balanced k-d tree to sort points has a worst-case complexity of `O(kn log n)`,
- Finding the nearest point is an `O(log n)` operation on average.

I ran performance tests to compare the current (`master`) implementation of `NearestNeighbourWordExtractor` and the one using the kd-tree (`kd-tree`): **203** documents were analysed for a total of **12,669** pages.

**The results show that the kd-tree implementation is 3.50 times faster on average.**
|    | master | kd-tree |
|---|:---:|:---:|
| **total time (min)** |16.5|4.7|
| **avg time/page (ms)** |78|22|

Below is a chart that plots the time spent on each page, as a function of the number of input letters:
![kd tree improvement](https://user-images.githubusercontent.com/38405645/74605317-f99c4d80-50be-11ea-9fe4-f09e99cafbad.png)
