### PR TITLE
FIX Error when getting Encoding from an IndirectReferenceToken referencing a Name Token

### DIFF
--- a/src/UglyToad.PdfPig/PdfFonts/Parser/EncodingReader.cs
+++ b/src/UglyToad.PdfPig/PdfFonts/Parser/EncodingReader.cs
@@ -26,7 +26,7 @@
                 return null;
             }
 
-            if (baseEncodingObject is NameToken name)
+            if (DirectObjectFinder.TryGet(baseEncodingObject, pdfScanner, out NameToken name))
             {
                 if (TryGetNamedEncoding(descriptor, name, out var namedEncoding))
                 {


### PR DESCRIPTION
if baseEncodingObject is a IndirectReferenceToken to a NameToken the previous implementation tried to resolve it as a DictionaryToken, which resultet in an PdfFormatException.


