### PR TITLE
NearestNeighbourWordExtractor: Improve default max function

### DIFF
--- a/src/UglyToad.PdfPig.DocumentLayoutAnalysis/WordExtractor/NearestNeighbourWordExtractor.cs
+++ b/src/UglyToad.PdfPig.DocumentLayoutAnalysis/WordExtractor/NearestNeighbourWordExtractor.cs
@@ -31,43 +31,52 @@
         /// <param name="letters">The letters in the page.</param>
         public IEnumerable<Word> GetWords(IReadOnlyList<Letter> letters)
         {
+            Func<Letter, Letter, double> baseMaxFunc = (l1, l2) =>
+            {
+                return Math.Max(Math.Max(Math.Max(
+                    Math.Abs(l1.GlyphRectangle.Width),
+                    Math.Abs(l2.GlyphRectangle.Width)),
+                    Math.Abs(l1.Width)), 
+                    Math.Abs(l2.Width));
+            };
+
             List<Word> wordsH = GetWords(
-                letters.Where(l => l.TextDirection == TextDirection.Horizontal),
-                (l1, l2) => Math.Max(l1.GlyphRectangle.Width, l2.GlyphRectangle.Width) * 0.2,
+                letters.Where(l => l.TextDirection == TextDirection.Horizontal).ToList(),
+                (l1, l2) => baseMaxFunc(l1, l2) * 0.2,
                 Distances.Manhattan, MaxDegreeOfParallelism)
                 .OrderByDescending(x => x.BoundingBox.Bottom)
                 .ThenBy(x => x.BoundingBox.Left).ToList();
 
-            List<Word> words270 = GetWords(
-                letters.Where(l => l.TextDirection == TextDirection.Rotate270),
-                (l1, l2) => Math.Max(l1.GlyphRectangle.Width, l2.GlyphRectangle.Width) * 0.2,
+            var words270 = GetWords(
+                letters.Where(l => l.TextDirection == TextDirection.Rotate270).ToList(),
+                (l1, l2) => baseMaxFunc(l1, l2) * 0.2,
                 Distances.Manhattan, MaxDegreeOfParallelism)
                 .OrderBy(x => x.BoundingBox.Right)
-                .ThenByDescending(x => x.BoundingBox.Bottom).ToList();
+                .ThenByDescending(x => x.BoundingBox.Bottom);
             wordsH.AddRange(words270);
 
-            List<Word> words180 = GetWords(
-                letters.Where(l => l.TextDirection == TextDirection.Rotate180),
-                (l1, l2) => Math.Max(Math.Abs(l1.GlyphRectangle.Width), Math.Abs(l2.GlyphRectangle.Width)) * 0.2,
+            var words180 = GetWords(
+                letters.Where(l => l.TextDirection == TextDirection.Rotate180).ToList(),
+                (l1, l2) => baseMaxFunc(l1, l2) * 0.2,
                 Distances.Manhattan, MaxDegreeOfParallelism)
                 .OrderBy(x => x.BoundingBox.Top)
-                .ThenByDescending(x => x.BoundingBox.Right).ToList();
+                .ThenByDescending(x => x.BoundingBox.Right);
             wordsH.AddRange(words180);
 
-            List<Word> words90 = GetWords(
-                letters.Where(l => l.TextDirection == TextDirection.Rotate90),
-                (l1, l2) => Math.Max(Math.Abs(l1.GlyphRectangle.Width), Math.Abs(l2.GlyphRectangle.Width)) * 0.2,
+            var words90 = GetWords(
+                letters.Where(l => l.TextDirection == TextDirection.Rotate90).ToList(),
+                (l1, l2) => baseMaxFunc(l1, l2) * 0.2,
                 Distances.Manhattan, MaxDegreeOfParallelism)
                 .OrderByDescending(x => x.BoundingBox.Left)
-                .ThenBy(x => x.BoundingBox.Top).ToList();
+                .ThenBy(x => x.BoundingBox.Top);
             wordsH.AddRange(words90);
 
-            List<Word> wordsU = GetWords(
-                letters.Where(l => l.TextDirection == TextDirection.Other),
-                (l1, l2) => Math.Max(Math.Abs(l1.GlyphRectangle.Width), Math.Abs(l2.GlyphRectangle.Width)) * 0.5,
+            var wordsU = GetWords(
+                letters.Where(l => l.TextDirection == TextDirection.Other).ToList(),
+                (l1, l2) => baseMaxFunc(l1, l2) * 0.5,
                 Distances.Euclidean, MaxDegreeOfParallelism)
                 .OrderByDescending(x => x.BoundingBox.Bottom)
-                .ThenBy(x => x.BoundingBox.Left).ToList();
+                .ThenBy(x => x.BoundingBox.Left);
             wordsH.AddRange(wordsU);
 
             return wordsH;
@@ -85,7 +94,7 @@
         /// <param name="maxDegreeOfParallelism">Sets the maximum number of concurrent tasks enabled. 
         /// <para>A positive property value limits the number of concurrent operations to the set value. 
         /// If it is -1, there is no limit on the number of concurrently running operations.</para></param>
-        public List<Word> GetWords(IEnumerable<Letter> pageLetters,
+        public List<Word> GetWords(IReadOnlyList<Letter> pageLetters,
             Func<Letter, Letter, double> maxDistanceFunction, Func<PdfPoint, PdfPoint, double> distMeasure,
             int maxDegreeOfParallelism)
         {
@@ -97,9 +106,7 @@
                 throw new ArgumentException("NearestNeighbourWordExtractor.GetWords(): Mixed Text Direction.");
             }
 
-            Letter[] letters = pageLetters.ToArray();
-
-            var groupedIndexes = ClusteringAlgorithms.ClusterNearestNeighbours(letters,
+            var groupedIndexes = ClusteringAlgorithms.ClusterNearestNeighbours(pageLetters,
                 distMeasure, maxDistanceFunction,
                 l => l.EndBaseLine, l => l.StartBaseLine,
                 l => !string.IsNullOrWhiteSpace(l.Value),
@@ -107,9 +114,9 @@
                 maxDegreeOfParallelism).ToList();
 
             List<Word> words = new List<Word>();
-            for (int a = 0; a < groupedIndexes.Count(); a++)
+            for (int a = 0; a < groupedIndexes.Count; a++)
             {
-                words.Add(new Word(groupedIndexes[a].Select(i => letters[i]).ToList()));
+                words.Add(new Word(groupedIndexes[a].Select(i => pageLetters[i]).ToList()));
             }
 
             return words;


### PR DESCRIPTION
Use Max of `Letter.GlyphRectangle.Width` and `Letter.Width` for both letters (instead of just `GlyphRectangle.Width`).