### PR TITLE
Fix Letter's PointSize computation

### DIFF
--- a/src/UglyToad.PdfPig.Tests/Fonts/PointSizeTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Fonts/PointSizeTests.cs
@@ -1,0 +1,22 @@
+﻿namespace UglyToad.PdfPig.Tests.Fonts
+{
+    using UglyToad.PdfPig.Tests.Dla;
+    using Xunit;
+
+    public class PointSizeTests
+    {
+        [Fact]
+        public void RotatedText()
+        {
+            using (var document = PdfDocument.Open(DlaHelper.GetDocumentPath("complex rotated")))
+            {
+                var page = document.GetPage(1);
+
+                foreach (var letter in page.Letters)
+                {
+                    Assert.Equal(12, letter.PointSize);
+                }
+            }
+        }
+    }
+}

--- a/src/UglyToad.PdfPig/Content/Letter.cs
+++ b/src/UglyToad.PdfPig/Content/Letter.cs
@@ -68,7 +68,6 @@
 
         /// <summary>
         /// The size of the font in points.
-        /// <para>This is considered experimental because the calculated value is incorrect for some documents at present.</para>
         /// </summary>
         public double PointSize { get; }
 

--- a/src/UglyToad.PdfPig/Graphics/ContentStreamProcessor.cs
+++ b/src/UglyToad.PdfPig/Graphics/ContentStreamProcessor.cs
@@ -241,20 +241,7 @@
             var renderingMatrix =
                 TransformationMatrix.FromValues(fontSize * horizontalScaling, 0, 0, fontSize, 0, rise);
 
-            // TODO: this does not seem correct, produces the correct result for now but we need to revisit.
-            // see: https://stackoverflow.com/questions/48010235/pdf-specification-get-font-size-in-points
-            var fontSizeMatrix = transformationMatrix.Multiply(TextMatrices.TextMatrix).Multiply(fontSize);
-            var pointSize = Math.Round(fontSizeMatrix.A, 2);
-            // Assume a rotated letter
-            if (pointSize == 0)
-            {
-                pointSize = Math.Round(fontSizeMatrix.B, 2);
-            }
-
-            if (pointSize < 0)
-            {
-                pointSize *= -1;
-            }
+            var pointSize = Math.Round(transformationMatrix.Multiply(TextMatrices.TextMatrix).Transform(new PdfRectangle(0, 0, 1, fontSize)).Height, 2);
 
             while (bytes.MoveNext())
             {
@@ -292,7 +279,7 @@
                 var boundingBox = font.GetBoundingBox(code);
 
                 var transformedGlyphBounds = PerformantRectangleTransformer
-                    .Transform(renderingMatrix, textMatrix, transformationMatrix, boundingBox.GlyphBounds);
+                      .Transform(renderingMatrix, textMatrix, transformationMatrix, boundingBox.GlyphBounds);
 
                 var transformedPdfBounds = PerformantRectangleTransformer
                     .Transform(renderingMatrix, textMatrix, transformationMatrix, new PdfRectangle(0, 0, boundingBox.Width, 0));


### PR DESCRIPTION
- fix `Letter`'s `PointSize` computation by applying the transform to a rectangle of height `fontSize`
- add test with rotated letters

Issue was related to https://stackoverflow.com/questions/48010235/pdf-specification-get-font-size-in-points