### PR TITLE
ADD : name on type 3 fonts

### DIFF
--- a/src/UglyToad.PdfPig/PdfFonts/Parser/Handlers/Type3FontHandler.cs
+++ b/src/UglyToad.PdfPig/PdfFonts/Parser/Handlers/Type3FontHandler.cs
@@ -58,14 +58,9 @@
 
         private NameToken GetFontName(DictionaryToken dictionary)
         {
-            if (!dictionary.TryGet(NameToken.Name, out var fontName))
+            if (dictionary.TryGet(NameToken.Name, scanner, out NameToken fontName))
             {
-                return NameToken.Type3;
-            }
-
-            if (fontName is NameToken nameToken)
-            {
-                return nameToken;
+                return fontName;
             }
 
             return NameToken.Type3;

--- a/src/UglyToad.PdfPig/PdfFonts/Parser/Handlers/Type3FontHandler.cs
+++ b/src/UglyToad.PdfPig/PdfFonts/Parser/Handlers/Type3FontHandler.cs
@@ -49,9 +49,26 @@
                     toUnicodeCMap = CMapCache.Parse(new ByteArrayInputBytes(decodedUnicodeCMap));
                 }
             }
-            
-            return new Type3Font(NameToken.Type3, boundingBox, fontMatrix, encoding, firstCharacter,
+
+            var name = GetFontName(dictionary);
+
+            return new Type3Font(name, boundingBox, fontMatrix, encoding, firstCharacter,
                 lastCharacter, widths, toUnicodeCMap);
+        }
+
+        private NameToken GetFontName(DictionaryToken dictionary)
+        {
+            if (!dictionary.TryGet(NameToken.Name, out var fontName))
+            {
+                return NameToken.Type3;
+            }
+
+            if (fontName is NameToken nameToken)
+            {
+                return nameToken;
+            }
+
+            return NameToken.Type3;
         }
 
         private TransformationMatrix GetFontMatrix(DictionaryToken dictionary)


### PR DESCRIPTION
I stumbled upon a type 3 font with a name, which seems required in PDF 1.0, according to the spec https://www.adobe.com/content/dam/acom/en/devnet/pdf/pdfs/PDF32000_2008.pdf 

The current code does not take it into account, this PR fixes that.