### PR TITLE
add handling for combining diacritics #439

### DIFF
--- a/src/UglyToad.PdfPig.Tests/Integration/FarmerMacTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Integration/FarmerMacTests.cs
@@ -42,6 +42,5 @@
                 Assert.Contains("financial results for the fiscal quarter ended June 30, 2017 and (2) a conference call to discuss those results and Farmer Mac", page.Text);
             }
         }
-
     }
 }

--- a/src/UglyToad.PdfPig.Tests/Integration/Math119FakingDataTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Integration/Math119FakingDataTests.cs
@@ -1,0 +1,18 @@
+﻿namespace UglyToad.PdfPig.Tests.Integration;
+
+using Xunit;
+
+public class Math119FakingDataTests
+{
+    [Fact]
+    public void CombinesDiaeresisForWords()
+    {
+        using var document = PdfDocument.Open(IntegrationHelpers.GetDocumentPath("Math119FakingData.pdf"));
+
+        var lastPage = document.GetPage(8);
+
+        var words = lastPage.GetWords();
+
+
+    }
+}

--- a/src/UglyToad.PdfPig/Graphics/ContentStreamProcessor.cs
+++ b/src/UglyToad.PdfPig/Graphics/ContentStreamProcessor.cs
@@ -295,7 +295,7 @@
                     : currentState.CurrentStrokingColor;
 
                 Letter letter = null;
-                if (Diacritics.IsInCombiningDiacriticRange(unicode) && letters.Count > 0)
+                if (Diacritics.IsInCombiningDiacriticRange(unicode) && bytes.CurrentOffset > 0 && letters.Count > 0)
                 {
                     var attachTo = letters[letters.Count - 1];
 

--- a/src/UglyToad.PdfPig/Util/Diacritics.cs
+++ b/src/UglyToad.PdfPig/Util/Diacritics.cs
@@ -1,0 +1,75 @@
+﻿namespace UglyToad.PdfPig.Util
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Globalization;
+
+    internal static class Diacritics
+    {
+        private static readonly HashSet<string> NonCombiningDiacritics = new HashSet<string>
+        {
+            "´",
+            "^",
+            "ˆ",
+            "¨",
+            "©",
+            "™",
+            "®",
+            "`",
+            "˜",
+            "∼",
+            "¸"
+        };
+
+        public static bool IsPotentialStandaloneDiacritic(string value) => NonCombiningDiacritics.Contains(value);
+
+        public static bool IsInCombiningDiacriticRange(string value)
+        {
+            if (value.Length != 1)
+            {
+                return false;
+            }
+
+            var intVal = (int)value[0];
+
+            if (intVal >= 768 && intVal <= 879)
+            {
+                return true;
+            }
+
+            return false;
+        }
+
+        public static bool TryCombineDiacriticWithPreviousLetter(string diacritic, string previous, out string result)
+        {
+            result = null;
+
+            if (previous == null)
+            {
+                return false;
+            }
+
+            result = previous + diacritic;
+
+            // On combining the length should remain equal.
+            var beforeCombination = MeasureDiacriticAwareLength(previous);
+            var afterCombination = MeasureDiacriticAwareLength(result);
+
+            return beforeCombination == afterCombination;
+        }
+
+        private static int MeasureDiacriticAwareLength(string input)
+        {
+            var length = 0;
+
+            var enumerator = StringInfo.GetTextElementEnumerator(input);
+            while (enumerator.MoveNext())
+            {
+                var grapheme = enumerator.GetTextElement();
+                length++;
+            }
+
+            return length;
+        }
+    }
+}


### PR DESCRIPTION
Surprisingly PDFs can contain the combining diacritics as part of the content stream. For these combining types combine with the preceding letter since they don't make sense alone. See #439 