### PR TITLE
Fix TokenWriter::WriteString not escaping properly special characters

### DIFF
--- a/src/UglyToad.PdfPig.Tests/Writer/TokenWriterTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Writer/TokenWriterTests.cs
@@ -1,0 +1,30 @@
+﻿namespace UglyToad.PdfPig.Tests.Writer
+{
+    using Integration;
+    using PdfPig.Writer;
+    using System.IO;
+    using UglyToad.PdfPig.Tokens;
+    using Xunit;
+
+    public class TokenWriterTests
+    {
+
+        [Fact]
+        public void EscapeSpecialCharacter()
+        {
+            using (var memStream = new MemoryStream())
+            {
+                TokenWriter.WriteToken(new StringToken("\\"), memStream);
+                TokenWriter.WriteToken(new StringToken("(Hello)"), memStream);
+
+                // Read Test
+                memStream.Position = 0;
+                using (var streamReader = new StreamReader(memStream))
+                {
+                    var line = streamReader.ReadToEnd();
+                    Assert.Equal("(\\\\) (\\(Hello\\)) ", line);
+                }
+            }
+        }
+    }
+}

--- a/src/UglyToad.PdfPig/Writer/TokenWriter.cs
+++ b/src/UglyToad.PdfPig/Writer/TokenWriter.cs
@@ -16,6 +16,8 @@
     /// </summary>
     public class TokenWriter
     {
+        private static readonly byte Backslash = GetByte("\\");
+
         private static readonly byte ArrayStart = GetByte("[");
         private static readonly byte ArrayEnd = GetByte("]");
 
@@ -374,6 +376,12 @@
                 for (var i = 0; i < stringToken.Data.Length; i++)
                 {
                     var c = stringToken.Data[i];
+
+                    if (c == (char) StringStart || c == (char)StringEnd || c == (char) Backslash)
+                    {
+                        stringToken = new StringToken(stringToken.Data.Insert(i++, "\\"), stringToken.EncodedWith);
+                    }
+
                     // Close enough.
                     if (c > 250)
                     {


### PR DESCRIPTION
Before this fix we were producing a broken binary:

![Evidence](https://user-images.githubusercontent.com/2200611/102727184-33ac3080-431c-11eb-9bb6-06ca218de097.png)

The left document is the original. The right one, is the same document, but the operations of the content stream of that page were written by the library. As you can see operations are being treated as text of the page, rather than operation itself.

![ContentStream](https://user-images.githubusercontent.com/2200611/102727334-0449f380-431d-11eb-9feb-e1231a987207.png)

Left content stream is from the original document, right content stream come from the document created by the library. As you can see in the we are not properly escaping the special characters. 

The pertinent paragraph in the specifications is:
![PDF Spec](https://user-images.githubusercontent.com/2200611/102727448-97832900-431d-11eb-98d1-11d85272f30d.png)

I didn't find where you were putting the TokenWriter test so I created the file (I didn't search very much either 😢).
Please comment on anything else...

PD: by any chance we can get right of those extra white spaces?

