### PR TITLE
Make IOperationContext neutral

### DIFF
--- a/src/UglyToad.PdfPig.Core/PdfSubpath.cs
+++ b/src/UglyToad.PdfPig.Core/PdfSubpath.cs
@@ -162,7 +162,7 @@
         }
         
         /// <summary>
-        /// Adds 4 <see cref="Line"/>s forming a rectangle to the path.
+        /// Add a rectangle following the pdf specification (m, l, l, l, c) path. A new subpath is created.
         /// </summary>
         public void Rectangle(double x, double y, double width, double height)
         {

--- a/src/UglyToad.PdfPig.Tests/Graphics/TestOperationContext.cs
+++ b/src/UglyToad.PdfPig.Tests/Graphics/TestOperationContext.cs
@@ -1,12 +1,14 @@
 ﻿namespace UglyToad.PdfPig.Tests.Graphics
 {
-    using System.Collections.Generic;
     using Content;
     using PdfFonts;
+    using PdfPig.Core;
     using PdfPig.Graphics;
     using PdfPig.Tokens;
-    using PdfPig.Core;
+    using System.Collections.Generic;
     using Tokens;
+    using UglyToad.PdfPig.Graphics.Core;
+    using UglyToad.PdfPig.Graphics.Operations.TextPositioning;
 
     internal class TestOperationContext : IOperationContext
     {
@@ -88,6 +90,66 @@
 
         }
 
+        public void MoveTo(double x, double y)
+        {
+            BeginSubpath();
+            var point = CurrentTransformationMatrix.Transform(new PdfPoint(x, y));
+            CurrentPosition = point;
+            CurrentSubpath.MoveTo(point.X, point.Y);
+        }
+
+        public void BezierCurveTo(double x2, double y2, double x3, double y3)
+        {
+            if (CurrentSubpath == null)
+            {
+                return;
+            }
+
+            var controlPoint2 = CurrentTransformationMatrix.Transform(new PdfPoint(x2, y2));
+            var end = CurrentTransformationMatrix.Transform(new PdfPoint(x3, y3));
+
+            CurrentSubpath.BezierCurveTo(CurrentPosition.X, CurrentPosition.Y, controlPoint2.X, controlPoint2.Y, end.X, end.Y);
+            CurrentPosition = end;
+        }
+
+        public void BezierCurveTo(double x1, double y1, double x2, double y2, double x3, double y3)
+        {
+            if (CurrentSubpath == null)
+            {
+                return;
+            }
+
+            var controlPoint1 = CurrentTransformationMatrix.Transform(new PdfPoint(x1, y1));
+            var controlPoint2 = CurrentTransformationMatrix.Transform(new PdfPoint(x2, y2));
+            var end = CurrentTransformationMatrix.Transform(new PdfPoint(x3, y3));
+
+            CurrentSubpath.BezierCurveTo(controlPoint1.X, controlPoint1.Y, controlPoint2.X, controlPoint2.Y, end.X, end.Y);
+            CurrentPosition = end;
+        }
+
+        public void LineTo(double x, double y)
+        {
+            if (CurrentSubpath == null)
+            {
+                return;
+            }
+
+            var endPoint = CurrentTransformationMatrix.Transform(new PdfPoint(x, y));
+
+            CurrentSubpath.LineTo(endPoint.X, endPoint.Y);
+            CurrentPosition = endPoint;
+        }
+
+        public void Rectangle(double x, double y, double width, double height)
+        {
+            BeginSubpath();
+            var lowerLeft = CurrentTransformationMatrix.Transform(new PdfPoint(x, y));
+            var upperRight = CurrentTransformationMatrix.Transform(new PdfPoint(x + width, y + height));
+
+            CurrentSubpath.Rectangle(lowerLeft.X, lowerLeft.Y, upperRight.X - lowerLeft.X, upperRight.Y - lowerLeft.Y);
+            AddCurrentSubpath();
+        }
+
         public void EndPath()
         {
         }
@@ -122,6 +184,91 @@
 
         public void ModifyClippingIntersect(FillingRule clippingRule)
         {
+        }
+
+        private void AdjustTextMatrix(double tx, double ty)
+        {
+            var matrix = TransformationMatrix.GetTranslationMatrix(tx, ty);
+            TextMatrices.TextMatrix = matrix.Multiply(TextMatrices.TextMatrix);
+        }
+
+        public void SetFlatnessTolerance(decimal tolerance)
+        {
+            GetCurrentState().Flatness = tolerance;
+        }
+
+        public void SetLineCap(LineCapStyle cap)
+        {
+            GetCurrentState().CapStyle = cap;
+        }
+
+        public void SetLineDashPattern(LineDashPattern pattern)
+        {
+            GetCurrentState().LineDashPattern = pattern;
+        }
+
+        public void SetLineJoin(LineJoinStyle join)
+        {
+            GetCurrentState().JoinStyle = join;
+        }
+
+        public void SetLineWidth(decimal width)
+        {
+            GetCurrentState().LineWidth = width;
+        }
+
+        public void SetMiterLimit(decimal limit)
+        {
+            GetCurrentState().MiterLimit = limit;
+        }
+
+        public void MoveToNextLineWithOffset()
+        {
+            var tdOperation = new MoveToNextLineWithOffset(0, -1 * (decimal)GetCurrentState().FontState.Leading);
+            tdOperation.Run(this);
+        }
+
+        public void SetFontAndSize(NameToken font, double size)
+        {
+            var currentState = GetCurrentState();
+            currentState.FontState.FontSize = size;
+            currentState.FontState.FontName = font;
+        }
+
+        public void SetHorizontalScaling(double scale)
+        {
+            GetCurrentState().FontState.HorizontalScaling = scale;
+        }
+
+        public void SetTextLeading(double leading)
+        {
+            GetCurrentState().FontState.Leading = leading;
+        }
+
+        public void SetTextRenderingMode(TextRenderingMode mode)
+        {
+            GetCurrentState().FontState.TextRenderingMode = mode;
+        }
+
+        public void SetTextRise(double rise)
+        {
+            GetCurrentState().FontState.Rise = rise;
+        }
+
+        public void SetWordSpacing(double spacing)
+        {
+            GetCurrentState().FontState.WordSpacing = spacing;
+        }
+
+        public void ModifyCurrentTransformationMatrix(double[] value)
+        {
+            var ctm = GetCurrentState().CurrentTransformationMatrix;
+            GetCurrentState().CurrentTransformationMatrix = TransformationMatrix.FromArray(value).Multiply(ctm);
+        }
+
+        public void SetCharacterSpacing(double spacing)
+        {
+            GetCurrentState().FontState.CharacterSpacing = spacing;
         }
 
         private class TestFontFactory : IFontFactory

--- a/src/UglyToad.PdfPig.Tests/PublicApiScannerTests.cs
+++ b/src/UglyToad.PdfPig.Tests/PublicApiScannerTests.cs
@@ -1,10 +1,10 @@
 ﻿namespace UglyToad.PdfPig.Tests
 {
+    using PdfPig.Graphics.Operations;
     using System;
     using System.Collections.Generic;
     using System.Linq;
     using System.Reflection;
-    using PdfPig.Graphics.Operations;
     using Xunit;
 
     public class PublicApiScannerTests
@@ -64,6 +64,7 @@
                 "UglyToad.PdfPig.Annotations.AnnotationFlags",
                 "UglyToad.PdfPig.Annotations.AnnotationType",
                 "UglyToad.PdfPig.Annotations.QuadPointsQuadrilateral",
+                "UglyToad.PdfPig.BaseDrawingProcessor",
                 "UglyToad.PdfPig.Content.ArtifactMarkedContentElement",
                 "UglyToad.PdfPig.Content.Catalog",
                 "UglyToad.PdfPig.Content.CropBox",
@@ -186,6 +187,7 @@
                 "UglyToad.PdfPig.Graphics.Operations.TextState.Type3SetGlyphWidth",
                 "UglyToad.PdfPig.Graphics.Operations.TextState.Type3SetGlyphWidthAndBoundingBox",
                 "UglyToad.PdfPig.Graphics.TextMatrices",
+                "UglyToad.PdfPig.IDrawingProcessor",
                 "UglyToad.PdfPig.Logging.ILog",
                 "UglyToad.PdfPig.Outline.Bookmarks",
                 "UglyToad.PdfPig.Outline.BookmarkNode",

--- a/src/UglyToad.PdfPig/CrossReference/CrossReferenceTableBuilder.cs
+++ b/src/UglyToad.PdfPig/CrossReference/CrossReferenceTableBuilder.cs
@@ -1,14 +1,14 @@
 ﻿namespace UglyToad.PdfPig.CrossReference
 {
+    using Core;
+    using Logging;
     using System;
     using System.Collections.Generic;
     using System.Linq;
-    using Core;
-    using Logging;
     using Tokens;
 
     /// <summary>
-    /// 
+    /// Cross reference table builder
     /// </summary>
     /// <remarks>
     /// The table contains a one-line entry for each indirect object, specifying the location of that object within the body of the file. 

--- a/src/UglyToad.PdfPig/Graphics/ContentStreamProcessor.cs
+++ b/src/UglyToad.PdfPig/Graphics/ContentStreamProcessor.cs
@@ -1,9 +1,5 @@
 ﻿namespace UglyToad.PdfPig.Graphics
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Diagnostics;
-    using System.Linq;
     using Colors;
     using Content;
     using Core;
@@ -14,8 +10,13 @@
     using Parser;
     using PdfFonts;
     using PdfPig.Core;
+    using System;
+    using System.Collections.Generic;
+    using System.Diagnostics;
+    using System.Linq;
     using Tokenization.Scanner;
     using Tokens;
+    using UglyToad.PdfPig.Graphics.Operations.TextPositioning;
     using XObjects;
     using static PdfPig.Core.PdfSubpath;
 
@@ -573,7 +574,67 @@
 
             ClosePath();
         }
-        
+
+        public void MoveTo(double x, double y)
+        {
+            BeginSubpath();
+            var point = CurrentTransformationMatrix.Transform(new PdfPoint(x, y));
+            CurrentPosition = point;
+            CurrentSubpath.MoveTo(point.X, point.Y);
+        }
+
+        public void BezierCurveTo(double x2, double y2, double x3, double y3)
+        {
+            if (CurrentSubpath == null)
+            {
+                return;
+            }
+
+            var controlPoint2 = CurrentTransformationMatrix.Transform(new PdfPoint(x2, y2));
+            var end = CurrentTransformationMatrix.Transform(new PdfPoint(x3, y3));
+
+            CurrentSubpath.BezierCurveTo(CurrentPosition.X, CurrentPosition.Y, controlPoint2.X, controlPoint2.Y, end.X, end.Y);
+            CurrentPosition = end;
+        }
+
+        public void BezierCurveTo(double x1, double y1, double x2, double y2, double x3, double y3)
+        {
+            if (CurrentSubpath == null)
+            {
+                return;
+            }
+
+            var controlPoint1 = CurrentTransformationMatrix.Transform(new PdfPoint(x1, y1));
+            var controlPoint2 = CurrentTransformationMatrix.Transform(new PdfPoint(x2, y2));
+            var end = CurrentTransformationMatrix.Transform(new PdfPoint(x3, y3));
+
+            CurrentSubpath.BezierCurveTo(controlPoint1.X, controlPoint1.Y, controlPoint2.X, controlPoint2.Y, end.X, end.Y);
+            CurrentPosition = end;
+        }
+
+        public void LineTo(double x, double y)
+        {
+            if (CurrentSubpath == null)
+            {
+                return;
+            }
+
+            var endPoint = CurrentTransformationMatrix.Transform(new PdfPoint(x, y));
+
+            CurrentSubpath.LineTo(endPoint.X, endPoint.Y);
+            CurrentPosition = endPoint;
+        }
+
+        public void Rectangle(double x, double y, double width, double height)
+        {
+            BeginSubpath();
+            var lowerLeft = CurrentTransformationMatrix.Transform(new PdfPoint(x, y));
+            var upperRight = CurrentTransformationMatrix.Transform(new PdfPoint(x + width, y + height));
+
+            CurrentSubpath.Rectangle(lowerLeft.X, lowerLeft.Y, upperRight.X - lowerLeft.X, upperRight.Y - lowerLeft.Y);
+            AddCurrentSubpath();
+        }
+
         public void EndPath()
         {
             if (CurrentPath == null)
@@ -757,17 +818,96 @@
             if (markedContentStack.CanPop)
             {
                 var mc = markedContentStack.Pop(pdfScanner);
-                if (mc != null) markedContents.Add(mc);
+                if (mc != null)
+                {
+                    markedContents.Add(mc);
+                }
             }
         }
 
         private void AdjustTextMatrix(double tx, double ty)
         {
             var matrix = TransformationMatrix.GetTranslationMatrix(tx, ty);
+            TextMatrices.TextMatrix = matrix.Multiply(TextMatrices.TextMatrix);
+        }
 
-            var newMatrix = matrix.Multiply(TextMatrices.TextMatrix);
+        public void SetFlatnessTolerance(decimal tolerance)
+        {
+            GetCurrentState().Flatness = tolerance;
+        }
 
-            TextMatrices.TextMatrix = newMatrix;
+        public void SetLineCap(LineCapStyle cap)
+        {
+            GetCurrentState().CapStyle = cap;
+        }
+
+        public void SetLineDashPattern(LineDashPattern pattern)
+        {
+            GetCurrentState().LineDashPattern = pattern;
+        }
+
+        public void SetLineJoin(LineJoinStyle join)
+        {
+            GetCurrentState().JoinStyle = join;
+        }
+
+        public void SetLineWidth(decimal width)
+        {
+            GetCurrentState().LineWidth = width;
+        }
+
+        public void SetMiterLimit(decimal limit)
+        {
+            GetCurrentState().MiterLimit = limit;
+        }
+
+        public void MoveToNextLineWithOffset()
+        {
+            var tdOperation = new MoveToNextLineWithOffset(0, -1 * (decimal)GetCurrentState().FontState.Leading);
+            tdOperation.Run(this);
+        }
+
+        public void SetFontAndSize(NameToken font, double size)
+        {
+            var currentState = GetCurrentState();
+            currentState.FontState.FontSize = size;
+            currentState.FontState.FontName = font;
+        }
+
+        public void SetHorizontalScaling(double scale)
+        {
+            GetCurrentState().FontState.HorizontalScaling = scale;
+        }
+
+        public void SetTextLeading(double leading)
+        {
+            GetCurrentState().FontState.Leading = leading;
+        }
+
+        public void SetTextRenderingMode(TextRenderingMode mode)
+        {
+            GetCurrentState().FontState.TextRenderingMode = mode;
+        }
+
+        public void SetTextRise(double rise)
+        {
+            GetCurrentState().FontState.Rise = rise;
+        }
+
+        public void SetWordSpacing(double spacing)
+        {
+            GetCurrentState().FontState.WordSpacing = spacing;
+        }
+
+        public void ModifyCurrentTransformationMatrix(double[] value)
+        {
+            var ctm = GetCurrentState().CurrentTransformationMatrix;
+            GetCurrentState().CurrentTransformationMatrix = TransformationMatrix.FromArray(value).Multiply(ctm);
+        }
+
+        public void SetCharacterSpacing(double spacing)
+        {
+            GetCurrentState().FontState.CharacterSpacing = spacing;
         }
     }
 }

--- a/src/UglyToad.PdfPig/Graphics/IOperationContext.cs
+++ b/src/UglyToad.PdfPig/Graphics/IOperationContext.cs
@@ -4,27 +4,12 @@
     using System.Collections.Generic;
     using Tokens;
     using UglyToad.PdfPig.Graphics.Core;
-    //using Util.JetBrains.Annotations;
 
     /// <summary>
     /// The current graphics state context when running a PDF content stream.
     /// </summary>
     public interface IOperationContext
     {
-        /*
-        /// <summary>
-        /// The current subpath being drawn if applicable.
-        /// </summary>
-        [CanBeNull]
-        PdfSubpath CurrentSubpath { get; }
-
-        /// <summary>
-        /// The current path being drawn if applicable.
-        /// </summary>
-        [CanBeNull]
-        PdfPath CurrentPath { get; }
-        */
-
         /// <summary>
         /// The active colorspaces for this content stream.
         /// </summary>

--- a/src/UglyToad.PdfPig/Graphics/IOperationContext.cs
+++ b/src/UglyToad.PdfPig/Graphics/IOperationContext.cs
@@ -3,13 +3,15 @@
     using PdfPig.Core;
     using System.Collections.Generic;
     using Tokens;
-    using Util.JetBrains.Annotations;
+    using UglyToad.PdfPig.Graphics.Core;
+    //using Util.JetBrains.Annotations;
 
     /// <summary>
     /// The current graphics state context when running a PDF content stream.
     /// </summary>
     public interface IOperationContext
     {
+        /*
         /// <summary>
         /// The current subpath being drawn if applicable.
         /// </summary>
@@ -21,6 +23,7 @@
         /// </summary>
         [CanBeNull]
         PdfPath CurrentPath { get; }
+        */
 
         /// <summary>
         /// The active colorspaces for this content stream.
@@ -33,20 +36,9 @@
         PdfPoint CurrentPosition { get; set; }
 
         /// <summary>
-        /// Get the currently active <see cref="CurrentGraphicsState"/>. States are stored on a stack structure.
-        /// </summary>
-        /// <returns>The currently active graphics state.</returns>
-        CurrentGraphicsState GetCurrentState();
-
-        /// <summary>
         /// The matrices for the current text state.
         /// </summary>
         TextMatrices TextMatrices { get; }
-
-        /// <summary>
-        /// The current transformation matrix
-        /// </summary>
-        TransformationMatrix CurrentTransformationMatrix { get; }
 
         /// <summary>
         /// The number of graphics states on the stack.
@@ -117,6 +109,46 @@
         void FillStrokePath(FillingRule fillingRule, bool close);
 
         /// <summary>
+        /// Add a move command to the path.
+        /// <para>Points are NOT transformed.</para>
+        /// </summary>
+        void MoveTo(double x, double y);
+
+        /// <summary>
+        /// Add a bezier curve to the current subpath.
+        /// <para>Points are NOT transformed.</para>
+        /// </summary>
+        /// <param name="x1"></param>
+        /// <param name="y1"></param>
+        /// <param name="x2"></param>
+        /// <param name="y2"></param>
+        /// <param name="x3"></param>
+        /// <param name="y3"></param>
+        void BezierCurveTo(double x1, double y1, double x2, double y2, double x3, double y3);
+
+        /// <summary>
+        /// Add a bezier curve to the current subpath.
+        /// <para>Points are NOT transformed.</para>
+        /// </summary>
+        /// <param name="x2"></param>
+        /// <param name="y2"></param>
+        /// <param name="x3"></param>
+        /// <param name="y3"></param>
+        void BezierCurveTo(double x2, double y2, double x3, double y3);
+
+        /// <summary>
+        /// Add a line command to the subpath.
+        /// <para>Points are NOT transformed.</para>
+        /// </summary>
+        void LineTo(double x, double y);
+
+        /// <summary>
+        /// Add a rectangle following the pdf specification (m, l, l, l, c) path. A new subpath will be created.
+        /// <para>Points are NOT transformed.</para>
+        /// </summary>
+        void Rectangle(double x, double y, double width, double height);
+
+        /// <summary>
         /// End the path object without filling or stroking it. This operator shall be a path-painting no-op,
         /// used primarily for the side effect of changing the current clipping path (see 8.5.4, "Clipping Path Operators").
         /// </summary>
@@ -162,5 +194,90 @@
         /// Modify the clipping rule of the current path.
         /// </summary>
         void ModifyClippingIntersect(FillingRule clippingRule);
+
+        /// <summary>
+        /// Set the flatness tolerance in the graphics state.
+        /// Flatness is a number in the range 0 to 100; a value of 0 specifies the output device’s default flatness tolerance.
+        /// </summary>
+        /// <param name="tolerance"></param>
+        void SetFlatnessTolerance(decimal tolerance);
+
+        /// <summary>
+        /// Set the line cap style in the graphics state.
+        /// </summary>
+        void SetLineCap(LineCapStyle cap);
+
+        /// <summary>
+        /// Set the line dash pattern in the graphics state.
+        /// </summary>
+        void SetLineDashPattern(LineDashPattern pattern);
+
+        /// <summary>
+        /// Set the line join style in the graphics state.
+        /// </summary>
+        void SetLineJoin(LineJoinStyle join);
+
+        /// <summary>
+        /// Set the line width in the graphics state.
+        /// </summary>
+        void SetLineWidth(decimal width);
+
+        /// <summary>
+        /// Set the miter limit in the graphics state.
+        /// </summary>
+        void SetMiterLimit(decimal limit);
+
+        /// <summary>
+        /// Move to the start of the next line.
+        /// </summary>
+        /// <remarks>
+        /// This performs this operation: 0 -Tl Td
+        /// The offset is negative leading text (Tl) value, this is incorrect in the specification.
+        /// </remarks>
+        void MoveToNextLineWithOffset();
+
+        /// <summary>
+        /// Set the font and the font size.
+        /// Font is the name of a font resource in the Font subdictionary of the current resource dictionary.
+        /// Size is a number representing a scale factor.
+        /// </summary>
+        void SetFontAndSize(NameToken font, double size);
+
+        /// <summary>
+        /// Set the horizontal scaling.
+        /// </summary>
+        /// <param name="scale"></param>
+        void SetHorizontalScaling(double scale);
+
+        /// <summary>
+        /// Set the text leading.
+        /// </summary>
+        void SetTextLeading(double leading);
+
+        /// <summary>
+        /// Set the text rendering mode.
+        /// </summary>
+        void SetTextRenderingMode(TextRenderingMode mode);
+
+        /// <summary>
+        /// Set text rise.
+        /// </summary>
+        void SetTextRise(double rise);
+
+        /// <summary>
+        /// Sets the word spacing.
+        /// </summary>
+        void SetWordSpacing(double spacing);
+
+        /// <summary>
+        /// Modify the current transformation matrix by concatenating the specified matrix.
+        /// </summary>
+        void ModifyCurrentTransformationMatrix(double[] value);
+
+        /// <summary>
+        /// Set the character spacing to a number expressed in unscaled text space units.
+        /// Initial value: 0.
+        /// </summary>
+        void SetCharacterSpacing(double spacing);
     }
 }

--- a/src/UglyToad.PdfPig/Graphics/Operations/General/SetFlatnessTolerance.cs
+++ b/src/UglyToad.PdfPig/Graphics/Operations/General/SetFlatnessTolerance.cs
@@ -4,7 +4,7 @@
 
     /// <inheritdoc />
     /// <summary>
-    /// Set the flatness tolerance in the graphics state. 
+    /// Set the flatness tolerance in the graphics state.
     /// Flatness is a number in the range 0 to 100; a value of 0 specifies the output device’s default flatness tolerance.
     /// </summary>
     public class SetFlatnessTolerance : IGraphicsStateOperation
@@ -35,7 +35,7 @@
         /// <inheritdoc />
         public void Run(IOperationContext operationContext)
         {
-            operationContext.GetCurrentState().Flatness = Tolerance;
+            operationContext.SetFlatnessTolerance(Tolerance);
         }
 
         /// <inheritdoc />

--- a/src/UglyToad.PdfPig/Graphics/Operations/General/SetLineCap.cs
+++ b/src/UglyToad.PdfPig/Graphics/Operations/General/SetLineCap.cs
@@ -1,8 +1,8 @@
 ﻿namespace UglyToad.PdfPig.Graphics.Operations.General
 {
+    using Core;
     using System;
     using System.IO;
-    using Core;
 
     /// <inheritdoc />
     /// <summary>
@@ -45,7 +45,7 @@
         /// <inheritdoc />
         public void Run(IOperationContext operationContext)
         {
-            operationContext.GetCurrentState().CapStyle = Cap;
+            operationContext.SetLineCap(Cap);
         }
 
         /// <inheritdoc />

--- a/src/UglyToad.PdfPig/Graphics/Operations/General/SetLineDashPattern.cs
+++ b/src/UglyToad.PdfPig/Graphics/Operations/General/SetLineDashPattern.cs
@@ -1,7 +1,7 @@
 ﻿namespace UglyToad.PdfPig.Graphics.Operations.General
 {
-    using System.IO;
     using Core;
+    using System.IO;
 
     /// <inheritdoc />
     /// <summary>
@@ -33,7 +33,7 @@
         /// <inheritdoc />
         public void Run(IOperationContext operationContext)
         {
-            operationContext.GetCurrentState().LineDashPattern = Pattern;
+            operationContext.SetLineDashPattern(Pattern);
         }
 
         /// <inheritdoc />

--- a/src/UglyToad.PdfPig/Graphics/Operations/General/SetLineJoin.cs
+++ b/src/UglyToad.PdfPig/Graphics/Operations/General/SetLineJoin.cs
@@ -1,8 +1,8 @@
 ﻿namespace UglyToad.PdfPig.Graphics.Operations.General
 {
+    using Core;
     using System;
     using System.IO;
-    using Core;
 
     /// <inheritdoc />
     public class SetLineJoin : IGraphicsStateOperation
@@ -40,7 +40,7 @@
         /// <inheritdoc />
         public void Run(IOperationContext operationContext)
         {
-            operationContext.GetCurrentState().JoinStyle = Join;
+            operationContext.SetLineJoin(Join);
         }
 
         /// <inheritdoc />

--- a/src/UglyToad.PdfPig/Graphics/Operations/General/SetLineWidth.cs
+++ b/src/UglyToad.PdfPig/Graphics/Operations/General/SetLineWidth.cs
@@ -33,9 +33,7 @@
         /// <inheritdoc />
         public void Run(IOperationContext operationContext)
         {
-            var currentState = operationContext.GetCurrentState();
-
-            currentState.LineWidth = Width;
+            operationContext.SetLineWidth(Width);
         }
 
         /// <inheritdoc />

--- a/src/UglyToad.PdfPig/Graphics/Operations/General/SetMiterLimit.cs
+++ b/src/UglyToad.PdfPig/Graphics/Operations/General/SetMiterLimit.cs
@@ -33,9 +33,7 @@
         /// <inheritdoc />
         public void Run(IOperationContext operationContext)
         {
-            var currentState = operationContext.GetCurrentState();
-
-            currentState.MiterLimit = Limit;
+            operationContext.SetMiterLimit(Limit);
         }
 
         /// <inheritdoc />

--- a/src/UglyToad.PdfPig/Graphics/Operations/PathConstruction/AppendDualControlPointBezierCurve.cs
+++ b/src/UglyToad.PdfPig/Graphics/Operations/PathConstruction/AppendDualControlPointBezierCurve.cs
@@ -1,7 +1,6 @@
 ﻿namespace UglyToad.PdfPig.Graphics.Operations.PathConstruction
 {
     using System.IO;
-    using PdfPig.Core;
 
     /// <inheritdoc />
     /// <summary>
@@ -65,20 +64,12 @@
             Y2 = y2;
             X3 = x3;
             Y3 = y3;
-
         }
 
         /// <inheritdoc />
         public void Run(IOperationContext operationContext)
         {
-            if (operationContext.CurrentSubpath == null) return;
-
-            var controlPoint1 = operationContext.CurrentTransformationMatrix.Transform(new PdfPoint(X1, Y1));
-            var controlPoint2 = operationContext.CurrentTransformationMatrix.Transform(new PdfPoint(X2, Y2));
-            var end = operationContext.CurrentTransformationMatrix.Transform(new PdfPoint(X3, Y3));
-            operationContext.CurrentSubpath.BezierCurveTo(controlPoint1.X, controlPoint1.Y,
-                controlPoint2.X, controlPoint2.Y, end.X, end.Y);
-            operationContext.CurrentPosition = end;
+            operationContext.BezierCurveTo((double)X1, (double)Y1, (double)X2, (double)Y2, (double)X3, (double)Y3);
         }
 
         /// <inheritdoc />

--- a/src/UglyToad.PdfPig/Graphics/Operations/PathConstruction/AppendEndControlPointBezierCurve.cs
+++ b/src/UglyToad.PdfPig/Graphics/Operations/PathConstruction/AppendEndControlPointBezierCurve.cs
@@ -1,7 +1,6 @@
 ﻿namespace UglyToad.PdfPig.Graphics.Operations.PathConstruction
 {
     using System.IO;
-    using PdfPig.Core;
 
     /// <inheritdoc />
     /// <summary>
@@ -52,16 +51,11 @@
             X3 = x3;
             Y3 = y3;
         }
-        
+
         /// <inheritdoc />
         public void Run(IOperationContext operationContext)
         {
-            if (operationContext.CurrentSubpath == null) return;
-
-            var controlPoint1 = operationContext.CurrentTransformationMatrix.Transform(new PdfPoint(X1, Y1));
-            var end = operationContext.CurrentTransformationMatrix.Transform(new PdfPoint(X3, Y3));
-            operationContext.CurrentSubpath.BezierCurveTo(controlPoint1.X, controlPoint1.Y, end.X, end.Y, end.X, end.Y);
-            operationContext.CurrentPosition = end;
+            operationContext.BezierCurveTo((double)X1, (double)Y1, (double)X3, (double)Y3, (double)X3, (double)Y3);
         }
 
         /// <inheritdoc />

--- a/src/UglyToad.PdfPig/Graphics/Operations/PathConstruction/AppendRectangle.cs
+++ b/src/UglyToad.PdfPig/Graphics/Operations/PathConstruction/AppendRectangle.cs
@@ -1,7 +1,6 @@
 ﻿namespace UglyToad.PdfPig.Graphics.Operations.PathConstruction
 {
     using System.IO;
-    using PdfPig.Core;
 
     /// <inheritdoc />
     /// <remarks>
@@ -56,12 +55,7 @@
         /// <inheritdoc />
         public void Run(IOperationContext operationContext)
         {
-            operationContext.BeginSubpath();
-            var lowerLeft = operationContext.CurrentTransformationMatrix.Transform(new PdfPoint(LowerLeftX, LowerLeftY));
-            var upperRight = operationContext.CurrentTransformationMatrix.Transform(new PdfPoint(LowerLeftX + Width, LowerLeftY + Height));
-
-            operationContext.CurrentSubpath.Rectangle(lowerLeft.X, lowerLeft.Y, upperRight.X - lowerLeft.X, upperRight.Y - lowerLeft.Y);
-            operationContext.AddCurrentSubpath();
+            operationContext.Rectangle((double)LowerLeftX, (double)LowerLeftY, (double)Width, (double)Height);
         }
 
         /// <inheritdoc />

--- a/src/UglyToad.PdfPig/Graphics/Operations/PathConstruction/AppendStartControlPointBezierCurve.cs
+++ b/src/UglyToad.PdfPig/Graphics/Operations/PathConstruction/AppendStartControlPointBezierCurve.cs
@@ -1,7 +1,6 @@
 ﻿namespace UglyToad.PdfPig.Graphics.Operations.PathConstruction
 {
     using System.IO;
-    using PdfPig.Core;
 
     /// <inheritdoc />
     /// <summary>
@@ -56,17 +55,7 @@
         /// <inheritdoc />
         public void Run(IOperationContext operationContext)
         {
-            if (operationContext.CurrentSubpath == null) return;
-
-            var controlPoint2 = operationContext.CurrentTransformationMatrix.Transform(new PdfPoint(X2, Y2));
-            var end = operationContext.CurrentTransformationMatrix.Transform(new PdfPoint(X3, Y3));
-            operationContext.CurrentSubpath.BezierCurveTo(operationContext.CurrentPosition.X,
-                operationContext.CurrentPosition.Y,
-                controlPoint2.X,
-                controlPoint2.Y,
-                end.X,
-                end.Y);
-            operationContext.CurrentPosition = end;
+            operationContext.BezierCurveTo((double)X2, (double)Y2, (double)X3, (double)Y3);
         }
 
         /// <inheritdoc />

--- a/src/UglyToad.PdfPig/Graphics/Operations/PathConstruction/AppendStraightLineSegment.cs
+++ b/src/UglyToad.PdfPig/Graphics/Operations/PathConstruction/AppendStraightLineSegment.cs
@@ -1,7 +1,6 @@
 ﻿namespace UglyToad.PdfPig.Graphics.Operations.PathConstruction
 {
     using System.IO;
-    using PdfPig.Core;
 
     /// <inheritdoc />
     /// <summary>
@@ -41,11 +40,7 @@
         /// <inheritdoc />
         public void Run(IOperationContext operationContext)
         {
-            if (operationContext.CurrentSubpath == null) return;
-
-            var endPoint = operationContext.CurrentTransformationMatrix.Transform(new PdfPoint(X, Y));
-            operationContext.CurrentSubpath.LineTo(endPoint.X, endPoint.Y);
-            operationContext.CurrentPosition = endPoint;
+            operationContext.LineTo((double)X, (double)Y);
         }
 
         /// <inheritdoc />

--- a/src/UglyToad.PdfPig/Graphics/Operations/PathConstruction/BeginNewSubpath.cs
+++ b/src/UglyToad.PdfPig/Graphics/Operations/PathConstruction/BeginNewSubpath.cs
@@ -1,7 +1,6 @@
 ﻿namespace UglyToad.PdfPig.Graphics.Operations.PathConstruction
 {
     using System.IO;
-    using PdfPig.Core;
 
     /// <inheritdoc />
     /// <summary>
@@ -41,10 +40,7 @@
         /// <inheritdoc />
         public void Run(IOperationContext operationContext)
         {
-            operationContext.BeginSubpath();
-            var point = operationContext.CurrentTransformationMatrix.Transform(new PdfPoint(X, Y));
-            operationContext.CurrentPosition = point;
-            operationContext.CurrentSubpath.MoveTo(point.X, point.Y);
+            operationContext.MoveTo((double)X, (double)Y);
         }
 
         /// <inheritdoc />

--- a/src/UglyToad.PdfPig/Graphics/Operations/SpecialGraphicsState/ModifyCurrentTransformationMatrix.cs
+++ b/src/UglyToad.PdfPig/Graphics/Operations/SpecialGraphicsState/ModifyCurrentTransformationMatrix.cs
@@ -2,7 +2,6 @@
 {
     using System;
     using System.IO;
-    using PdfPig.Core;
 
     /// <inheritdoc />
     /// <summary>
@@ -44,13 +43,7 @@
         /// <inheritdoc />
         public void Run(IOperationContext operationContext)
         {
-            var newMatrix = TransformationMatrix.FromArray(Value);
-
-            var ctm = operationContext.GetCurrentState().CurrentTransformationMatrix;
-
-            var newCtm = newMatrix.Multiply(ctm);
-
-            operationContext.GetCurrentState().CurrentTransformationMatrix = newCtm;
+            operationContext.ModifyCurrentTransformationMatrix(Array.ConvertAll(Value, x => (double)x));
         }
 
         /// <inheritdoc />

--- a/src/UglyToad.PdfPig/Graphics/Operations/TextPositioning/MoveToNextLine.cs
+++ b/src/UglyToad.PdfPig/Graphics/Operations/TextPositioning/MoveToNextLine.cs
@@ -32,9 +32,7 @@
         /// <inheritdoc />
         public void Run(IOperationContext operationContext)
         {
-            var tdOperation = new MoveToNextLineWithOffset(0, -1 * (decimal)operationContext.GetCurrentState().FontState.Leading);
-
-            tdOperation.Run(operationContext);
+            operationContext.MoveToNextLineWithOffset();
         }
 
         /// <inheritdoc />

--- a/src/UglyToad.PdfPig/Graphics/Operations/TextState/SetCharacterSpacing.cs
+++ b/src/UglyToad.PdfPig/Graphics/Operations/TextState/SetCharacterSpacing.cs
@@ -5,7 +5,7 @@
     /// <inheritdoc />
     /// <summary>
     /// Set the character spacing to a number expressed in unscaled text space units.
-    /// Initial value: 0. 
+    /// Initial value: 0.
     /// </summary>
     public class SetCharacterSpacing : IGraphicsStateOperation
     {
@@ -34,9 +34,7 @@
         /// <inheritdoc />
         public void Run(IOperationContext operationContext)
         {
-            var currentState = operationContext.GetCurrentState();
-
-            currentState.FontState.CharacterSpacing = (double)Spacing;
+            operationContext.SetCharacterSpacing((double)Spacing);
         }
 
         /// <inheritdoc />

--- a/src/UglyToad.PdfPig/Graphics/Operations/TextState/SetFontAndSize.cs
+++ b/src/UglyToad.PdfPig/Graphics/Operations/TextState/SetFontAndSize.cs
@@ -48,10 +48,7 @@
         /// <inheritdoc />
         public void Run(IOperationContext operationContext)
         {
-            var currentState = operationContext.GetCurrentState();
-
-            currentState.FontState.FontSize = (double)Size;
-            currentState.FontState.FontName = Font;
+            operationContext.SetFontAndSize(Font, (double)Size);
         }
 
         /// <inheritdoc />

--- a/src/UglyToad.PdfPig/Graphics/Operations/TextState/SetHorizontalScaling.cs
+++ b/src/UglyToad.PdfPig/Graphics/Operations/TextState/SetHorizontalScaling.cs
@@ -30,9 +30,7 @@
         /// <inheritdoc />
         public void Run(IOperationContext operationContext)
         {
-            var currentState = operationContext.GetCurrentState();
-
-            currentState.FontState.HorizontalScaling = (double)Scale;
+            operationContext.SetHorizontalScaling((double)Scale);
         }
 
         /// <inheritdoc />

--- a/src/UglyToad.PdfPig/Graphics/Operations/TextState/SetTextLeading.cs
+++ b/src/UglyToad.PdfPig/Graphics/Operations/TextState/SetTextLeading.cs
@@ -33,9 +33,7 @@
         /// <inheritdoc />
         public void Run(IOperationContext operationContext)
         {
-            var currentState = operationContext.GetCurrentState();
-
-            currentState.FontState.Leading = (double)Leading;
+            operationContext.SetTextLeading((double)Leading);
         }
 
         /// <inheritdoc />

--- a/src/UglyToad.PdfPig/Graphics/Operations/TextState/SetTextRenderingMode.cs
+++ b/src/UglyToad.PdfPig/Graphics/Operations/TextState/SetTextRenderingMode.cs
@@ -1,7 +1,7 @@
 ﻿namespace UglyToad.PdfPig.Graphics.Operations.TextState
 {
-    using System.IO;
     using Core;
+    using System.IO;
 
     /// <inheritdoc />
     /// <summary>
@@ -33,9 +33,7 @@
         /// <inheritdoc />
         public void Run(IOperationContext operationContext)
         {
-            var currentState = operationContext.GetCurrentState();
-
-            currentState.FontState.TextRenderingMode = Mode;
+            operationContext.SetTextRenderingMode(Mode);
         }
 
         /// <inheritdoc />

--- a/src/UglyToad.PdfPig/Graphics/Operations/TextState/SetTextRise.cs
+++ b/src/UglyToad.PdfPig/Graphics/Operations/TextState/SetTextRise.cs
@@ -33,9 +33,7 @@
         /// <inheritdoc />
         public void Run(IOperationContext operationContext)
         {
-            var currentState = operationContext.GetCurrentState();
-
-            currentState.FontState.Rise = (double)Rise;
+            operationContext.SetTextRise((double)Rise);
         }
 
         /// <inheritdoc />

--- a/src/UglyToad.PdfPig/Graphics/Operations/TextState/SetWordSpacing.cs
+++ b/src/UglyToad.PdfPig/Graphics/Operations/TextState/SetWordSpacing.cs
@@ -34,9 +34,7 @@
         /// <inheritdoc />
         public void Run(IOperationContext operationContext)
         {
-            var currentState = operationContext.GetCurrentState();
-
-            currentState.FontState.WordSpacing = (double)Spacing;
+            operationContext.SetWordSpacing((double)Spacing);
         }
 
         /// <inheritdoc />


### PR DESCRIPTION
- remove reference to `TransformationMatrix`, `CurrentGraphicsState`, `PdfPath` and `PdfSubpath` from `IOperationContext` to make it stream processor neutral.
- `IGraphicsStateOperation` are just limited to calling the corresponding operation in `IOperationContext`. `ContentStreamProcessor` takes care of all of that.

Note: `Util.JetBrains.Annotations` is not used anymore in `IOperationContext`. Do we need `[CanBeNull]` in `ContentStreamProcessor`?

This PR should have no impact on the output of document processing/drawing.

This is needed as part of my previous remark:
> - investigate further using a different `IOperationContext` using directly `System.Drawing`'s `Matrix` and `GraphicsPath` (and not using `PdfPig`'s version of these class at all)