### PR TITLE
fix LinuxSystemFontLister not able to find any font

### DIFF
--- a/src/UglyToad.PdfPig.Fonts/SystemFonts/LinuxSystemFontLister.cs
+++ b/src/UglyToad.PdfPig.Fonts/SystemFonts/LinuxSystemFontLister.cs
@@ -19,6 +19,10 @@
             try
             {
                 var folder = Environment.GetEnvironmentVariable("$HOME");
+                if (string.IsNullOrWhiteSpace(folder))
+                {
+                    folder = Environment.GetEnvironmentVariable("HOME");
+                }
 
                 if (!string.IsNullOrWhiteSpace(folder))
                 {
@@ -48,7 +52,7 @@
 
                 try
                 {
-                    files = Directory.GetFiles(directory);
+                    files = Directory.GetFiles(directory, "*.*", SearchOption.AllDirectories);
                 }
                 catch
                 {

--- a/src/UglyToad.PdfPig.Tests/Fonts/SystemFonts/Linux.cs
+++ b/src/UglyToad.PdfPig.Tests/Fonts/SystemFonts/Linux.cs
@@ -1,0 +1,43 @@
+﻿using System.Collections.Generic;
+using UglyToad.PdfPig.Tests.Dla;
+using Xunit;
+
+namespace UglyToad.PdfPig.Tests.Fonts.SystemFonts
+{
+    public class Linux
+    {
+        public static IEnumerable<object[]> DataExtract => new[]
+         {
+            new object[]
+            {
+                "90 180 270 rotated.pdf",
+                new object[][]
+                {
+                    new object[] { "[(x:53.88, y:759.48), 2.495859375, 0]", 0.0 },
+                    new object[] { "[(x:514.925312502883, y:744.099765720344), 6.83203125, 7.94531249999983]", -90.0 },
+                    new object[] { "[(x:512.505390717836, y:736.603703191305), 5.1796875, 5.68945312499983]", -90.0 },
+                    new object[] { "[(x:512.505390785898, y:730.931828191305), 3.99609375, 5.52539062499994]", -90.0 },
+                }
+            },
+        };
+
+        [Theory]
+        [MemberData(nameof(DataExtract))]
+        public void GetCorrectBBoxLinux(string name, object[][] expected)
+        {
+            // success on Windows but LinuxSystemFontLister cannot find the 'TimesNewRomanPSMT' font
+            using (var document = PdfDocument.Open(DlaHelper.GetDocumentPath(name)))
+            {
+                var page = document.GetPage(1);
+                for (int i = 0; i < expected.Length; i++)
+                {
+                    string bbox = (string)expected[i][0];
+                    var rotation = (double)expected[i][1];
+                    var current = page.Letters[i];
+                    Assert.Equal(bbox, current.GlyphRectangle.ToString());
+                    Assert.Equal(rotation, current.GlyphRectangle.Rotation, 3);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
- `LinuxSystemFontLister` now checks both '$HOME' and 'HOME' environment variables. It was previously only checking '$HOME' (see [here](https://stackoverflow.com/questions/1143706/getting-the-path-of-the-home-directory-in-c), 'HOME' works on my linux computer);

- It will also check all sub-folders of candidate font folders (fonts are not in the root folder on my linux computer);

- PdfPig will still fail to correctly display the letters of "90 180 270 rotated.pdf" on Linux, as the **TimesNewRomanPSMT** font cannot be found. A check has been added. It work without any problem on windows but fails on linux. Test should be added for mac. **EDIT:** it seems to also fail on MacOs.