### PR TITLE
Fix an issue where the root `/Pages` Count was incorrect

### DIFF
--- a/src/UglyToad.PdfPig.Tests/Writer/PdfMergerTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Writer/PdfMergerTests.cs
@@ -2,6 +2,7 @@
 {
     using Integration;
     using PdfPig.Writer;
+    using System.IO;
     using Xunit;
 
     public class PdfMergerTests
@@ -53,6 +54,29 @@
                 var page2 = document.GetPage(2);
 
                 Assert.Equal("Write something inInkscape", page2.Text);
+            }
+        }
+
+        [Fact]
+        public void RootNodePageCount()
+        {
+            var one = IntegrationHelpers.GetDocumentPath("Single Page Simple - from open office.pdf");
+            var two = IntegrationHelpers.GetDocumentPath("Single Page Simple - from inkscape.pdf");
+
+            var result = PdfMerger.Merge(one, two);
+
+            using (var document = PdfDocument.Open(result, ParsingOptions.LenientParsingOff))
+            {
+                Assert.Equal(2, document.NumberOfPages);
+            }
+
+            var oneBytes = File.ReadAllBytes(one);
+
+            var result2 = PdfMerger.Merge(new[] { result, oneBytes });
+
+            using (var document = PdfDocument.Open(result2, ParsingOptions.LenientParsingOff))
+            {
+                Assert.Equal(3, document.NumberOfPages);
             }
         }
     }


### PR DESCRIPTION
`/Pages` Count should reflect the number leaf nodes (page objects) that are descendants of this node. Contrary to what I believe, which was the count Kids object

This is indicated in the [Pdf Specification](https://www.adobe.com/content/dam/acom/en/devnet/pdf/pdfs/PDF32000_2008.pdf):
![image](https://user-images.githubusercontent.com/2200611/76147187-0d105800-6070-11ea-83b8-34e23810f4bd.png)

I added test case too.
