### PR TITLE
Merger API: Lower object count

### DIFF
--- a/src/UglyToad.PdfPig.Tests/Writer/PdfMergerTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Writer/PdfMergerTests.cs
@@ -79,5 +79,21 @@
                 Assert.Equal(3, document.NumberOfPages);
             }
         }
+
+        [Fact]
+        public void ObjectCountLower()
+        {
+            var one = IntegrationHelpers.GetDocumentPath("Single Page Simple - from inkscape.pdf");
+            var two = IntegrationHelpers.GetDocumentPath("Single Page Simple - from inkscape.pdf");
+
+            var result = PdfMerger.Merge(one, two);
+
+            using (var document = PdfDocument.Open(result, ParsingOptions.LenientParsingOff))
+            {
+                Assert.Equal(2, document.NumberOfPages);
+                Assert.True(document.Structure.CrossReferenceTable.ObjectOffsets.Count < 24,
+                    "Expected object count to be lower than 24");
+            }
+        }
     }
 }

--- a/src/UglyToad.PdfPig.Tokens/ArrayToken.cs
+++ b/src/UglyToad.PdfPig.Tokens/ArrayToken.cs
@@ -88,5 +88,26 @@
 
             return builder.ToString();
         }
+        
+        /// <inheritdoc />
+        public bool Equals(IToken obj)
+        {
+            if (this == obj)
+                return true;
+
+            if (!(obj is ArrayToken other))
+                return false;
+
+            if (other.Length != Length)
+                return false;
+
+            for (var index = 0; index < Length; ++index)
+            {
+                if (!Data[index].Equals(other[index]))
+                    return false;
+            }
+
+            return true;
+        }
     }
 }

--- a/src/UglyToad.PdfPig.Tokens/ArrayToken.cs
+++ b/src/UglyToad.PdfPig.Tokens/ArrayToken.cs
@@ -92,19 +92,27 @@
         /// <inheritdoc />
         public bool Equals(IToken obj)
         {
-            if (this == obj)
+            if (ReferenceEquals(this, obj))
+            {
                 return true;
+            }
 
             if (!(obj is ArrayToken other))
+            {
                 return false;
+            }
 
             if (other.Length != Length)
+            {
                 return false;
+            }
 
             for (var index = 0; index < Length; ++index)
             {
                 if (!Data[index].Equals(other[index]))
+                {
                     return false;
+                }
             }
 
             return true;

--- a/src/UglyToad.PdfPig.Tokens/BooleanToken.cs
+++ b/src/UglyToad.PdfPig.Tokens/BooleanToken.cs
@@ -30,17 +30,6 @@
         }
 
         /// <inheritdoc />
-        public override bool Equals(object obj)
-        {
-            if (!(obj is BooleanToken other))
-            {
-                return false;
-            }
-
-            return other.Data == Data;
-        }
-        
-        /// <inheritdoc />
         public override int GetHashCode()
         {
             return Data.GetHashCode();
@@ -50,6 +39,20 @@
         public override string ToString()
         {
             return Data.ToString();
+        }
+
+        /// <inheritdoc />
+        public bool Equals(IToken obj)
+        {
+            if (this == obj)
+                return true;
+
+            if (!(obj is BooleanToken other))
+            {
+                return false;
+            }
+
+            return other.Data == Data;
         }
     }
 }

--- a/src/UglyToad.PdfPig.Tokens/BooleanToken.cs
+++ b/src/UglyToad.PdfPig.Tokens/BooleanToken.cs
@@ -44,8 +44,10 @@
         /// <inheritdoc />
         public bool Equals(IToken obj)
         {
-            if (this == obj)
+            if (ReferenceEquals(this, obj))
+            {
                 return true;
+            }
 
             if (!(obj is BooleanToken other))
             {

--- a/src/UglyToad.PdfPig.Tokens/CommentToken.cs
+++ b/src/UglyToad.PdfPig.Tokens/CommentToken.cs
@@ -29,6 +29,11 @@
         /// <inheritdoc />
         public bool Equals(IToken obj)
         {
+            if (ReferenceEquals(this, obj))
+            {
+                return true;
+            }
+
             if (!(obj is CommentToken other))
             {
                 return false;

--- a/src/UglyToad.PdfPig.Tokens/CommentToken.cs
+++ b/src/UglyToad.PdfPig.Tokens/CommentToken.cs
@@ -25,5 +25,16 @@
         {
             return Data;
         }
+
+        /// <inheritdoc />
+        public bool Equals(IToken obj)
+        {
+            if (!(obj is CommentToken other))
+            {
+                return false;
+            }
+
+            return other.Data == Data;
+        }
     }
 }

--- a/src/UglyToad.PdfPig.Tokens/DictionaryToken.cs
+++ b/src/UglyToad.PdfPig.Tokens/DictionaryToken.cs
@@ -114,6 +114,26 @@
             return new DictionaryToken(result);
         }
 
+
+        /// <inheritdoc />
+        public bool Equals(IToken obj)
+        {
+            if (this == obj)
+                return true;
+
+            if (!(obj is DictionaryToken other))
+            {
+                return false;
+            }
+
+            if (Data.Count != other.Data.Count)
+                return false;
+
+            // TODO: Maybe consider using a sorted dictionary?
+            return Data.OrderBy(kvp => kvp.Key)
+           .SequenceEqual(other.Data.OrderBy(kvp => kvp.Key));
+        }
+
         /// <inheritdoc />
         public override string ToString()
         {

--- a/src/UglyToad.PdfPig.Tokens/DictionaryToken.cs
+++ b/src/UglyToad.PdfPig.Tokens/DictionaryToken.cs
@@ -118,8 +118,10 @@
         /// <inheritdoc />
         public bool Equals(IToken obj)
         {
-            if (this == obj)
+            if (ReferenceEquals(this, obj))
+            {
                 return true;
+            }
 
             if (!(obj is DictionaryToken other))
             {
@@ -127,11 +129,19 @@
             }
 
             if (Data.Count != other.Data.Count)
+            {
                 return false;
+            }
 
-            // TODO: Maybe consider using a sorted dictionary?
-            return Data.OrderBy(kvp => kvp.Key)
-           .SequenceEqual(other.Data.OrderBy(kvp => kvp.Key));
+            foreach (var kvp in other.Data)
+            {
+                if (!Data.TryGetValue(kvp.Key, out var val) || !val.Equals(kvp.Value))
+                {
+                    return false;
+                }
+            }
+
+            return true;
         }
 
         /// <inheritdoc />

--- a/src/UglyToad.PdfPig.Tokens/EndOfLineToken.cs
+++ b/src/UglyToad.PdfPig.Tokens/EndOfLineToken.cs
@@ -13,5 +13,19 @@
         private EndOfLineToken()
         {
         }
+
+        /// <inheritdoc />
+        public bool Equals(IToken obj)
+        {
+            if (this == obj)
+                return true;
+
+            if (!(obj is EndOfLineToken other))
+            {
+                return false;
+            }
+
+            return true;
+        }
     }
 }

--- a/src/UglyToad.PdfPig.Tokens/EndOfLineToken.cs
+++ b/src/UglyToad.PdfPig.Tokens/EndOfLineToken.cs
@@ -17,15 +17,12 @@
         /// <inheritdoc />
         public bool Equals(IToken obj)
         {
-            if (this == obj)
-                return true;
-
-            if (!(obj is EndOfLineToken other))
+            if (ReferenceEquals(this, obj))
             {
-                return false;
+                return true;
             }
 
-            return true;
+            return obj is EndOfLineToken;
         }
     }
 }

--- a/src/UglyToad.PdfPig.Tokens/HexToken.cs
+++ b/src/UglyToad.PdfPig.Tokens/HexToken.cs
@@ -141,8 +141,10 @@ namespace UglyToad.PdfPig.Tokens
         /// <inheritdoc />
         public bool Equals(IToken obj)
         {
-            if (this == obj)
+            if (ReferenceEquals(this, obj))
+            {
                 return true;
+            }
 
             if (!(obj is HexToken other))
             {

--- a/src/UglyToad.PdfPig.Tokens/HexToken.cs
+++ b/src/UglyToad.PdfPig.Tokens/HexToken.cs
@@ -138,6 +138,20 @@ namespace UglyToad.PdfPig.Tokens
             return value;
         }
 
+        /// <inheritdoc />
+        public bool Equals(IToken obj)
+        {
+            if (this == obj)
+                return true;
+
+            if (!(obj is HexToken other))
+            {
+                return false;
+            }
+
+            return Data == other.Data;
+        }
+
         /// <summary>
         /// Converts the binary data back to a hex string representation.
         /// </summary>

--- a/src/UglyToad.PdfPig.Tokens/IToken.cs
+++ b/src/UglyToad.PdfPig.Tokens/IToken.cs
@@ -1,9 +1,11 @@
-﻿namespace UglyToad.PdfPig.Tokens
+﻿using System;
+
+namespace UglyToad.PdfPig.Tokens
 {
     /// <summary>
     /// A marker interface for tokens from the PDF file contents.
     /// </summary>
-    public interface IToken
+    public interface IToken : IEquatable<IToken>
     {
     }
 }

--- a/src/UglyToad.PdfPig.Tokens/IndirectReferenceToken.cs
+++ b/src/UglyToad.PdfPig.Tokens/IndirectReferenceToken.cs
@@ -22,6 +22,20 @@
         }
 
         /// <inheritdoc />
+        public bool Equals(IToken obj)
+        {
+            if (this == obj)
+                return true;
+
+            if (!(obj is IndirectReferenceToken other))
+            {
+                return false;
+            }
+
+            return Data.Equals(other.Data);
+        }
+
+        /// <inheritdoc />
         public override string ToString()
         {
             return $"{Data}";

--- a/src/UglyToad.PdfPig.Tokens/IndirectReferenceToken.cs
+++ b/src/UglyToad.PdfPig.Tokens/IndirectReferenceToken.cs
@@ -24,8 +24,10 @@
         /// <inheritdoc />
         public bool Equals(IToken obj)
         {
-            if (this == obj)
+            if (ReferenceEquals(this, obj))
+            {
                 return true;
+            }
 
             if (!(obj is IndirectReferenceToken other))
             {

--- a/src/UglyToad.PdfPig.Tokens/InlineImageDataToken.cs
+++ b/src/UglyToad.PdfPig.Tokens/InlineImageDataToken.cs
@@ -22,8 +22,10 @@
         /// <inheritdoc />
         public bool Equals(IToken obj)
         {
-            if (this == obj)
+            if (ReferenceEquals(this, obj))
+            {
                 return true;
+            }
 
             if (!(obj is InlineImageDataToken other))
             {
@@ -31,14 +33,17 @@
             }
 
             if (Data.Count != other.Data.Count)
+            {
                 return false;
+            }
 
-            // Note: This maybe slow?
-            // Maybe pre calculate some sort of hash and compare that?
+
             for (var index = 0; index < Data.Count; ++index)
             {
                 if (Data[index] != other.Data[index])
+                {
                     return false;
+                }
             }
 
             return true;

--- a/src/UglyToad.PdfPig.Tokens/InlineImageDataToken.cs
+++ b/src/UglyToad.PdfPig.Tokens/InlineImageDataToken.cs
@@ -18,5 +18,30 @@
         {
             Data = data;
         }
+
+        /// <inheritdoc />
+        public bool Equals(IToken obj)
+        {
+            if (this == obj)
+                return true;
+
+            if (!(obj is InlineImageDataToken other))
+            {
+                return false;
+            }
+
+            if (Data.Count != other.Data.Count)
+                return false;
+
+            // Note: This maybe slow?
+            // Maybe pre calculate some sort of hash and compare that?
+            for (var index = 0; index < Data.Count; ++index)
+            {
+                if (Data[index] != other.Data[index])
+                    return false;
+            }
+
+            return true;
+        }
     }
 }

--- a/src/UglyToad.PdfPig.Tokens/NameToken.cs
+++ b/src/UglyToad.PdfPig.Tokens/NameToken.cs
@@ -59,6 +59,12 @@
         }
 
         /// <inheritdoc />
+        public bool Equals(IToken obj)
+        {
+            return Equals(obj as NameToken);
+        }
+
+        /// <inheritdoc />
         public override int GetHashCode()
         {
             return Data.GetHashCode();

--- a/src/UglyToad.PdfPig.Tokens/NullToken.cs
+++ b/src/UglyToad.PdfPig.Tokens/NullToken.cs
@@ -35,6 +35,12 @@
         }
 
         /// <inheritdoc />
+        public bool Equals(IToken obj)
+        {
+            return obj is NullToken;
+        }
+
+        /// <inheritdoc />
         public override int GetHashCode()
         {
             return 0;

--- a/src/UglyToad.PdfPig.Tokens/NumericToken.cs
+++ b/src/UglyToad.PdfPig.Tokens/NumericToken.cs
@@ -107,6 +107,20 @@
         }
 
         /// <inheritdoc />
+        public bool Equals(IToken obj)
+        {
+            if (this == obj)
+                return true;
+
+            if (!(obj is NumericToken other))
+            {
+                return false;
+            }
+
+            return Data == other.Data;
+        }
+
+        /// <inheritdoc />
         public override int GetHashCode()
         {
             return Data.GetHashCode();

--- a/src/UglyToad.PdfPig.Tokens/NumericToken.cs
+++ b/src/UglyToad.PdfPig.Tokens/NumericToken.cs
@@ -109,8 +109,10 @@
         /// <inheritdoc />
         public bool Equals(IToken obj)
         {
-            if (this == obj)
+            if (ReferenceEquals(this, obj))
+            {
                 return true;
+            }
 
             if (!(obj is NumericToken other))
             {

--- a/src/UglyToad.PdfPig.Tokens/ObjectToken.cs
+++ b/src/UglyToad.PdfPig.Tokens/ObjectToken.cs
@@ -38,6 +38,39 @@
         }
 
         /// <inheritdoc />
+        public bool Equals(IToken obj)
+        {
+            if (this == obj)
+                return true;
+
+            if (!(obj is ObjectToken other))
+            {
+                return false;
+            }
+
+            // I don't think we should compare this value...
+            // If this values are the same but this object are not the same (reference)
+            // It means that one of the obj is not from stream or one of the object have been overwritten
+            // So maybe putting an assert instead, would be a good idea?
+            if (Position != other.Position)
+            {
+                return false;
+            }
+
+            if (!Number.Equals(other.Number))
+            {
+                return false;
+            }
+
+            if (!Data.Equals(other.Data))
+            {
+                return false;
+            }
+
+            return true;
+        }
+
+        /// <inheritdoc />
         public override string ToString()
         {
             return $"Number: {Number}, Position: {Position}, Type: {Data.GetType().Name}";

--- a/src/UglyToad.PdfPig.Tokens/ObjectToken.cs
+++ b/src/UglyToad.PdfPig.Tokens/ObjectToken.cs
@@ -40,34 +40,17 @@
         /// <inheritdoc />
         public bool Equals(IToken obj)
         {
-            if (this == obj)
+            if (ReferenceEquals(this, obj))
+            {
                 return true;
+            }
 
             if (!(obj is ObjectToken other))
             {
                 return false;
             }
 
-            // I don't think we should compare this value...
-            // If this values are the same but this object are not the same (reference)
-            // It means that one of the obj is not from stream or one of the object have been overwritten
-            // So maybe putting an assert instead, would be a good idea?
-            if (Position != other.Position)
-            {
-                return false;
-            }
-
-            if (!Number.Equals(other.Number))
-            {
-                return false;
-            }
-
-            if (!Data.Equals(other.Data))
-            {
-                return false;
-            }
-
-            return true;
+            return Number.Equals(other.Number) && Data.Equals(other.Data);
         }
 
         /// <inheritdoc />

--- a/src/UglyToad.PdfPig.Tokens/OperatorToken.cs
+++ b/src/UglyToad.PdfPig.Tokens/OperatorToken.cs
@@ -196,6 +196,20 @@
         }
 
         /// <inheritdoc />
+        public bool Equals(IToken obj)
+        {
+            if (this == obj)
+                return true;
+
+            if (!(obj is OperatorToken other))
+            {
+                return false;
+            }
+
+            return Data == other.Data;
+        }
+
+        /// <inheritdoc />
         public override int GetHashCode()
         {
             return Data.GetHashCode();

--- a/src/UglyToad.PdfPig.Tokens/OperatorToken.cs
+++ b/src/UglyToad.PdfPig.Tokens/OperatorToken.cs
@@ -198,8 +198,10 @@
         /// <inheritdoc />
         public bool Equals(IToken obj)
         {
-            if (this == obj)
+            if (ReferenceEquals(this, obj))
+            {
                 return true;
+            }
 
             if (!(obj is OperatorToken other))
             {

--- a/src/UglyToad.PdfPig.Tokens/StreamToken.cs
+++ b/src/UglyToad.PdfPig.Tokens/StreamToken.cs
@@ -29,7 +29,34 @@
             StreamDictionary = streamDictionary ?? throw new ArgumentNullException(nameof(streamDictionary));
             Data = data ?? throw new ArgumentNullException(nameof(data));
         }
-        
+
+        /// <inheritdoc />
+        public bool Equals(IToken obj)
+        {
+            if (this == obj)
+                return true;
+
+            if (!(obj is StreamToken other))
+            {
+                return false;
+            }
+
+            if (!StreamDictionary.Equals(other.StreamDictionary))
+            {
+                return false;
+            }
+
+            // Note: This maybe slow?
+            // Maybe pre calculate some sort of hash and compare that?
+            for (var index = 0; index < Data.Count; ++index)
+            {
+                if (Data[index] != other.Data[index])
+                    return false;
+            }
+
+            return true;
+        }
+
         /// <inheritdoc />
         public override string ToString()
         {

--- a/src/UglyToad.PdfPig.Tokens/StreamToken.cs
+++ b/src/UglyToad.PdfPig.Tokens/StreamToken.cs
@@ -33,8 +33,10 @@
         /// <inheritdoc />
         public bool Equals(IToken obj)
         {
-            if (this == obj)
+            if (ReferenceEquals(this, obj))
+            {
                 return true;
+            }
 
             if (!(obj is StreamToken other))
             {
@@ -46,12 +48,17 @@
                 return false;
             }
 
-            // Note: This maybe slow?
-            // Maybe pre calculate some sort of hash and compare that?
+            if (Data.Count != other.Data.Count)
+            {
+                return false;
+            }
+
             for (var index = 0; index < Data.Count; ++index)
             {
                 if (Data[index] != other.Data[index])
+                {
                     return false;
+                }
             }
 
             return true;

--- a/src/UglyToad.PdfPig.Tokens/StringToken.cs
+++ b/src/UglyToad.PdfPig.Tokens/StringToken.cs
@@ -59,6 +59,25 @@ namespace UglyToad.PdfPig.Tokens
         }
 
         /// <inheritdoc />
+        public bool Equals(IToken obj)
+        {
+            if (this == obj)
+                return true;
+
+            if (!(obj is StringToken other))
+            {
+                return false;
+            }
+
+            if (!EncodedWith.Equals(other.EncodedWith))
+            {
+                return false;
+            }
+
+            return Data.Equals(other.Data);
+        }
+
+        /// <inheritdoc />
         public override string ToString()
         {
             return $"({Data})";

--- a/src/UglyToad.PdfPig.Tokens/StringToken.cs
+++ b/src/UglyToad.PdfPig.Tokens/StringToken.cs
@@ -61,20 +61,17 @@ namespace UglyToad.PdfPig.Tokens
         /// <inheritdoc />
         public bool Equals(IToken obj)
         {
-            if (this == obj)
+            if (ReferenceEquals(this, obj))
+            {
                 return true;
+            }
 
             if (!(obj is StringToken other))
             {
                 return false;
             }
 
-            if (!EncodedWith.Equals(other.EncodedWith))
-            {
-                return false;
-            }
-
-            return Data.Equals(other.Data);
+            return EncodedWith.Equals(other.EncodedWith) && Data.Equals(other.Data);
         }
 
         /// <inheritdoc />

--- a/src/UglyToad.PdfPig/Writer/PdfMerger.cs
+++ b/src/UglyToad.PdfPig/Writer/PdfMerger.cs
@@ -16,8 +16,6 @@
     using Tokenization.Scanner;
     using Tokens;
     using Exceptions;
-    using Graphics.Operations;
-    using Fonts;
 
     /// <summary>
     /// Merges PDF documents into each other.
@@ -132,45 +130,35 @@
         {
             private const decimal DefaultVersion = 1.2m;
             
-            private readonly BuilderContext context = new BuilderContext();
-            private readonly List<IndirectReferenceToken> documentPages = new List<IndirectReferenceToken>();
-            private readonly IndirectReferenceToken rootPagesIndirectReference;
+            private readonly PdfStreamWriter context = new PdfStreamWriter();
+            private readonly List<IndirectReferenceToken> pagesTokenReferences = new List<IndirectReferenceToken>();
+            private readonly IndirectReferenceToken rootPagesReference;
 
             private decimal currentVersion = DefaultVersion;
-            private MemoryStream memory = new MemoryStream();
-
             private int pageCount = 0;
+            
+            private readonly Dictionary<IndirectReferenceToken, IndirectReferenceToken> referencesFromDocument =
+                new Dictionary<IndirectReferenceToken, IndirectReferenceToken>();
 
             public DocumentMerger()
             {
-                var reserved = context.ReserveNumber();
-                rootPagesIndirectReference = new IndirectReferenceToken(new IndirectReference(reserved, 0));
-
-                WriteHeaderToStream();
+                rootPagesReference = context.ReserveNumberToken();
             }
  
             public void AppendDocument(Catalog documentCatalog, decimal version, IPdfTokenScanner tokenScanner)
             {
-                if (memory == null)
-                {
-                    throw new ObjectDisposedException("Merger closed already");
-                }
-
                 currentVersion = Math.Max(version, currentVersion);
 
-                var (pagesReference, count) = CopyPagesTree(documentCatalog.PageTree, rootPagesIndirectReference, tokenScanner);
+                var (pagesReference, count) = CopyPagesTree(documentCatalog.PageTree, rootPagesReference, tokenScanner);
                 pageCount += count;
-                documentPages.Add(new IndirectReferenceToken(pagesReference.Number));
+                pagesTokenReferences.Add(pagesReference);
+
+                referencesFromDocument.Clear();
             }
 
             public byte[] Build()
             {
-                if (memory == null)
-                {
-                    throw new ObjectDisposedException("Merger closed already");
-                }
-
-                if (documentPages.Count < 1)
+                if (pagesTokenReferences.Count < 1)
                 {
                     throw new PdfDocumentFormatException("Empty document");
                 }
@@ -178,29 +166,23 @@
                 var pagesDictionary = new DictionaryToken(new Dictionary<NameToken, IToken>
                 {
                     { NameToken.Type, NameToken.Pages },
-                    { NameToken.Kids, new ArrayToken(documentPages) },
+                    { NameToken.Kids, new ArrayToken(pagesTokenReferences) },
                     { NameToken.Count, new NumericToken(pageCount) }
                 });
 
-                var pagesRef = context.WriteObject(memory, pagesDictionary, (int)rootPagesIndirectReference.Data.ObjectNumber);
+                var pagesRef = context.WriteToken( pagesDictionary, (int)rootPagesReference.Data.ObjectNumber);
 
                 var catalog = new DictionaryToken(new Dictionary<NameToken, IToken>
                 {
                     { NameToken.Type, NameToken.Catalog },
-                    { NameToken.Pages, new IndirectReferenceToken(pagesRef.Number) }
+                    { NameToken.Pages, pagesRef }
                 });
 
-                var catalogRef = context.WriteObject(memory, catalog);
-
-                TokenWriter.WriteCrossReferenceTable(context.ObjectOffsets, catalogRef, memory, null);
+                var catalogRef = context.WriteToken(catalog);
                 
-                if (currentVersion != DefaultVersion)
-                {
-                    memory.Seek(0, SeekOrigin.Begin);
-                    WriteHeaderToStream();
-                }
-
-                var bytes = memory.ToArray();
+                context.Flush(currentVersion, catalogRef);
+                
+                var bytes = context.ToArray();
 
                 Close();
 
@@ -209,22 +191,20 @@
 
             public void Close()
             {
-                memory?.Dispose();
-                memory = null;
+                context.Dispose();
             }
 
-            private (ObjectToken, int) CopyPagesTree(PageTreeNode treeNode, IndirectReferenceToken treeParentReference, IPdfTokenScanner tokenScanner)
+            private (IndirectReferenceToken, int) CopyPagesTree(PageTreeNode treeNode, IndirectReferenceToken treeParentReference, IPdfTokenScanner tokenScanner)
             {
                 Debug.Assert(!treeNode.IsPage);
-
-                var currentNodeReserved = context.ReserveNumber();
-                var currentNodeReference = new IndirectReferenceToken(new IndirectReference(currentNodeReserved, 0));
+                
+                var currentNodeReference = context.ReserveNumberToken();
 
                 var pageReferences = new List<IndirectReferenceToken>();
                 var nodeCount = 0;
                 foreach (var pageNode in treeNode.Children)
                 {
-                    ObjectToken newEntry;
+                    IndirectReferenceToken newEntry;
                     if (!pageNode.IsPage)
                     {
                         var count = 0;
@@ -237,7 +217,7 @@
                         ++nodeCount;
                     }
                     
-                    pageReferences.Add(new IndirectReferenceToken(newEntry.Number));
+                    pageReferences.Add(newEntry);
                 }
 
                 var newPagesNode = new Dictionary<NameToken, IToken>
@@ -260,10 +240,10 @@
 
                 var pagesDictionary = new DictionaryToken(newPagesNode);
 
-                return (context.WriteObject(memory, pagesDictionary, currentNodeReserved), nodeCount);
+                return (context.WriteToken(pagesDictionary, (int)currentNodeReference.Data.ObjectNumber), nodeCount);
             }
 
-            private ObjectToken CopyPageNode(PageTreeNode pageNode, IndirectReferenceToken parentPagesObject, IPdfTokenScanner tokenScanner)
+            private IndirectReferenceToken CopyPageNode(PageTreeNode pageNode, IndirectReferenceToken parentPagesObject, IPdfTokenScanner tokenScanner)
             {
                 Debug.Assert(pageNode.IsPage);
 
@@ -286,79 +266,111 @@
                     pageDictionary.Add(NameToken.Create(name), CopyToken(token, tokenScanner));
                 }
 
-                return context.WriteObject(memory, new DictionaryToken(pageDictionary));
+                return context.WriteToken(new DictionaryToken(pageDictionary));
             }
-
+            
             /// <summary>
             /// The purpose of this method is to resolve indirect reference. That mean copy the reference's content to the new document's stream
             /// and replace the indirect reference with the correct/new one
             /// </summary>
             /// <param name="tokenToCopy">Token to inspect for reference</param>
             /// <param name="tokenScanner">scanner get the content from the original document</param>
-            /// <returns>A copy of the token with all his content copied to the new document's stream</returns>
-            private IToken CopyToken(IToken tokenToCopy, IPdfTokenScanner tokenScanner)
+            /// <param name="deepCopy">Weather we want to create a new token for basic token(Ex. NumericToken) because the original could be modified</param>
+            /// <returns>A reference of the token that was copied. With all the reference updated</returns>
+            private IToken CopyToken(IToken tokenToCopy, IPdfTokenScanner tokenScanner, bool deepCopy = false)
             {
-                if (tokenToCopy is DictionaryToken dictionaryToken)
+                // This token need to be deep copied, because they could contain reference. So we have to update them.
+                switch (tokenToCopy)
                 {
-                    var newContent = new Dictionary<NameToken, IToken>();
-                    foreach (var setPair in dictionaryToken.Data)
+                    case DictionaryToken dictionaryToken:
                     {
-                        var name = setPair.Key;
-                        var token = setPair.Value;
-                        newContent.Add(NameToken.Create(name), CopyToken(token, tokenScanner));
-                    }
+                        var newContent = new Dictionary<NameToken, IToken>();
+                        foreach (var setPair in dictionaryToken.Data)
+                        {
+                            var name = setPair.Key;
+                            var token = setPair.Value;
+                            newContent.Add(NameToken.Create(name), CopyToken(token, tokenScanner, deepCopy));
+                        }
 
-                    return new DictionaryToken(newContent);
-                }
-                else if (tokenToCopy is ArrayToken arrayToken)
-                {
-                    var newArray = new List<IToken>(arrayToken.Length);
-                    foreach (var token in arrayToken.Data)
+                        return new DictionaryToken(newContent);
+                    }
+                    case ArrayToken arrayToken:
                     {
-                        newArray.Add(CopyToken(token, tokenScanner));
+                        var newArray = new List<IToken>(arrayToken.Length);
+                        foreach (var token in arrayToken.Data)
+                        {
+                            newArray.Add(CopyToken(token, tokenScanner, deepCopy));
+                        }
+
+                        return new ArrayToken(newArray);
                     }
+                    case IndirectReferenceToken referenceToken:
+                    {
+                        if (referencesFromDocument.TryGetValue(referenceToken, out var newReferenceToken))
+                        {
+                            return newReferenceToken;
+                        }
+                        
+                        var tokenObject = DirectObjectFinder.Get<IToken>(referenceToken.Data, tokenScanner);
 
-                    return new ArrayToken(newArray);
-                }
-                else if (tokenToCopy is IndirectReferenceToken referenceToken)
-                {
-                    var tokenObject = DirectObjectFinder.Get<IToken>(referenceToken.Data, tokenScanner);
+                        Debug.Assert(!(tokenObject is IndirectReferenceToken));
 
-                    Debug.Assert(!(tokenObject is IndirectReferenceToken));
+                        var newToken = CopyToken(tokenObject, tokenScanner, deepCopy);
+                        newReferenceToken = context.WriteToken(newToken);
+                        
+                        referencesFromDocument.Add(referenceToken, newReferenceToken);
+                        
+                        return newReferenceToken;
+                    }
+                    case StreamToken streamToken:
+                    {
+                        var properties = CopyToken(streamToken.StreamDictionary, tokenScanner, deepCopy) as DictionaryToken;
+                        Debug.Assert(properties != null);
 
-                    var newToken = CopyToken(tokenObject, tokenScanner);
-                    var objToken = context.WriteObject(memory, newToken);
-                    return new IndirectReferenceToken(objToken.Number);
+                        var bytes = deepCopy ? new List<byte>(streamToken.Data) : streamToken.Data;
+                        return new StreamToken(properties, bytes);
+                    }
+                    
+                    case ObjectToken _:
+                    {
+                        // This is because, since we don't write token directly to the stream. So can't know the offset.
+                        // The token would be invalid. Although I don't think the copy of an object token would ever happen
+                        throw new NotSupportedException("Copying a Object token is not supported");
+                    }
                 }
-                else if (tokenToCopy is StreamToken streamToken)
-                {
-                    var properties = CopyToken(streamToken.StreamDictionary, tokenScanner) as DictionaryToken;
-                    Debug.Assert(properties != null);
-                    return new StreamToken(properties, new List<byte>(streamToken.Data));
-                }
-                else // Non Complex Token - BooleanToken, NumericToken, NameToken, Etc...
-                {
+
+                if (!deepCopy)
                     return tokenToCopy;
+
+                // This tokens can't be deep copied
+                if (tokenToCopy is EndOfLineToken || tokenToCopy is NullToken || tokenToCopy is BooleanToken)
+                    return tokenToCopy;
+                
+                switch (tokenToCopy)
+                {
+                    case CommentToken commentToken:
+                        return new CommentToken(commentToken.Data);
+
+                    case HexToken hexToken:
+                        return new HexToken(hexToken.Data.ToCharArray());
+                    
+                    case InlineImageDataToken imageDataToken:
+                        return new InlineImageDataToken(imageDataToken.Data);
+                    
+                    case NameToken nameToken:
+                        return NameToken.Create(nameToken.Data);
+                    
+                    case NumericToken numericToken:
+                        return new NumericToken(numericToken.Data);
+                    
+                    case OperatorToken operatorToken:
+                        return OperatorToken.Create(operatorToken.Data);
+                    
+                    case StringToken stringToken:
+                        return new StringToken(stringToken.Data, stringToken.EncodedWith);
                 }
-            }
-
-            private void WriteHeaderToStream()
-            {
-                WriteString($"%PDF-{currentVersion:0.0}", memory);
-
-                memory.WriteText("%");
-                memory.WriteByte(169);
-                memory.WriteByte(205);
-                memory.WriteByte(196);
-                memory.WriteByte(210);
-                memory.WriteNewLine();
-            }
-
-            private static void WriteString(string text, Stream stream)
-            {
-                var bytes = OtherEncodings.StringAsLatin1Bytes(text);
-                stream.Write(bytes, 0, bytes.Length);
-                stream.WriteNewLine();
+                
+                throw new NotSupportedException($"Tried to deep copy {tokenToCopy.GetType()}");
             }
 
             private static bool IgnoreKeyForPagesNode(KeyValuePair<string, IToken> token)

--- a/src/UglyToad.PdfPig/Writer/PdfStreamWriter.cs
+++ b/src/UglyToad.PdfPig/Writer/PdfStreamWriter.cs
@@ -1,0 +1,164 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using UglyToad.PdfPig.Core;
+using UglyToad.PdfPig.Graphics.Operations;
+using UglyToad.PdfPig.Tokens;
+
+namespace UglyToad.PdfPig.Writer
+{
+    /// <summary>
+    /// This class would lazily flush all token. Allowing us to make changes to references without need to rewrite the whole stream
+    /// </summary>
+    internal class PdfStreamWriter : IDisposable
+    {
+        private readonly SortedSet<int> reservedNumbers = new SortedSet<int>();
+
+        private readonly Dictionary<IndirectReferenceToken, IToken> tokenReferences = new Dictionary<IndirectReferenceToken, IToken>();
+
+        public int CurrentNumber { get; private set; } = 1;
+
+        public Stream Stream { get; }
+
+        public PdfStreamWriter() : this(new MemoryStream()) { }
+
+        public PdfStreamWriter(Stream baseStream)
+        {
+            Stream = baseStream;
+        }
+        
+        public void Flush(decimal version, IndirectReferenceToken catalogReference)
+        {
+            if (catalogReference == null)
+                throw new ArgumentNullException(nameof(catalogReference));
+
+            WriteString($"%PDF-{version:0.0}", Stream);
+
+            Stream.WriteText("%");
+            Stream.WriteByte(169);
+            Stream.WriteByte(205);
+            Stream.WriteByte(196);
+            Stream.WriteByte(210);
+            Stream.WriteNewLine();
+
+            var offsets = new Dictionary<IndirectReference, long>();
+            ObjectToken catalogToken = null;
+            foreach(var pair in tokenReferences)
+            {
+                var referenceToken = pair.Key;
+                var token = pair.Value;
+                var offset = Stream.Position;
+                var obj = new ObjectToken(offset, referenceToken.Data, token);
+
+                TokenWriter.WriteToken(obj, Stream);
+
+                offsets.Add(referenceToken.Data, offset);
+
+                if (catalogToken == null && referenceToken == catalogReference)
+                {
+                    catalogToken = new ObjectToken(offset, referenceToken.Data, token);
+                }
+            }
+
+            if (catalogToken == null)
+            {
+                throw new Exception("Catalog object wasn't found");
+            }
+
+            // TODO: Support document information
+            TokenWriter.WriteCrossReferenceTable(offsets, catalogToken, Stream, null);
+        }
+
+        public IndirectReferenceToken WriteObject(IToken token, int? reservedNumber = null)
+        {
+            // if you can't consider deduplicating a token. 
+            // It must be because it's referenced by his child element, so you must have reserved a number before hand
+            // Example /Pages Obj
+            var canBeDuplicated = !reservedNumber.HasValue;
+            if (!canBeDuplicated)
+            {
+                if (!reservedNumbers.Remove(reservedNumber.Value))
+                {
+                    throw new InvalidOperationException("You can't reuse a reserved number");
+                }
+
+                // When we end up writing this token, all of his child would already have been added and checked for duplicate
+                return AddObject(token, reservedNumber.Value);
+            }
+
+            var reference = FindToken(token);
+            if (reference == null)
+            {
+                // TODO: Check his children
+                return AddObject(token, CurrentNumber++);
+            }
+
+            return reference;
+        }
+
+        private IndirectReferenceToken AddObject(IToken token, int reservedNumber)
+        {
+            var reference = new IndirectReference(reservedNumber, 0);
+            var referenceToken = new IndirectReferenceToken(reference);
+            tokenReferences.Add(referenceToken, token);
+            return referenceToken;
+        }
+
+        private IndirectReferenceToken FindToken(IToken token)
+        {
+            foreach(var pair in tokenReferences)
+            {
+                var reference = pair.Key;
+                var storedToken = pair.Value;
+                if (storedToken.Equals(token))
+                {
+                    return reference;
+                }
+            }
+
+            return null;
+        }
+
+        public int ReserveNumber()
+        {
+            var reserved = CurrentNumber;
+            reservedNumbers.Add(reserved);
+            CurrentNumber++;
+            return reserved;
+        }
+
+        public IndirectReferenceToken ReserveNumberToken() => new IndirectReferenceToken(new IndirectReference(ReserveNumber(), 0));
+
+        private static void WriteString(string text, Stream stream)
+        {
+            var bytes = OtherEncodings.StringAsLatin1Bytes(text);
+            stream.Write(bytes, 0, bytes.Length);
+            stream.WriteNewLine();
+        }
+
+        public byte[] ToArray()
+        {
+            if (!Stream.CanSeek)
+                throw new NotSupportedException("Stream can't seek");
+            
+            var currentPosition = Stream.Position;
+            Stream.Seek(0, SeekOrigin.Begin);
+
+            var bytes = new byte[Stream.Length];
+
+            // Should we slice the reading into smaller chunks?
+            if (Stream.Read(bytes, 0, bytes.Length) != bytes.Length)
+                throw new Exception("Unable to read all the bytes from stream");
+
+            Stream.Seek(currentPosition, SeekOrigin.Begin);
+
+            return bytes;
+        }
+
+        public void Dispose()
+        {
+            Stream.Dispose();
+        }
+    }
+}

--- a/src/UglyToad.PdfPig/Writer/PdfStreamWriter.cs
+++ b/src/UglyToad.PdfPig/Writer/PdfStreamWriter.cs
@@ -1,38 +1,37 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.IO;
-using UglyToad.PdfPig.Core;
-using UglyToad.PdfPig.Graphics.Operations;
-using UglyToad.PdfPig.Tokens;
-
-namespace UglyToad.PdfPig.Writer
+﻿namespace UglyToad.PdfPig.Writer
 {
+    using System;
+    using System.Collections.Generic;
+    using System.IO;
+    using Core;
+    using Graphics.Operations;
+    using Tokens;
+    
     /// <summary>
     /// This class would lazily flush all token. Allowing us to make changes to references without need to rewrite the whole stream
     /// </summary>
     internal class PdfStreamWriter : IDisposable
     {
-        private readonly SortedSet<int> reservedNumbers = new SortedSet<int>();
+        private readonly List<int> reservedNumbers = new List<int>();
 
         private readonly Dictionary<IndirectReferenceToken, IToken> tokenReferences = new Dictionary<IndirectReferenceToken, IToken>();
 
         public int CurrentNumber { get; private set; } = 1;
 
-        public Stream Stream { get; }
+        public Stream Stream { get; private set; }
 
         public PdfStreamWriter() : this(new MemoryStream()) { }
 
         public PdfStreamWriter(Stream baseStream)
         {
-            Stream = baseStream;
+            Stream = baseStream ?? throw new ArgumentNullException(nameof(baseStream));
         }
         
         public void Flush(decimal version, IndirectReferenceToken catalogReference)
         {
             if (catalogReference == null)
                 throw new ArgumentNullException(nameof(catalogReference));
-
+            
             WriteString($"%PDF-{version:0.0}", Stream);
 
             Stream.WriteText("%");
@@ -57,7 +56,7 @@ namespace UglyToad.PdfPig.Writer
 
                 if (catalogToken == null && referenceToken == catalogReference)
                 {
-                    catalogToken = new ObjectToken(offset, referenceToken.Data, token);
+                    catalogToken = obj;
                 }
             }
 
@@ -70,9 +69,9 @@ namespace UglyToad.PdfPig.Writer
             TokenWriter.WriteCrossReferenceTable(offsets, catalogToken, Stream, null);
         }
 
-        public IndirectReferenceToken WriteObject(IToken token, int? reservedNumber = null)
+        public IndirectReferenceToken WriteToken(IToken token, int? reservedNumber = null)
         {
-            // if you can't consider deduplicating a token. 
+            // if you can't consider deduplicating the token. 
             // It must be because it's referenced by his child element, so you must have reserved a number before hand
             // Example /Pages Obj
             var canBeDuplicated = !reservedNumber.HasValue;
@@ -84,20 +83,57 @@ namespace UglyToad.PdfPig.Writer
                 }
 
                 // When we end up writing this token, all of his child would already have been added and checked for duplicate
-                return AddObject(token, reservedNumber.Value);
+                return AddToken(token, reservedNumber.Value);
             }
 
             var reference = FindToken(token);
             if (reference == null)
             {
-                // TODO: Check his children
-                return AddObject(token, CurrentNumber++);
+                return AddToken(token, CurrentNumber++);
             }
 
             return reference;
         }
+        
+        public int ReserveNumber()
+        {
+            var reserved = CurrentNumber;
+            reservedNumbers.Add(reserved);
+            CurrentNumber++;
+            return reserved;
+        }
 
-        private IndirectReferenceToken AddObject(IToken token, int reservedNumber)
+        public IndirectReferenceToken ReserveNumberToken()
+        { 
+            return new IndirectReferenceToken(new IndirectReference(ReserveNumber(), 0));
+        }
+        
+        public byte[] ToArray()
+        {
+            if (!Stream.CanSeek)
+                throw new NotSupportedException($"{Stream.GetType()} can't seek");
+            
+            var currentPosition = Stream.Position;
+            Stream.Seek(0, SeekOrigin.Begin);
+
+            var bytes = new byte[Stream.Length];
+
+            // Should we slice the reading into smaller chunks?
+            if (Stream.Read(bytes, 0, bytes.Length) != bytes.Length)
+                throw new Exception("Unable to read all the bytes from stream");
+
+            Stream.Seek(currentPosition, SeekOrigin.Begin);
+
+            return bytes;
+        }
+
+        public void Dispose()
+        {
+            Stream?.Dispose();
+            Stream = null;
+        }
+        
+        private IndirectReferenceToken AddToken(IToken token, int reservedNumber)
         {
             var reference = new IndirectReference(reservedNumber, 0);
             var referenceToken = new IndirectReferenceToken(reference);
@@ -119,46 +155,12 @@ namespace UglyToad.PdfPig.Writer
 
             return null;
         }
-
-        public int ReserveNumber()
-        {
-            var reserved = CurrentNumber;
-            reservedNumbers.Add(reserved);
-            CurrentNumber++;
-            return reserved;
-        }
-
-        public IndirectReferenceToken ReserveNumberToken() => new IndirectReferenceToken(new IndirectReference(ReserveNumber(), 0));
-
+        
         private static void WriteString(string text, Stream stream)
         {
             var bytes = OtherEncodings.StringAsLatin1Bytes(text);
             stream.Write(bytes, 0, bytes.Length);
             stream.WriteNewLine();
-        }
-
-        public byte[] ToArray()
-        {
-            if (!Stream.CanSeek)
-                throw new NotSupportedException("Stream can't seek");
-            
-            var currentPosition = Stream.Position;
-            Stream.Seek(0, SeekOrigin.Begin);
-
-            var bytes = new byte[Stream.Length];
-
-            // Should we slice the reading into smaller chunks?
-            if (Stream.Read(bytes, 0, bytes.Length) != bytes.Length)
-                throw new Exception("Unable to read all the bytes from stream");
-
-            Stream.Seek(currentPosition, SeekOrigin.Begin);
-
-            return bytes;
-        }
-
-        public void Dispose()
-        {
-            Stream.Dispose();
         }
     }
 }


### PR DESCRIPTION
First attempt at trying to lower the binary size of merged document.  The first thing that I did was to 
create a heavy modified version of `UglyToad.PdfPig.Writer.Fonts.BuilderContext` as `UglyToad.PdfPig.Writer.PdfStreamWriter`. This class would be in charge of writing tokens to an arbitrary stream. Token would only be written once, as we push token to the stream, the class would make sure to look for token already written, returning an `IndirectReferenceToken` to it.

When we push token to `PdfStreamWriter`, if this token have a reserved number, it would be immediately pushed to the token list. On the contrary, if the token doesn't have a reserved number the complexity of the insertion would be `O(n) (n being the amount of token that have already being push)`, this is because we have to check that this token is not duplicated. I was thinking about reducing this complexity by grouping token by type, but this would need some design thoughts, so I left it as it is, so we can discuss it.

One thing to notice, this improvement would not improve all merged document, only those that share similar properties.

I would leave some comment on specific line to discuss some piece of code