### PR TITLE
PdfTokenScanner: Fix reading stream operator

### DIFF
--- a/src/UglyToad.PdfPig/Parser/Parts/DirectObjectFinder.cs
+++ b/src/UglyToad.PdfPig/Parser/Parts/DirectObjectFinder.cs
@@ -76,7 +76,7 @@
                 }
             }
 
-            throw new PdfDocumentFormatException($"Could not find the object number {reference} with type {typeof(T).Name}.");
+            throw new PdfDocumentFormatException($"Could not find the object number {reference} with type {typeof(T).Name} instead, it was found with type {temp.GetType().Name}.");
         }
 
         public static T Get<T>(IToken token, IPdfTokenScanner scanner) where T : class, IToken
@@ -91,7 +91,7 @@
                 return Get<T>(reference.Data, scanner);
             }
 
-            throw new PdfDocumentFormatException($"Could not find the object {token} with type {typeof(T).Name}.");
+            throw new PdfDocumentFormatException($"Could not find the object {token} with type {typeof(T).Name} instead, it was found with type {token.GetType().Name}.");
         }
     }
 }

--- a/src/UglyToad.PdfPig/Tokenization/Scanner/PdfTokenScanner.cs
+++ b/src/UglyToad.PdfPig/Tokenization/Scanner/PdfTokenScanner.cs
@@ -256,35 +256,20 @@
 
             // Verify again that we start with "stream"
             var hasStartStreamToken = ReadStreamTokenStart(inputBytes, startStreamTokenOffset);
-
             if (!hasStartStreamToken)
             {
                 return false;
             }
 
             // From the specification: The stream operator should be followed by \r\n or \n, not just \r.
-            if (!inputBytes.MoveNext())
+            // While the specification demands a \n we have seen files with `garbage` before the actual data
+            do
             {
-                return false;
-            }
-
-            // While the specification demands a \n we have seen files with \r only in the wild.
-            var hadWhiteSpace = false;
-            if (inputBytes.CurrentByte == '\r')
-            {
-                hadWhiteSpace = true;
-                inputBytes.MoveNext();
-            }
-
-            if (inputBytes.CurrentByte != '\n')
-            {
-                if (!hadWhiteSpace)
+                if (!inputBytes.MoveNext())
                 {
                     return false;
                 }
-
-                inputBytes.Seek(inputBytes.CurrentOffset - 1);
-            }
+            } while ((char)inputBytes.CurrentByte != '\n');
 
             // Store where we started reading the first byte of data.
             long startDataOffset = inputBytes.CurrentOffset;


### PR DESCRIPTION
While testing the library wth a bunch of pdf. I found this "error". The pdf is readable by Adobe Reader and Foxit Reader, although the pdf is not completely compliant since after the `stream` operator contain a space.

![Stream Operator](https://user-images.githubusercontent.com/2200611/121818715-d6ec5b80-cc56-11eb-93d4-e729b1c9160d.png)

So I make the scanner more tolerable to `garbage` after the operator.

The second commit is not related to this problem at all, but it would allow us to see more clearly what token we are reading vs what token we were expecting. QoL
