### PR TITLE
Add `SetTextRenderingMode` method to `PdfPageBuilder`

### DIFF
--- a/src/UglyToad.PdfPig.Core/TextRenderingMode.cs
+++ b/src/UglyToad.PdfPig.Core/TextRenderingMode.cs
@@ -1,4 +1,4 @@
-﻿namespace UglyToad.PdfPig.Graphics.Core
+﻿namespace UglyToad.PdfPig.Core
 {
     /// <summary>
     /// The text rendering mode determines whether showing text causes glyph outlines to be stroked, filled, used as a clipping boundary,

--- a/src/UglyToad.PdfPig.Tests/Writer/PdfDocumentBuilderTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Writer/PdfDocumentBuilderTests.cs
@@ -190,6 +190,62 @@
         }
 
         [Fact]
+        public void CanWriteSinglePageInvisibleHelloWorld()
+        {
+            var builder = new PdfDocumentBuilder();
+
+            PdfPageBuilder page = builder.AddPage(PageSize.A4);
+
+            PdfDocumentBuilder.AddedFont font = builder.AddStandard14Font(Standard14Font.Helvetica);
+
+            page.SetTextRenderingMode(TextRenderingMode.Neither);
+
+            page.AddText("Hello World!", 12, new PdfPoint(25, 520), font);
+
+            var b = builder.Build();
+
+            WriteFile(nameof(CanWriteSinglePageInvisibleHelloWorld), b);
+
+            using (var document = PdfDocument.Open(b))
+            {
+                var page1 = document.GetPage(1);
+
+                Assert.Equal(new[] { "Hello", "World!" }, page1.GetWords().Select(x => x.Text));
+            }
+        }
+
+        [Fact]
+        public void CanWriteSinglePageMixedRenderingMode()
+        {
+            var builder = new PdfDocumentBuilder();
+
+            PdfPageBuilder page = builder.AddPage(PageSize.A4);
+
+            PdfDocumentBuilder.AddedFont font = builder.AddStandard14Font(Standard14Font.Helvetica);
+
+            page.AddText("Hello World!", 12, new PdfPoint(25, 520), font);
+
+            page.SetTextRenderingMode(TextRenderingMode.Neither);
+
+            page.AddText("Invisible!", 12, new PdfPoint(25, 500), font);
+
+            page.SetTextRenderingMode(TextRenderingMode.Fill);
+
+            page.AddText("Filled again!", 12, new PdfPoint(25, 480), font);
+
+            var b = builder.Build();
+
+            WriteFile(nameof(CanWriteSinglePageMixedRenderingMode), b);
+
+            using (var document = PdfDocument.Open(b))
+            {
+                var page1 = document.GetPage(1);
+
+                Assert.Equal(new[] { "Hello", "World!", "Invisible!", "Filled", "again!" }, page1.GetWords().Select(x => x.Text));
+            }
+        }
+
+        [Fact]
         public void CanWriteSinglePageHelloWorld()
         {
             var builder = new PdfDocumentBuilder();

--- a/src/UglyToad.PdfPig/Graphics/Core/RenderingModeExtensions.cs
+++ b/src/UglyToad.PdfPig/Graphics/Core/RenderingModeExtensions.cs
@@ -1,5 +1,7 @@
 ﻿namespace UglyToad.PdfPig.Graphics.Core
 {
+    using UglyToad.PdfPig.Core;
+
     internal static class RenderingModeExtensions
     {
         public static bool IsFill(this TextRenderingMode mode)

--- a/src/UglyToad.PdfPig/Graphics/Operations/TextState/SetTextRenderingMode.cs
+++ b/src/UglyToad.PdfPig/Graphics/Operations/TextState/SetTextRenderingMode.cs
@@ -1,6 +1,7 @@
 ﻿namespace UglyToad.PdfPig.Graphics.Operations.TextState
 {
     using System.IO;
+    using PdfPig.Core;
     using Core;
 
     /// <inheritdoc />
@@ -21,6 +22,14 @@
         /// The text rendering mode to set.
         /// </summary>
         public TextRenderingMode Mode { get; }
+
+        /// <summary>
+        /// Create a new <see cref="SetTextRenderingMode"/>.
+        /// </summary>
+        public SetTextRenderingMode(TextRenderingMode mode)
+        {
+            Mode = mode;
+        }
 
         /// <summary>
         /// Create a new <see cref="SetTextRenderingMode"/>.

--- a/src/UglyToad.PdfPig/Writer/PdfPageBuilder.cs
+++ b/src/UglyToad.PdfPig/Writer/PdfPageBuilder.cs
@@ -340,6 +340,17 @@
             return letters;
         }
 
+        /// <summary>
+        /// Set the text rendering mode. This will apply to all future calls to AddText until called again.
+        ///
+        /// To insert invisible text, for example output of OCR, use <c>TextRenderingMode.Neither</c>.
+        /// </summary>
+        /// <param name="mode">Text rendering mode to set.</param>
+        public void SetTextRenderingMode(TextRenderingMode mode)
+        {
+            currentStream.Add(new SetTextRenderingMode(mode));
+        }
+
         private NameToken GetAddedFont(PdfDocumentBuilder.AddedFont font)
         {
             if (!documentFonts.TryGetValue(font.Id, out NameToken value))


### PR DESCRIPTION
Adds support for setting the text rendering mode when creating PDFs, as discussed in #368.

The tests are somewhat limited unfortunately, since I don't think there's a way of checking parsed text rendering mode with the current API, it only checks that the text is correctly inserted and can be read again. Is adding rendering mode information to letters  (when parsed) something you'd be interested in?