### PR TITLE
[New Feature] PdfPageBuilder: Allow to copy pages from another document

### DIFF
--- a/src/UglyToad.PdfPig.Tests/Writer/PdfDocumentBuilderTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Writer/PdfDocumentBuilderTests.cs
@@ -644,6 +644,53 @@
             }
         }
 
+        [Fact]
+        public void CanCopyPage()
+        {
+
+            byte[] b;
+            {
+                var builder = new PdfDocumentBuilder();
+
+                var page1 = builder.AddPage(PageSize.A4);
+
+                var file = TrueTypeTestHelper.GetFileBytes("Andada-Regular.ttf");
+
+                var font = builder.AddTrueTypeFont(file);
+
+                page1.AddText("Hello", 12, new PdfPoint(30, 50), font);
+
+                Assert.NotEmpty(page1.CurrentStream.Operations);
+
+
+                using (var readDocument = PdfDocument.Open(IntegrationHelpers.GetDocumentPath("bold-italic.pdf")))
+                {
+                    var rpage = readDocument.GetPage(1);
+
+                    var page2 = builder.AddPage(PageSize.A4);
+                    page2.CopyFrom(rpage);
+                }
+
+                b = builder.Build();
+                Assert.NotEmpty(b);
+            }
+
+            WriteFile(nameof(CanCopyPage), b);
+
+            using (var document = PdfDocument.Open(b))
+            {
+                Assert.Equal( 2, document.NumberOfPages);
+
+                var page1 = document.GetPage(1);
+
+                Assert.Equal("Hello", page1.Text);
+
+                var page2 = document.GetPage(2);
+                
+                Assert.Equal("Lorem ipsum dolor sit amet, consectetur adipiscing elit. ", page2.Text);
+            }
+        }
+
         private static void WriteFile(string name, byte[] bytes, string extension = "pdf")
         {
             try

--- a/src/UglyToad.PdfPig.Tests/Writer/PdfDocumentBuilderTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Writer/PdfDocumentBuilderTests.cs
@@ -136,7 +136,7 @@
 
             var letters = page.AddText("Hello World!", 12, new PdfPoint(30, 50), font);
 
-            Assert.NotEmpty(page.Operations);
+            Assert.NotEmpty(page.CurrentStream.Operations);
 
             var b = builder.Build();
 
@@ -186,7 +186,7 @@
 
             page.AddText("eé", 12, new PdfPoint(30, 520), font);
 
-            Assert.NotEmpty(page.Operations);
+            Assert.NotEmpty(page.CurrentStream.Operations);
 
             var b = builder.Build();
 
@@ -232,7 +232,7 @@
 
             page.AddText("eé", 12, new PdfPoint(30, 520), font);
 
-            Assert.NotEmpty(page.Operations);
+            Assert.NotEmpty(page.CurrentStream.Operations);
 
             var b = builder.Build();
 
@@ -279,7 +279,7 @@
             var letters = page.AddText("Hello World!", 16, new PdfPoint(30, 520), font);
             page.AddText("This is some further text continuing to write", 12, new PdfPoint(30, 500), font);
 
-            Assert.NotEmpty(page.Operations);
+            Assert.NotEmpty(page.CurrentStream.Operations);
 
             var b = builder.Build();
 
@@ -601,6 +601,47 @@
             
             var file = builder.Build();
             WriteFile(nameof(CanCreateDocumentWithFilledRectangle), file);
+        }
+
+        [Fact]
+        public void CanGeneratePageWithMultipleStream()
+        {
+            var builder = new PdfDocumentBuilder();
+
+            var page = builder.AddPage(PageSize.A4);
+
+            var file = TrueTypeTestHelper.GetFileBytes("Andada-Regular.ttf");
+
+            var font = builder.AddTrueTypeFont(file);
+
+            var letters = page.AddText("Hello", 12, new PdfPoint(30, 50), font);
+
+            Assert.NotEmpty(page.CurrentStream.Operations);
+
+            page.NewContentStreamAfter();
+
+            page.AddText("World!", 12, new PdfPoint(50, 50), font);
+
+            Assert.NotEmpty(page.CurrentStream.Operations);
+
+
+            var b = builder.Build();
+
+            WriteFile(nameof(CanGeneratePageWithMultipleStream), b);
+
+            Assert.NotEmpty(b);
+
+            using (var document = PdfDocument.Open(b))
+            {
+                var page1 = document.GetPage(1);
+
+                Assert.Equal("HelloWorld!", page1.Text);
+
+                var h = page1.Letters[0];
+
+                Assert.Equal("H", h.Value);
+                Assert.Equal("Andada-Regular", h.FontName);
+            }
         }
 
         private static void WriteFile(string name, byte[] bytes, string extension = "pdf")

--- a/src/UglyToad.PdfPig/Content/Page.cs
+++ b/src/UglyToad.PdfPig/Content/Page.cs
@@ -17,7 +17,7 @@
     public class Page
     {
         private readonly AnnotationProvider annotationProvider;
-        private readonly IPdfTokenScanner pdfScanner;
+        internal readonly IPdfTokenScanner pdfScanner;
         private readonly Lazy<string> textLazy;
 
         /// <summary>

--- a/src/UglyToad.PdfPig/Writer/PdfDocumentBuilder.cs
+++ b/src/UglyToad.PdfPig/Writer/PdfDocumentBuilder.cs
@@ -3,6 +3,7 @@ namespace UglyToad.PdfPig.Writer
 {
     using System;
     using System.Collections.Generic;
+    using System.Diagnostics;
     using System.IO;
     using System.Linq;
     using Content;
@@ -10,8 +11,10 @@ namespace UglyToad.PdfPig.Writer
     using Fonts;
     using PdfPig.Fonts.TrueType;
     using Graphics.Operations;
+    using Parser.Parts;
     using PdfPig.Fonts.Standard14Fonts;
     using PdfPig.Fonts.TrueType.Parser;
+    using Tokenization.Scanner;
     using Tokens;
 
     using Util.JetBrains.Annotations;
@@ -25,6 +28,9 @@ namespace UglyToad.PdfPig.Writer
         private readonly Dictionary<int, PdfPageBuilder> pages = new Dictionary<int, PdfPageBuilder>();
         private readonly Dictionary<Guid, FontStored> fonts = new Dictionary<Guid, FontStored>();
         private readonly Dictionary<Guid, ImageStored> images = new Dictionary<Guid, ImageStored>();
+        private readonly Dictionary<IndirectReferenceToken, IToken> unwrittenTokens = new Dictionary<IndirectReferenceToken, IToken>();
+
+        internal int fontId = 0;
 
         /// <summary>
         /// The standard of PDF/A compliance of the generated document. Defaults to <see cref="PdfAStandard.None"/>.
@@ -50,7 +56,12 @@ namespace UglyToad.PdfPig.Writer
         /// <summary>
         /// The fonts currently available in the document builder added via <see cref="AddTrueTypeFont"/> or <see cref="AddStandard14Font"/>. Keyed by id for internal purposes.
         /// </summary>
-        internal IReadOnlyDictionary<Guid, IWritingFont> Fonts => fonts.ToDictionary(x => x.Key, x => x.Value.FontProgram);
+        internal IReadOnlyDictionary<Guid, FontStored> Fonts => fonts;
+
+        /// <summary>
+        /// The images currently available in the document builder added via <see cref="AddImage"/>. Keyed by id for internal purposes.
+        /// </summary>
+        internal IReadOnlyDictionary<Guid, ImageStored> Images => images;
 
         /// <summary>
         /// Determines whether the bytes of the TrueType font file provided can be used in a PDF document.
@@ -116,8 +127,7 @@ namespace UglyToad.PdfPig.Writer
             {
                 var font = TrueTypeFontParser.Parse(new TrueTypeDataBytes(new ByteArrayInputBytes(fontFileBytes)));
                 var id = Guid.NewGuid();
-                var i = fonts.Count;
-                var added = new AddedFont(id, NameToken.Create($"F{i}"));
+                var added = new AddedFont(id, NameToken.Create($"F{fontId++}"));
                 fonts[id] = new FontStored(added, new TrueTypeWritingFont(font, fontFileBytes));
 
                 return added;
@@ -141,7 +151,7 @@ namespace UglyToad.PdfPig.Writer
             }
 
             var id = Guid.NewGuid();
-            var name = NameToken.Create($"F{fonts.Count}");
+            var name = NameToken.Create($"F{fontId++}");
             var added = new AddedFont(id, name);
             fonts[id] = new FontStored(added, new Standard14WritingFont(Standard14.GetAdobeFontMetrics(type)));
 
@@ -259,6 +269,11 @@ namespace UglyToad.PdfPig.Writer
                     context.WriteObject(memory, streamToken, image.Value.ObjectNumber);
                 }
 
+                foreach (var tokenSet in unwrittenTokens)
+                {
+                    context.WriteObject(memory, tokenSet.Value, (int)tokenSet.Key.Data.ObjectNumber);
+                }
+
                 var procSet = new List<NameToken>
                 {
                     NameToken.Create("PDF"),
@@ -278,9 +293,7 @@ namespace UglyToad.PdfPig.Writer
                     var fontsDictionary = new DictionaryToken(fontsWritten.Select(x => (fonts[x.Key].FontKey.Name, (IToken)new IndirectReferenceToken(x.Value.Number)))
                         .ToDictionary(x => x.Item1, x => x.Item2));
 
-                    var fontsDictionaryRef = context.WriteObject(memory, fontsDictionary);
-
-                    resources.Add(NameToken.Font, new IndirectReferenceToken(fontsDictionaryRef.Number));
+                    resources.Add(NameToken.Font, fontsDictionary);
                 }
 
                 var reserved = context.ReserveNumber();
@@ -301,8 +314,24 @@ namespace UglyToad.PdfPig.Writer
                     {
                         foreach (var kvp in page.Value.Resources)
                         {
-                            // TODO: combine resources if value is dictionary or array, otherwise overwrite.
-                            individualResources[kvp.Key] = kvp.Value;
+                            var value = kvp.Value;
+                            if (individualResources.TryGetValue(kvp.Key, out var pageToken))
+                            {
+                                if (pageToken is DictionaryToken leftDictionary && value is DictionaryToken rightDictionary)
+                                {
+                                    var merged = leftDictionary.Data.ToDictionary(k => NameToken.Create(k.Key), v => v.Value);
+                                    foreach (var set in rightDictionary.Data)
+                                    {
+                                        merged[NameToken.Create(set.Key)] = set.Value;
+                                    }
+
+                                    value = new DictionaryToken(merged);
+
+                                }
+                                // Else override
+                            }
+
+                            individualResources[kvp.Key] = value;
                         }
                     }
 
@@ -390,6 +419,75 @@ namespace UglyToad.PdfPig.Writer
 
                 return memory.ToArray();
             }
+        }
+
+        /// <summary>
+        /// The purpose of this method is to resolve indirect reference. That mean copy the reference's content to the new document's stream
+        /// and replace the indirect reference with the correct/new one
+        /// </summary>
+        /// <param name="tokenToCopy">Token to inspect for reference</param>
+        /// <param name="tokenScanner">scanner get the content from the original document</param>
+        /// <returns>A reference of the token that was copied. With all the reference updated</returns>
+        internal IToken CopyToken(IToken tokenToCopy, IPdfTokenScanner tokenScanner)
+        {
+            // This token need to be deep copied, because they could contain reference. So we have to update them.
+            switch (tokenToCopy)
+            {
+                case DictionaryToken dictionaryToken:
+                    {
+                        var newContent = new Dictionary<NameToken, IToken>();
+                        foreach (var setPair in dictionaryToken.Data)
+                        {
+                            var name = setPair.Key;
+                            var token = setPair.Value;
+                            newContent.Add(NameToken.Create(name), CopyToken(token, tokenScanner));
+                        }
+
+                        return new DictionaryToken(newContent);
+                    }
+                case ArrayToken arrayToken:
+                    {
+                        var newArray = new List<IToken>(arrayToken.Length);
+                        foreach (var token in arrayToken.Data)
+                        {
+                            newArray.Add(CopyToken(token, tokenScanner));
+                        }
+
+                        return new ArrayToken(newArray);
+                    }
+                case IndirectReferenceToken referenceToken:
+                    {
+                        var tokenObject = DirectObjectFinder.Get<IToken>(referenceToken.Data, tokenScanner);
+
+                        Debug.Assert(!(tokenObject is IndirectReferenceToken));
+
+                        var newToken = CopyToken(tokenObject, tokenScanner);
+
+                        var reserved = context.ReserveNumber();
+                        var newReference = new IndirectReferenceToken(new IndirectReference(reserved, 0));
+
+                        unwrittenTokens.Add(newReference, newToken);
+
+                        return newReference;
+                    }
+                case StreamToken streamToken:
+                    {
+                        var properties = CopyToken(streamToken.StreamDictionary, tokenScanner) as DictionaryToken;
+                        Debug.Assert(properties != null);
+
+                        var bytes = streamToken.Data;
+                        return new StreamToken(properties, bytes);
+                    }
+
+                case ObjectToken _:
+                    {
+                        // Since we don't write token directly to the stream.
+                        // We can't know the offset. Therefore the token would be invalid
+                        throw new NotSupportedException("Copying a Object token is not supported");
+                    }
+            }
+
+            return tokenToCopy;
         }
 
         private static StreamToken WriteContentStream(IReadOnlyList<IGraphicsStateOperation> content)


### PR DESCRIPTION
This is a very naive implementation, because if you copy a lot of pages from a given document you would have duplicated resources. But, I would like to get some thoughts on this implementation.

I was surprise by the amount of code that this feature needed to be implemented. I was expecting a lot more. Even so, there is some duplicated code in two parts:
- [Copying Token](https://github.com/InusualZ/PdfPig/commit/7126564eefbc30c205a165739d333dd6da3ddb0e#diff-a4cfeaa02b17ecfae6639ce457a744a267bf3e7d478740f850a02d0e42cb8c0eR431-R492) This piece of code keep reappearing, I really don't like it.
- [Resource Management](https://github.com/InusualZ/PdfPig/commit/7126564eefbc30c205a165739d333dd6da3ddb0e#diff-ffb8dc0dfd0b8bc578f2ecd4517965154295f4b8900e71ed5948bc2325dd12eeR537-R666) I think this piece of code and the one that write the resources to the stream can be transformed into a nice interface behind a read only interface and mutable interface, kind of like `IReadOnlyList<>` and `IList<>`, but `IReadOnlyResourceStore` and `IResourceStore`. I would like yours thought about that

Anyway, This code have some `TODO` I would like to address them, but I don't know If you even want the feature in it's current path of implementation, so maybe the effort to implement them are not worth.

If you have any suggestions, thought, anything feel free to comment.