### PR TITLE
 Fix KdTree.FindNearestNeighbours(k) returning the pivot itself 

### DIFF
--- a/src/UglyToad.PdfPig.Core/PdfRectangle.cs
+++ b/src/UglyToad.PdfPig.Core/PdfRectangle.cs
@@ -81,6 +81,7 @@
 
         /// <summary>
         /// Rotation angle of the rectangle. Counterclockwise, in degrees.
+        /// <para>-180 ≤ θ ≤ 180</para>
         /// </summary>
         public double Rotation
         {
@@ -173,6 +174,9 @@
                                     BottomLeft.Translate(dx, dy), BottomRight.Translate(dx, dy));
         }
 
+        /// <summary>
+        /// -π ≤ θ ≤ π
+        /// </summary>
         private double GetT()
         {
             if (!BottomRight.Equals(BottomLeft))

--- a/src/UglyToad.PdfPig.DocumentLayoutAnalysis/Distances.cs
+++ b/src/UglyToad.PdfPig.DocumentLayoutAnalysis/Distances.cs
@@ -49,12 +49,13 @@
 
         /// <summary>
         /// The angle in degrees between the horizontal axis and the line between two points.
+        /// <para>-180 ≤ θ ≤ 180</para>
         /// </summary>
-        /// <param name="point1">The first point.</param>
-        /// <param name="point2">The second point.</param>
-        public static double Angle(PdfPoint point1, PdfPoint point2)
+        /// <param name="startPoint">The first point.</param>
+        /// <param name="endPoint">The second point.</param>
+        public static double Angle(PdfPoint startPoint, PdfPoint endPoint)
         {
-            return Math.Atan2(point2.Y - point1.Y, point2.X - point1.X) * 57.29577951;
+            return Math.Atan2(endPoint.Y - startPoint.Y, endPoint.X - startPoint.X) * 180 / Math.PI;
         }
 
         /// <summary>

--- a/src/UglyToad.PdfPig.DocumentLayoutAnalysis/KdTree.cs
+++ b/src/UglyToad.PdfPig.DocumentLayoutAnalysis/KdTree.cs
@@ -250,7 +250,7 @@
                 var point = pivotPointFunc(pivot);
                 var currentNearestNode = node;
                 var currentDistance = distance(node.Value, point);
-                if (!queue.IsFull || currentDistance <= queue.LastDistance)
+                if ((!queue.IsFull || currentDistance <= queue.LastDistance) && !node.Element.Equals(pivot))
                 {
                     queue.Add(currentDistance, currentNearestNode);
                     currentDistance = queue.LastDistance;

--- a/src/UglyToad.PdfPig/Content/Word.cs
+++ b/src/UglyToad.PdfPig/Content/Word.cs
@@ -333,33 +333,33 @@
             // Find the orientation of the OBB, using the baseline angle
             var firstLetter = letters[0];
             var lastLetter = letters[letters.Count - 1];
+
             var baseLineAngle = Math.Atan2(
                 lastLetter.EndBaseLine.Y - firstLetter.StartBaseLine.Y,
                 lastLetter.EndBaseLine.X - firstLetter.StartBaseLine.X) * 180 / Math.PI;
 
-            var bbox = obb;
-            var deltaAngle = Math.Abs(baseLineAngle - angleRad * 180 / Math.PI);
-
+            double deltaAngle = Math.Abs(baseLineAngle - obb.Rotation);
             double deltaAngle1 = Math.Abs(baseLineAngle - obb1.Rotation);
             if (deltaAngle1 < deltaAngle)
             {
                 deltaAngle = deltaAngle1;
-                bbox = obb1;
+                obb = obb1;
             }
 
             double deltaAngle2 = Math.Abs(baseLineAngle - obb2.Rotation);
             if (deltaAngle2 < deltaAngle)
             {
                 deltaAngle = deltaAngle2;
-                bbox = obb2;
+                obb = obb2;
             }
 
             double deltaAngle3 = Math.Abs(baseLineAngle - obb3.Rotation);
             if (deltaAngle3 < deltaAngle)
             {
-                bbox = obb3;
+                obb = obb3;
             }
-            return new Tuple<string, PdfRectangle>(builder.ToString(), bbox);
+
+            return new Tuple<string, PdfRectangle>(builder.ToString(), obb);
         }
         #endregion
 

--- a/src/UglyToad.PdfPig/Geometry/GeometryExtensions.cs
+++ b/src/UglyToad.PdfPig/Geometry/GeometryExtensions.cs
@@ -230,7 +230,7 @@
             var slope = sumProduct / sumDiffSquaredX;
 
             // Rotate the points to build the axis-aligned bounding box (AABB)
-            var angleRad = Math.Atan(slope);
+            var angleRad = Math.Atan(slope); // -π/2 ≤ θ ≤ π/2
             var cos = Math.Cos(angleRad);
             var sin = Math.Sin(angleRad);
 

--- a/src/UglyToad.PdfPig/Parser/PdfDocumentFactory.cs
+++ b/src/UglyToad.PdfPig/Parser/PdfDocumentFactory.cs
@@ -58,7 +58,7 @@
 
             var passwords = new List<string>();
 
-            var clipPaths = options?.ClipPaths ?? true;
+            var clipPaths = options?.ClipPaths ?? false;
 
             if (options?.Password != null)
             {


### PR DESCRIPTION
- Fix `KdTree.FindNearestNeighbours` returning the pivot itself when looking for k nearest neighbours
- Minors clarification doc changes