### PR TITLE
Opening a PdfDocument via a file path opens a stream instead of allocating

### DIFF
--- a/src/UglyToad.PdfPig/Parser/PdfDocumentFactory.cs
+++ b/src/UglyToad.PdfPig/Parser/PdfDocumentFactory.cs
@@ -40,7 +40,8 @@
                 throw new InvalidOperationException("No file exists at: " + filename);
             }
 
-            return Open(File.ReadAllBytes(filename), options);
+            var input = new StreamInputBytes(File.OpenRead(filename), true);
+            return Open(input, options);
         }
 
         internal static PdfDocument Open(Stream stream, ParsingOptions options)


### PR DESCRIPTION
In this PR, I suggest changing the default way to open a file, by switching to streams instead of getting the byte[].

This should be mostly beneficial for large documents, and treatments in loops (less pressure on the GC mostly).