### PR TITLE
Pdfmerger complete rearrangment api

### DIFF
--- a/src/UglyToad.PdfPig.Tests/PublicApiScannerTests.cs
+++ b/src/UglyToad.PdfPig.Tests/PublicApiScannerTests.cs
@@ -211,6 +211,7 @@
                 "UglyToad.PdfPig.Writer.PdfMerger",
                 "UglyToad.PdfPig.Writer.PdfPageBuilder",
                 "UglyToad.PdfPig.Writer.TokenWriter",
+                "UglyToad.PdfPig.Writer.IPdfArrangement",
                 "UglyToad.PdfPig.XObjects.XObjectImage"
             };
 

--- a/src/UglyToad.PdfPig/Writer/IPdfArrangement.cs
+++ b/src/UglyToad.PdfPig/Writer/IPdfArrangement.cs
@@ -1,0 +1,17 @@
+﻿namespace UglyToad.PdfPig.Writer
+{
+    using System.Collections.Generic;
+
+    /// <summary>
+    /// A class able to provides instructions for a pdf rearrangement
+    /// </summary>
+    public interface IPdfArrangement
+    {
+        /// <summary>
+        /// Provides instructions for a pdf rearrangement
+        /// </summary>
+        /// <param name="pagesCountPerFileIndex"></param>
+        /// <returns></returns>
+        IEnumerable<(int FileIndex, IReadOnlyCollection<int> PageIndices)> GetArrangements(Dictionary<int, int> pagesCountPerFileIndex);
+    }
+}

--- a/src/UglyToad.PdfPig/Writer/PageArrangements/PdfMerge.cs
+++ b/src/UglyToad.PdfPig/Writer/PageArrangements/PdfMerge.cs
@@ -1,0 +1,39 @@
+﻿namespace UglyToad.PdfPig.Writer.PageArrangements
+{
+    using System.Collections.Generic;
+    using System.Linq;
+
+    class PdfMerge : IPdfArrangement
+    {
+        private readonly IReadOnlyList<IReadOnlyList<int>> pagesBundle;
+        public PdfMerge(IReadOnlyList<IReadOnlyList<int>> pagesBundle)
+        {
+            this.pagesBundle = pagesBundle;
+        }
+
+        public IEnumerable<(int FileIndex, IReadOnlyCollection<int> PageIndices)> GetArrangements(Dictionary<int, int> pagesCountPerFileIndex)
+        {
+            if (pagesBundle is null)
+            {
+                foreach (var kvp in pagesCountPerFileIndex.OrderBy(d => d.Key))
+                {
+                    yield return (kvp.Key, Enumerable.Range(1, pagesCountPerFileIndex[kvp.Key]).ToArray());
+                }
+            }
+            else
+            {
+                for (var i = 0; i < pagesBundle.Count; i++)
+                {
+                    if (pagesBundle[i] is null)
+                    {
+                        yield return (i, Enumerable.Range(1, pagesCountPerFileIndex[i]).ToArray());
+                    }
+                    else
+                    {
+                        yield return (i, pagesBundle[i]);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/UglyToad.PdfPig/Writer/PdfMerger.cs
+++ b/src/UglyToad.PdfPig/Writer/PdfMerger.cs
@@ -365,6 +365,7 @@
                 }
 
                 CreateTree();
+                context.Flush();
             }
 
             public void Build()
@@ -389,11 +390,7 @@
                     { NameToken.Pages, pagesRef }
                 });
 
-                var catalogRef = context.WriteToken(catalog);
-
-                context.Flush(catalogRef);
-
-                Close();
+                context.Close(catalog);
             }
 
             public void Close()


### PR DESCRIPTION
In this PR, I introduce two new public apis:

 - `PdfMerger.Merge(IReadOnlyList<Stream> streams, Stream output, IPdfArrangement pageArrangment)`: this uses the new `IPdfArrangement` that lets the consumer entirely describe the way the new pdf is supposed to be generated, allowing new things like zip-merge for instance.

 - `PdfMerger.MergeMany(IReadOnlyList<Stream> streams, IReadOnlyCollection<(Stream Output, IPdfArrangement PageArrangments)> exports)` : similar api but for multiple output. Useful for pdf split.


I followed comments from [this PR](https://github.com/UglyToad/PdfPig/pull/251) and did not add other specialized apis (PdfSplitter.Split, PdfEditor.RemovePages), but I feel like it would be a good idea. I believe those two new apis would benefit from being exposed on a different class, something like `PdfCombiner` ou `PdfArranger`.

I also did not expose different `IPdfArrangement` implementation that would simplify differents specialized kind of merge, but I believe that could also be a way to simplify the api.