### PR TITLE
adjust string serialization to handle raw byte data properly

### DIFF
--- a/src/UglyToad.PdfPig/Writer/TokenWriter.cs
+++ b/src/UglyToad.PdfPig/Writer/TokenWriter.cs
@@ -423,7 +423,7 @@
 
             if (stringToken.EncodedWith == StringToken.Encoding.Iso88591)
             {
-                // iso 88591 (or really PdfDocEncoding non-contentstream circumstances0 shouldn't
+                // iso 88591 (or really PdfDocEncoding in non-contentstream circumstances shouldn't
                 // have these chars but seems like internally this isn't obeyed (see:
                 // CanCreateDocumentInformationDictionaryWithNonAsciiCharacters test) and it may
                 // happen during parsing as well -> switch to unicode

--- a/src/UglyToad.PdfPig/Writer/TokenWriter.cs
+++ b/src/UglyToad.PdfPig/Writer/TokenWriter.cs
@@ -448,7 +448,7 @@
                             outputStream.WriteByte((byte)'\\');
                             outputStream.WriteByte((byte)Escaped[ei]);
                         }
-                        else if (c < 32 || c > 127) // non printable
+                        else if (c < 32 || c > 126) // non printable
                         {
                             var b3 = c / 64;
                             var b2 = (c - b3 * 64) / 8;

--- a/src/UglyToad.PdfPig/Writer/TokenWriter.cs
+++ b/src/UglyToad.PdfPig/Writer/TokenWriter.cs
@@ -448,7 +448,7 @@
                             outputStream.WriteByte((byte)'\\');
                             outputStream.WriteByte((byte)Escaped[ei]);
                         }
-                        else if (c < 32 || c > 126) // non printable
+                        else if (c < 32 || c > 127) // non printable
                         {
                             var b3 = c / 64;
                             var b2 = (c - b3 * 64) / 8;


### PR DESCRIPTION
This should resolve issues (or some of them) from #395.

Existing solution was not properly handling non-Utf16BE string. It would potentially escape some data as if it were non-unicode but then convert to unicode after escaping under certain circumstances. This implementation will properly write out with escaping non-unicode pdf string literals.