### PR TITLE
Net6 target framework

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -13,9 +13,11 @@ jobs:
       - uses: actions/checkout@master
 
       - name: Set up dotnet core
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v2
         with:
-          dotnet-version: "2.1.x"
+          dotnet-version: | 
+            2.1.x
+            6.0.x
 
       - name: Add msbuild to PATH
         uses: microsoft/setup-msbuild@v1.0.2

--- a/.github/workflows/nightly_release.yml
+++ b/.github/workflows/nightly_release.yml
@@ -30,9 +30,11 @@ jobs:
       - uses: actions/checkout@master
 
       - name: Set up dotnet core
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v2
         with:
-          dotnet-version: "2.1.x"
+          dotnet-version: | 
+            2.1.x
+            6.0.x
 
       - name: Add msbuild to PATH
         uses: microsoft/setup-msbuild@v1.0.2

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,7 +45,7 @@ Open `.\src\UglyToad.PdfPig\UglyToad.PdfPig.csproj` in a text editor and change:
 
 ```
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net45;net451;net452;net46;net461;net462;net47</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net45;net451;net452;net46;net461;net462;net47;net6.0</TargetFrameworks>
     <PackageId>PdfPig</PackageId>
     ...
 ```

--- a/src/UglyToad.PdfPig.Core/UglyToad.PdfPig.Core.csproj
+++ b/src/UglyToad.PdfPig.Core/UglyToad.PdfPig.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net45;net451;net452;net46;net461;net462;net47</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net45;net451;net452;net46;net461;net462;net47;net6.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <Version>0.1.6-alpha001</Version>
     <IsTestProject>False</IsTestProject>

--- a/src/UglyToad.PdfPig.DocumentLayoutAnalysis/UglyToad.PdfPig.DocumentLayoutAnalysis.csproj
+++ b/src/UglyToad.PdfPig.DocumentLayoutAnalysis/UglyToad.PdfPig.DocumentLayoutAnalysis.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net45;net451;net452;net46;net461;net462;net47</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net45;net451;net452;net46;net461;net462;net47;net6.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <Version>0.1.6-alpha001</Version>
     <IsTestProject>False</IsTestProject>

--- a/src/UglyToad.PdfPig.Fonts/UglyToad.PdfPig.Fonts.csproj
+++ b/src/UglyToad.PdfPig.Fonts/UglyToad.PdfPig.Fonts.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net45;net451;net452;net46;net461;net462;net47</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net45;net451;net452;net46;net461;net462;net47;net6.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <Version>0.1.6-alpha001</Version>
     <IsTestProject>False</IsTestProject>

--- a/src/UglyToad.PdfPig.Tests/Encryption/AesEncryptionHelperTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Encryption/AesEncryptionHelperTests.cs
@@ -23,7 +23,9 @@ namespace UglyToad.PdfPig.Tests.Encryption
 
             var output = AesEncryptionHelper.Decrypt(data, key);
 
-            Assert.Equal("D:20180808103317-07'00'", OtherEncodings.BytesAsLatin1String(output));
+            var actual = OtherEncodings.BytesAsLatin1String(output);
+
+            Assert.Equal("D:20180808103317-07'00'", actual);
         }
     }
 }

--- a/src/UglyToad.PdfPig.Tests/Fonts/SystemFonts/Linux.cs
+++ b/src/UglyToad.PdfPig.Tests/Fonts/SystemFonts/Linux.cs
@@ -5,6 +5,8 @@ using Xunit;
 
 namespace UglyToad.PdfPig.Tests.Fonts.SystemFonts
 {
+    using PdfPig.Core;
+
     public class Linux
     {
         public static IEnumerable<object[]> DataExtract => new[]
@@ -12,19 +14,43 @@ namespace UglyToad.PdfPig.Tests.Fonts.SystemFonts
             new object[]
             {
                 "90 180 270 rotated.pdf",
-                new object[][]
+                new ExpectedLetterData[]
                 {
-                    new object[] { "[(x:53.88, y:759.48), 2.495859375, 0]", 0.0 },
-                    new object[] { "[(x:514.925312502883, y:744.099765720344), 6.83203125, 7.94531249999983]", -90.0 },
-                    new object[] { "[(x:512.505390717836, y:736.603703191305), 5.1796875, 5.68945312499983]", -90.0 },
-                    new object[] { "[(x:512.505390785898, y:730.931828191305), 3.99609375, 5.52539062499994]", -90.0 },
+                    new ExpectedLetterData
+                    {
+                        TopLeft = new PdfPoint(53.88, 759.48),
+                        Width = 2.495859375,
+                        Height = 0,
+                        Rotation = 0
+                    },
+                    new ExpectedLetterData
+                    {
+                        TopLeft = new PdfPoint(514.925312502883, 744.099765720344),
+                        Width = 6.83203125,
+                        Height = 7.94531249999983,
+                        Rotation = -90
+                    },
+                    new ExpectedLetterData
+                    {
+                        TopLeft = new PdfPoint(512.505390717836, 736.603703191305),
+                        Width = 5.1796875,
+                        Height = 5.68945312499983,
+                        Rotation = -90
+                    },
+                    new ExpectedLetterData
+                    {
+                        TopLeft = new PdfPoint(512.505390785898, 730.931828191305),
+                        Width = 3.99609375, 
+                        Height = 5.52539062499994,
+                        Rotation = -90
+                    },
                 }
             },
         };
 
         [SkippableTheory]
         [MemberData(nameof(DataExtract))]
-        public void GetCorrectBBoxLinux(string name, object[][] expected)
+        public void GetCorrectBBoxLinux(string name, ExpectedLetterData[] expected)
         {
             // success on Windows but LinuxSystemFontLister cannot find the 'TimesNewRomanPSMT' font
             var font = SystemFontFinder.Instance.GetTrueTypeFont("TimesNewRomanPSMT");
@@ -36,13 +62,28 @@ namespace UglyToad.PdfPig.Tests.Fonts.SystemFonts
                 var page = document.GetPage(1);
                 for (int i = 0; i < expected.Length; i++)
                 {
-                    string bbox = (string)expected[i][0];
-                    var rotation = (double)expected[i][1];
+                    var expectedData = expected[i];
+
                     var current = page.Letters[i];
-                    Assert.Equal(bbox, current.GlyphRectangle.ToString());
-                    Assert.Equal(rotation, current.GlyphRectangle.Rotation, 3);
+
+                    Assert.Equal(expectedData.TopLeft.X, current.GlyphRectangle.TopLeft.X, 7);
+                    Assert.Equal(expectedData.TopLeft.Y, current.GlyphRectangle.TopLeft.Y, 7);
+                    Assert.Equal(expectedData.Width, current.GlyphRectangle.Width, 7);
+                    Assert.Equal(expectedData.Height, current.GlyphRectangle.Height, 7);
+                    Assert.Equal(expectedData.Rotation, current.GlyphRectangle.Rotation, 3);
                 }
             }
+        }
+
+        public class ExpectedLetterData
+        {
+            public PdfPoint TopLeft { get; set; }
+
+            public double Width { get; set; }
+
+            public double Height { get; set; }
+
+            public double Rotation { get; set; }
         }
     }
 }

--- a/src/UglyToad.PdfPig.Tests/UglyToad.PdfPig.Tests.csproj
+++ b/src/UglyToad.PdfPig.Tests/UglyToad.PdfPig.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFrameworks>netcoreapp2.0;net6.0</TargetFrameworks>
     <IsTestProject>true</IsTestProject>
     <IsPackable>false</IsPackable>
     <DebugType>full</DebugType>

--- a/src/UglyToad.PdfPig.Tokenization/UglyToad.PdfPig.Tokenization.csproj
+++ b/src/UglyToad.PdfPig.Tokenization/UglyToad.PdfPig.Tokenization.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net45;net451;net452;net46;net461;net462;net47</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net45;net451;net452;net46;net461;net462;net47;net6.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <Version>0.1.6-alpha001</Version>
     <IsTestProject>False</IsTestProject>

--- a/src/UglyToad.PdfPig.Tokens/UglyToad.PdfPig.Tokens.csproj
+++ b/src/UglyToad.PdfPig.Tokens/UglyToad.PdfPig.Tokens.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net45;net451;net452;net46;net461;net462;net47</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net45;net451;net452;net46;net461;net462;net47;net6.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <Version>0.1.6-alpha001</Version>
     <IsTestProject>False</IsTestProject>

--- a/src/UglyToad.PdfPig/Encryption/AesEncryptionHelper.cs
+++ b/src/UglyToad.PdfPig/Encryption/AesEncryptionHelper.cs
@@ -35,16 +35,16 @@
                     input.Seek(iv.Length, SeekOrigin.Begin);
                     using (var cryptoStream = new CryptoStream(input, decryptor, CryptoStreamMode.Read))
                     {
+                        var offset = 0;
                         int read;
-                        while ((read = cryptoStream.Read(buffer, 0, buffer.Length)) != -1)
+                        do
                         {
-                            output.Write(buffer, 0, read);
+                            read = cryptoStream.Read(buffer, offset, buffer.Length - offset);
 
-                            if (read < buffer.Length)
-                            {
-                                break;
-                            }
-                        }
+                            output.Write(buffer, offset, read);
+
+                            offset += read;
+                        } while (read > 0);
 
                         return output.ToArray();
                     }

--- a/src/UglyToad.PdfPig/UglyToad.PdfPig.csproj
+++ b/src/UglyToad.PdfPig/UglyToad.PdfPig.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net45;net451;net452;net46;net461;net462;net47</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net45;net451;net452;net46;net461;net462;net47;net6.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <Version>0.1.6-alpha001</Version>
     <IsTestProject>False</IsTestProject>

--- a/tools/UglyToad.PdfPig.Package/UglyToad.PdfPig.Package.csproj
+++ b/tools/UglyToad.PdfPig.Package/UglyToad.PdfPig.Package.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net45;net451;net452;net46;net461;net462;net47</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net45;net451;net452;net46;net461;net462;net47;net6.0</TargetFrameworks>
     <PackageId>PdfPig</PackageId>
     <DebugType>full</DebugType>
     <Authors>UglyToad</Authors>


### PR DESCRIPTION
#433 includes details of issues when targetting .NET 6, this adds support for .NET 6 by fixing identified breaking changes in the AES API https://docs.microsoft.com/en-us/dotnet/core/compatibility/core-libraries/6.0/partial-byte-reads-in-streams

Adds .NET 6 target framework and runs tests on .NET 6.