### PR TITLE
Pdfmerger stream apis

### DIFF
--- a/src/UglyToad.PdfPig/Writer/PdfMerger.cs
+++ b/src/UglyToad.PdfPig/Writer/PdfMerger.cs
@@ -33,19 +33,28 @@
         /// </summary>
         public static byte[] Merge(string file1, string file2, IReadOnlyList<int> file1Selection = null, IReadOnlyList<int> file2Selection = null)
         {
-            if (file1 == null)
+            using (var output = new MemoryStream())
             {
-                throw new ArgumentNullException(nameof(file1));
+                Merge(file1, file2, output, file1Selection, file2Selection);
+                return output.ToArray();
             }
+        }
 
-            if (file2 == null)
+        /// <summary>
+        /// Merge two PDF documents together with the pages from <paramref name="file1"/> followed by <paramref name="file2"/> into the output stream.
+        /// </summary>
+        public static void Merge(string file1, string file2, Stream output, IReadOnlyList<int> file1Selection = null, IReadOnlyList<int> file2Selection = null)
+        {
+            _ = file1 ?? throw new ArgumentNullException(nameof(file1));
+            _ = file2 ?? throw new ArgumentNullException(nameof(file2));
+
+            using (var stream1 = new StreamInputBytes(File.OpenRead(file1)))
             {
-                throw new ArgumentNullException(nameof(file2));
+                using (var stream2 = new StreamInputBytes(File.OpenRead(file2)))
+                {
+                    Merge(new[] { stream1, stream2 }, output, new[] { file1Selection, file2Selection });
+                }
             }
-
-            using var stream1 = new StreamInputBytes(File.OpenRead(file1));
-            using var stream2 = new StreamInputBytes(File.OpenRead(file2));
-            return Merge(new[] { stream1, stream2 }, new [] { file1Selection, file2Selection });
         }
 
         /// <summary>
@@ -53,26 +62,32 @@
         /// </summary>
         public static byte[] Merge(params string[] filePaths)
         {
-            var bytes = new List<StreamInputBytes>(filePaths.Length);
+            using (var output = new MemoryStream())
+            {
+                Merge(output, filePaths);
+                return output.ToArray();
+            }
+        }
 
+        /// <summary>
+        /// Merge multiple PDF documents together with the pages in the order the file paths are provided into the output stream
+        /// </summary>
+        public static void Merge(Stream output, params string[] filePaths)
+        {
+            var streams = new List<StreamInputBytes>(filePaths.Length);
             try
             {
                 for (var i = 0; i < filePaths.Length; i++)
                 {
-                    var filePath = filePaths[i];
-                    if (filePath == null)
-                    {
-                        throw new ArgumentNullException(nameof(filePaths), $"Null filepath at index {i}.");
-                    }
-
-                    bytes.Add(new StreamInputBytes(File.OpenRead(filePath), true));
+                    var filePath = filePaths[i] ?? throw new ArgumentNullException(nameof(filePaths), $"Null filepath at index {i}.");
+                    streams.Add(new StreamInputBytes(File.OpenRead(filePath), true));
                 }
 
-                return Merge(bytes, null);
+                Merge(streams, output, null);
             }
             finally
             {
-                foreach (var stream in bytes)
+                foreach (var stream in streams)
                 {
                     stream.Dispose();
                 }
@@ -84,37 +99,37 @@
         /// </summary>
         public static byte[] Merge(IReadOnlyList<byte[]> files, IReadOnlyList<IReadOnlyList<int>> pagesBundle = null)
         {
-            if (files == null)
-            {
-                throw new ArgumentNullException(nameof(files));
-            }
+            _ = files ?? throw new ArgumentNullException(nameof(files));
 
-            return Merge(files.Select(f => new ByteArrayInputBytes(f)).ToArray(), pagesBundle);
+            using (var output = new MemoryStream())
+            {
+                Merge(files.Select(f => new ByteArrayInputBytes(f)).ToArray(), output, pagesBundle);
+                return output.ToArray();
+            }
         }
 
         /// <summary>
-        /// Merge the set of PDF documents.
+        /// Merge the set of PDF documents into the output stream
         /// The caller must manage disposing the stream. The created PdfDocument will not dispose the stream.
         /// <param name="streams">
         /// A list of streams for the files contents, this must support reading and seeking.
         /// </param>
+        /// <param name="output">Must be writable</param>
         /// <param name="pagesBundle"></param>
         /// </summary>
-        public static byte[] Merge(IReadOnlyList<Stream> streams, IReadOnlyList<IReadOnlyList<int>> pagesBundle = null)
+        public static void Merge(IReadOnlyList<Stream> streams, Stream output, IReadOnlyList<IReadOnlyList<int>> pagesBundle = null)
         {
-            if (streams == null)
-            {
-                throw new ArgumentNullException(nameof(streams));
-            }
+            _ = streams ?? throw new ArgumentNullException(nameof(streams));
+            _ = output ?? throw new ArgumentNullException(nameof(output));
 
-            return Merge(streams.Select(f => new StreamInputBytes(f, false)).ToArray(), pagesBundle);
+            Merge(streams.Select(f => new StreamInputBytes(f, false)).ToArray(), output, pagesBundle);
         }
 
-        private static byte[] Merge(IReadOnlyList<IInputBytes> files, IReadOnlyList<IReadOnlyList<int>> pagesBundle = null)
+        private static void Merge(IReadOnlyList<IInputBytes> files, Stream output, IReadOnlyList<IReadOnlyList<int>> pagesBundle)
         {
             const bool isLenientParsing = false;
 
-            var documentBuilder = new DocumentMerger();
+            var documentBuilder = new DocumentMerger(output);
 
             foreach (var fileIndex in Enumerable.Range(0, files.Count))
             {
@@ -153,7 +168,7 @@
                 documentBuilder.AppendDocument(documentCatalog, version.Version, pdfScanner, pages);
             }
 
-            return documentBuilder.Build();
+            documentBuilder.Build();
         }
 
         // This method is a basically a copy of the method UglyToad.PdfPig.Parser.PdfDocumentFactory.ParseTrailer()
@@ -190,15 +205,16 @@
 
             private const int ARTIFICIAL_NODE_LIMIT = 100;
 
-            private readonly PdfStreamWriter context = new PdfStreamWriter();
+            private readonly PdfStreamWriter context;
             private readonly List<IndirectReferenceToken> pagesTokenReferences = new List<IndirectReferenceToken>();
             private readonly IndirectReferenceToken rootPagesReference;
 
             private decimal currentVersion = DefaultVersion;
             private int pageCount = 0;
 
-            public DocumentMerger()
+            public DocumentMerger(Stream baseStream)
             {
+                context = new PdfStreamWriter(baseStream, false);
                 rootPagesReference = context.ReserveNumberToken();
             }
 
@@ -336,7 +352,7 @@
                 CreateTree();
             }
 
-            public byte[] Build()
+            public void Build()
             {
                 if (pagesTokenReferences.Count < 1)
                 {
@@ -362,11 +378,7 @@
 
                 context.Flush(currentVersion, catalogRef);
 
-                var bytes = context.ToArray();
-
                 Close();
-
-                return bytes;
             }
 
             public void Close()

--- a/src/UglyToad.PdfPig/Writer/PdfStreamWriter.cs
+++ b/src/UglyToad.PdfPig/Writer/PdfStreamWriter.cs
@@ -23,11 +23,14 @@
 
         public bool DisposeStream { get; set; }
 
-        public PdfStreamWriter() : this(new MemoryStream()) { }
-
         public PdfStreamWriter(Stream baseStream, bool disposeStream = true)
         {
             Stream = baseStream ?? throw new ArgumentNullException(nameof(baseStream));
+            if (!baseStream.CanWrite)
+            {
+                throw new ArgumentException("Output stream must be writable");
+            }
+
             DisposeStream = disposeStream;
         }
 
@@ -107,23 +110,6 @@
         public IndirectReferenceToken ReserveNumberToken()
         {
             return new IndirectReferenceToken(new IndirectReference(ReserveNumber(), 0));
-        }
-
-        public byte[] ToArray()
-        {
-            var currentPosition = Stream.Position;
-            Stream.Seek(0, SeekOrigin.Begin);
-
-            var bytes = new byte[Stream.Length];
-
-            if (Stream.Read(bytes, 0, bytes.Length) != bytes.Length)
-            {
-                throw new Exception("Unable to read all the bytes from stream");
-            }
-
-            Stream.Seek(currentPosition, SeekOrigin.Begin);
-
-            return bytes;
         }
 
         public void Dispose()


### PR DESCRIPTION
This pr does two things:
 - pdfmerger uses stream instead of byte[]. This should improve performance for large documents/treatments in loop.
 - adds an optional output Stream argument on PdfMerger methods. This prevents allocating the newly created documents in memory.