### PR TITLE
Add support for text colors with alpha (aka transparency)

### DIFF
--- a/src/UglyToad.PdfPig.SystemDrawing/SystemDrawingExtensions.cs
+++ b/src/UglyToad.PdfPig.SystemDrawing/SystemDrawingExtensions.cs
@@ -60,9 +60,15 @@ namespace UglyToad.PdfPig.SystemDrawing
             if (pdfColor != null)
             {
                 var colorRgb = pdfColor.ToRGBValues();
+                if (pdfColor is AlphaColor alphaColor)
+                {
+                    return Color.FromArgb((int)(alphaColor.A * 255), (int)(colorRgb.r * 255), (int)(colorRgb.g * 255), (int)(colorRgb.b * 255));
+                }
                 return Color.FromArgb((int)(colorRgb.r * 255), (int)(colorRgb.g * 255), (int)(colorRgb.b * 255));
+
             }
             return Color.Black;
         }
+
     }
 }

--- a/src/UglyToad.PdfPig/Graphics/Colors/AlphaColor.cs
+++ b/src/UglyToad.PdfPig/Graphics/Colors/AlphaColor.cs
@@ -1,0 +1,97 @@
+﻿namespace UglyToad.PdfPig.Graphics.Colors
+{
+    using System;
+    using System.Collections.Generic;
+
+    /// <summary>
+    /// A color with alpha then base color
+    /// </summary>
+    public class AlphaColor : IColor, IEquatable<AlphaColor>
+    {
+        /// <summary>
+        /// The alpha value between 0 and 1.
+        /// </summary>
+        public decimal A { get; }
+
+        /// <summary>
+        /// Base color without alpha.
+        /// </summary>
+        public IColor baseColor { get; }
+
+        /// <summary>
+        /// Create a new <see cref="AlphaColor"/>.
+        /// </summary>
+        /// <param name="a">The alpha value between 0 and 1.</param>
+        /// <param name="baseColor">The base color without alpha.</param>
+
+        public AlphaColor(decimal a, IColor baseColor)  
+        {
+            A = a;        
+            this.baseColor = baseColor;
+        }
+
+        /// <inheritdoc/>
+        public ColorSpace ColorSpace { get { return baseColor.ColorSpace; } }
+
+        /// <inheritdoc/>
+        public (decimal r, decimal g, decimal b) ToRGBValues()
+        {
+            var values = baseColor.ToRGBValues();
+            return values;
+        }
+
+
+
+        /// <inheritdoc />
+        public override bool Equals(object obj)
+        {
+            if (obj.GetType() == baseColor.GetType())
+            {
+                return Equals(obj);
+            }
+
+            return false;
+        }
+
+        /// <inheritdoc />
+        /// <summary>
+        /// Whether 2 RGB colors are equal across all channels.
+        /// </summary>
+        public bool Equals(AlphaColor other)
+        {
+            if (other is null) return false;             
+            if (A != other.A) return false;
+            var values = baseColor.ToRGBValues();
+            var valuesOther = baseColor.ToRGBValues();
+            return                    
+                   valuesOther.r == values.r &&
+                   valuesOther.g == values.g &&
+                   valuesOther.b == values.b;
+        }
+
+        /// <inheritdoc />
+        public override int GetHashCode()
+        {
+            var values = baseColor.ToRGBValues();
+            return (A, values.r, values.g, values.b).GetHashCode();
+        }
+
+        /// <summary>
+        /// Equals.
+        /// </summary>
+        public static bool operator ==(AlphaColor color1, AlphaColor color2) =>
+            EqualityComparer<AlphaColor>.Default.Equals(color1, color2);
+
+        /// <summary>
+        /// Not Equals.
+        /// </summary>
+        public static bool operator !=(AlphaColor color1, AlphaColor color2) => !(color1 == color2);
+
+        /// <inheritdoc />
+        public override string ToString()
+        {
+            var values = baseColor.ToRGBValues();
+            return $"ARGB: ({A}, {values.r}, {values.g}, {values.b})";
+        }
+    }
+}

--- a/src/UglyToad.PdfPig/Graphics/CurrentGraphicsState.cs
+++ b/src/UglyToad.PdfPig/Graphics/CurrentGraphicsState.cs
@@ -61,7 +61,12 @@ namespace UglyToad.PdfPig.Graphics
         /// <summary>
         /// Opacity value to be used for transparent imaging.
         /// </summary>
-        public decimal AlphaConstant { get; set; } = 1;
+        public decimal AlphaConstantStroking { get; set; } = 1;
+
+        /// <summary>
+        /// Opacity value to be used for transparent imaging.
+        /// </summary>
+        public decimal AlphaConstantNonStroking { get; set; } = 1;
 
         /// <summary>
         /// Should soft mask and alpha constant values be interpreted as shape (<see langword="true"/>) or opacity (<see langword="false"/>) values?
@@ -129,7 +134,8 @@ namespace UglyToad.PdfPig.Graphics
                 CapStyle = CapStyle,
                 MiterLimit = MiterLimit,
                 Flatness = Flatness,
-                AlphaConstant = AlphaConstant,
+                AlphaConstantStroking = AlphaConstantStroking,
+                AlphaConstantNonStroking = AlphaConstantNonStroking,
                 AlphaSource = AlphaSource,
                 NonStrokingOverprint = NonStrokingOverprint,
                 OverprintMode = OverprintMode,


### PR DESCRIPTION
Have a pdf document that uses gs operator to change the alpha state of non-stroked graphics to opaque (hidden) so show-text (operator Tj) is not shown  but then writes the text using path operators. The two are in similar places but render differently. 

This change 
1. In BaseDrawngProcessor.cs update SetNamedGraphicsState() to supports the 'ca' and 'CA' tokens in the gs operator to set 
     'AlphaConstantStroking' (renamed from just 'AlphaConstant' and a new matching 
     'AlphaConstantNonStroking'.
2. Adds a new class AlphaColor (supporting IColor interface) but can wrap any existing color (RGBColor, CMYKColor, GrayColor,...) but add alpha constant (also decimal).
3. In System.Drawing updates SystemDrawingExntions.cs method ToSystemColor() to check for new AlphaColor and return a system color which uses not only rgb but also alpha.
4. In BaseDrawngProcessor.cs update ShowText() to use AlphaColor to pass down DrawLetter.
