### PR TITLE
Fixes null reference exception

### DIFF
--- a/src/UglyToad.PdfPig/PdfFonts/Parser/EncodingReader.cs
+++ b/src/UglyToad.PdfPig/PdfFonts/Parser/EncodingReader.cs
@@ -57,6 +57,11 @@
 
         private Encoding ReadEncodingDictionary(DictionaryToken encodingDictionary, Encoding fontEncoding)
         {
+            if (encodingDictionary == null)
+            {
+                return null;
+            }
+            
             Encoding baseEncoding;
             if (encodingDictionary.TryGet(NameToken.BaseEncoding, out var baseEncodingToken) && baseEncodingToken is NameToken baseEncodingName)
             {


### PR DESCRIPTION
Fixes an issue I was having reading a PDF when encodingDictionary is null.

``System.NullReferenceException: Object reference not set to an instance of an object.
         at UglyToad.PdfPig.PdfFonts.Parser.EncodingReader.ReadEncodingDictionary(DictionaryToken encodingDictionary, Encoding fontEncoding) in E:\PdfPig\src\UglyToad.PdfPig\PdfFonts\Parser\EncodingReader.cs:line 66``
