### PR TITLE
fix null token handling in document creation

### DIFF
--- a/src/UglyToad.PdfPig/Writer/WriterUtil.cs
+++ b/src/UglyToad.PdfPig/Writer/WriterUtil.cs
@@ -127,6 +127,11 @@
                         // referencesFromDocument.Add(referenceToken.Data, newReferenceToken);
                         // 
                         var tokenObject = DirectObjectFinder.Get<IToken>(referenceToken.Data, tokenScanner);
+                        if (tokenObject is null) //NullToken allowed
+                        {
+                            return null;
+                        }
+
                         Debug.Assert(!(tokenObject is IndirectReferenceToken));
                         var result = CopyToken(writer, tokenObject, tokenScanner, referencesFromDocument, callstack);
 


### PR DESCRIPTION
Prevent a nullreference exception when the font in the dictionary is a `NullToken` (valid case).

I'm afraid I am unable to provide a test for this, as I can't share the pdf.