### PR TITLE
fixes NullToken for a font

### DIFF
--- a/src/UglyToad.PdfPig/Parser/Parts/DirectObjectFinder.cs
+++ b/src/UglyToad.PdfPig/Parser/Parts/DirectObjectFinder.cs
@@ -46,7 +46,7 @@
         public static T Get<T>(IndirectReference reference, IPdfTokenScanner scanner) where T : class, IToken
         {
             var temp = scanner.Get(reference);
-            if (temp is null)
+            if (temp is null || temp.Data is NullToken)
             {
                 return null;
             }


### PR DESCRIPTION
A font was in a streamObject, PdfTokenScanner.ParseObjectStream would return a NullToken (as the object was indeed null)

DirectObjectFinder.Get would then throw on line 79, even thus it should handle null tokens (i.e. ResourceStore.LoadFontDictionary line 152).

I'm unfortunately unable to provide the original pdf, for privacy reasons.

Being able to quickly have a release with this fix would be greatly appreciated 🙏 