### PR TITLE
Allow to have empty code space, fixes #256

### DIFF
--- a/src/UglyToad.PdfPig/PdfFonts/Parser/Parts/CodespaceRangeParser.cs
+++ b/src/UglyToad.PdfPig/PdfFonts/Parser/Parts/CodespaceRangeParser.cs
@@ -23,7 +23,18 @@
 
             for (var i = 0; i < numeric.Int; i++)
             {
-                if (!tokenScanner.MoveNext() || !(tokenScanner.CurrentToken is HexToken start))
+                if (!tokenScanner.MoveNext())
+                {
+                    throw new InvalidOperationException("Codespace range have reach an unexpected end");
+                }
+
+                if (tokenScanner.CurrentToken is OperatorToken operatorToken && operatorToken.Data == "endcodespacerange")
+                {
+                    // Don't add this code space range
+                    break;
+                }
+
+                if (!(tokenScanner.CurrentToken is HexToken start))
                 {
                     throw new InvalidOperationException("Codespace range contains an unexpected token: " + tokenScanner.CurrentToken);
                 }


### PR DESCRIPTION
Like the commit message say, allow to _parse_ empty code spaces, that way font that have `ToUnicode` dictionary, but no code spaces can be parsed correctly.

PDF Specification related to this problem. I'm in no expert in font, so this may not be the correct fix.
![PDF Specs](https://user-images.githubusercontent.com/2200611/103956480-7f464300-5140-11eb-8fa4-87a779b6c5ad.png)
