### PR TITLE
added check for bad fonts see https://github.com/apache/pdfbox/blob/6…

### DIFF
--- a/src/UglyToad.PdfPig.Fonts/TrueType/Parser/HorizontalMetricsTableParser.cs
+++ b/src/UglyToad.PdfPig.Fonts/TrueType/Parser/HorizontalMetricsTableParser.cs
@@ -26,10 +26,18 @@
 
                 bytesRead += 4;
             }
-            
+
+            int numberNonHorizontal = glyphCount - metricCount;
+
+            // handle bad fonts with too many hmetrics
+            if (numberNonHorizontal < 0)
+            {
+                numberNonHorizontal = glyphCount;
+            }
+
             // The number of entries in the left side bearing field per entry is number of glyphs - number of metrics
             // For bearings over the metric count, the width is the same as the last width in advanced widths.
-            var additionalLeftSideBearings = new short[glyphCount - metricCount];
+            var additionalLeftSideBearings = new short[numberNonHorizontal];
 
             for (var i = 0; i < additionalLeftSideBearings.Length; i++)
             {


### PR DESCRIPTION
Was getting an error on parsing a PDF with PDFPig but not on PDFBox. Found this difference that fixed my issue with a bad font causing an "Array dimensions exceeded supported range" exception. 

I can tag this with an issue if you want.

The corresponding PDFBox code is here: https://github.com/apache/pdfbox/blob/61ceca8376f08f23f62178bd4fd97e919a690e43/fontbox/src/main/java/org/apache/fontbox/ttf/HorizontalMetricsTable.java