### PR TITLE
Fix #199

### DIFF
--- a/src/UglyToad.PdfPig.Tests/Writer/PdfMergerTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Writer/PdfMergerTests.cs
@@ -89,7 +89,7 @@
             using (var document = PdfDocument.Open(result, ParsingOptions.LenientParsingOff))
             {
                 Assert.Equal(2, document.NumberOfPages);
-                Assert.True(document.Structure.CrossReferenceTable.ObjectOffsets.Count < 24,
+                Assert.True(document.Structure.CrossReferenceTable.ObjectOffsets.Count <= 24,
                     "Expected object count to be lower than 24");
             }
         }

--- a/src/UglyToad.PdfPig/Writer/PdfStreamWriter.cs
+++ b/src/UglyToad.PdfPig/Writer/PdfStreamWriter.cs
@@ -142,21 +142,6 @@
             return referenceToken;
         }
 
-        private IndirectReferenceToken FindToken(IToken token)
-        {
-            foreach (var pair in tokenReferences)
-            {
-                var reference = pair.Key;
-                var storedToken = pair.Value;
-                if (storedToken.Equals(token))
-                {
-                    return reference;
-                }
-            }
-
-            return null;
-        }
-
         private static void WriteString(string text, Stream stream)
         {
             var bytes = OtherEncodings.StringAsLatin1Bytes(text);

--- a/src/UglyToad.PdfPig/Writer/PdfStreamWriter.cs
+++ b/src/UglyToad.PdfPig/Writer/PdfStreamWriter.cs
@@ -77,28 +77,19 @@
 
         public IndirectReferenceToken WriteToken(IToken token, int? reservedNumber = null)
         {
-            // if you can't consider deduplicating the token. 
-            // It must be because it's referenced by his child element, so you must have reserved a number before hand
-            // Example /Pages Obj
-            var canBeDuplicated = !reservedNumber.HasValue;
-            if (!canBeDuplicated)
-            {
-                if (!reservedNumbers.Remove(reservedNumber.Value))
-                {
-                    throw new InvalidOperationException("You can't reuse a reserved number");
-                }
-
-                // When we end up writing this token, all of his child would already have been added and checked for duplicate
-                return AddToken(token, reservedNumber.Value);
-            }
-
-            var reference = FindToken(token);
-            if (reference == null)
+            if (!reservedNumber.HasValue)
             {
                 return AddToken(token, CurrentNumber++);
             }
 
-            return reference;
+            if (!reservedNumbers.Remove(reservedNumber.Value))
+            {
+                throw new InvalidOperationException("You can't reuse a reserved number");
+            }
+
+            // When we end up writing this token, all of his child would already have been added and checked for duplicate
+            return AddToken(token, reservedNumber.Value);
+
         }
 
         public int ReserveNumber()


### PR DESCRIPTION
In large file brute forcing the search of a specific token can be quite difficult. Detecting duplicated token can be made in a more performance way.

This theory was tested on a production program