### PR TITLE
allow a checkbox to not declare a value and only be checked by appearance #267

### DIFF
--- a/src/UglyToad.PdfPig/AcroForms/AcroFormFactory.cs
+++ b/src/UglyToad.PdfPig/AcroForms/AcroFormFactory.cs
@@ -478,6 +478,17 @@
             var isChecked = false;
             if (!fieldDictionary.TryGetOptionalTokenDirect(NameToken.V, tokenScanner, out NameToken valueToken))
             {
+                if (fieldDictionary.TryGetOptionalTokenDirect(NameToken.As, tokenScanner, out NameToken appearanceStateName)
+                    && fieldDictionary.TryGetOptionalTokenDirect(NameToken.Ap, tokenScanner, out DictionaryToken _))
+                {
+                    // Issue #267 - Use the set appearance instead, this might not work for 3 state checkboxes.
+                    isChecked = !string.Equals(
+                        appearanceStateName.Data,
+                        NameToken.Off,
+                        StringComparison.OrdinalIgnoreCase);
+                    valueToken = appearanceStateName;
+                    return (isChecked, valueToken);
+                }
                 valueToken = NameToken.Off;
             }
             else if (inheritsValue && fieldDictionary.TryGet(NameToken.As, tokenScanner, out NameToken appearanceStateName))


### PR DESCRIPTION
in the example document in issue #267 the checkbox declares an
appearance state with no corresponding value, as long as the checkbox
defines its appearances dictionary we treat non-off checkboxes as checked
if there is no corresponding value in the checkbox form field dictionary