### PR TITLE
Implement TryGetPath and TryGetNormalisedPath for fonts

### DIFF
--- a/src/UglyToad.PdfPig.Core/PdfSubpath.cs
+++ b/src/UglyToad.PdfPig.Core/PdfSubpath.cs
@@ -196,7 +196,7 @@
                 throw new ArgumentNullException("BezierCurveTo(): currentPosition is null.");
             }
         }
-        
+
         /// <summary>
         /// Close the path.
         /// </summary>
@@ -212,7 +212,7 @@
             }
             commands.Add(new Close());
         }
-        
+
         /// <summary>
         /// Determines if the path is currently closed.
         /// </summary>
@@ -348,6 +348,30 @@
             var height = line2.To.Y - line1.To.Y;
 
             return new PdfRectangle(mv.Location, new PdfPoint(mv.Location.X + width, mv.Location.Y + height));
+        }
+
+        /// <summary>
+        /// Gets a <see cref="PdfRectangle"/> which entirely contains the geometry of the defined path.
+        /// </summary>
+        /// <returns>For paths which don't define any geometry this returns <see langword="null"/>.</returns>
+        public static PdfRectangle? GetBoundingRectangle(IReadOnlyList<PdfSubpath> path)
+        {
+            if (path == null || path.Count == 0)
+            {
+                return null;
+            }
+
+            var bboxes = path.Select(x => x.GetBoundingRectangle()).Where(x => x.HasValue).Select(x => x.Value).ToList();
+            if (bboxes.Count == 0)
+            {
+                return null;
+            }
+
+            var minX = bboxes.Min(x => x.Left);
+            var minY = bboxes.Min(x => x.Bottom);
+            var maxX = bboxes.Max(x => x.Right);
+            var maxY = bboxes.Max(x => x.Top);
+            return new PdfRectangle(minX, minY, maxX, maxY);
         }
 
         /// <summary>

--- a/src/UglyToad.PdfPig.Fonts/CompactFontFormat/CharStrings/Type2CharStringParser.cs
+++ b/src/UglyToad.PdfPig.Fonts/CompactFontFormat/CharStrings/Type2CharStringParser.cs
@@ -1,13 +1,10 @@
 ﻿// ReSharper disable CompareOfFloatsByEqualityOperator
 namespace UglyToad.PdfPig.Fonts.CompactFontFormat.CharStrings
 {
+    using Charsets;
     using System;
     using System.Collections.Generic;
-    using System.Diagnostics;
     using System.Linq;
-    using System.Runtime.CompilerServices;
-    using Charsets;
-    using Core;
 
     /// <summary>
     /// Decodes the commands and numbers making up a Type 2 CharString. A Type 2 CharString extends on the Type 1 CharString format.
@@ -18,7 +15,7 @@ namespace UglyToad.PdfPig.Fonts.CompactFontFormat.CharStrings
     /// A Type 2 charstring program is a sequence of unsigned 8-bit bytes that encode numbers and operators.
     /// The byte value specifies a operator, a number, or subsequent bytes that are to be interpreted in a specific manner
     /// </remarks>
-    internal class Type2CharStringParser
+    internal static class Type2CharStringParser
     {
         private const byte HstemByte = 1;
         private const byte VstemByte = 3;
@@ -94,10 +91,7 @@ namespace UglyToad.PdfPig.Fonts.CompactFontFormat.CharStrings
                 new LazyType2Command("vmoveto", 1, ctx =>
                 {
                     var dy = ctx.Stack.PopBottom();
-
-                    ctx.Path.MoveTo(ctx.CurrentLocation.X, ctx.CurrentLocation.Y + dy);
-                    ctx.CurrentLocation = ctx.CurrentLocation.MoveY(dy);
-
+                    ctx.AddVerticallMoveTo(dy);
                     ctx.Stack.Clear();
                 })
             },
@@ -251,13 +245,7 @@ namespace UglyToad.PdfPig.Fonts.CompactFontFormat.CharStrings
                 {
                     var dx = ctx.Stack.PopBottom();
                     var dy = ctx.Stack.PopBottom();
-
-                    var newLocation = new PdfPoint(ctx.CurrentLocation.X + dx,
-                        ctx.CurrentLocation.Y + dy);
-
-                    ctx.Path.MoveTo(newLocation.X, newLocation.Y);
-                    ctx.CurrentLocation = newLocation;
-
+                    ctx.AddRelativeMoveTo(dx,dy);
                     ctx.Stack.Clear();
                 })
             },
@@ -265,10 +253,7 @@ namespace UglyToad.PdfPig.Fonts.CompactFontFormat.CharStrings
                 new LazyType2Command("hmoveto", 1, ctx =>
                 {
                     var dx = ctx.Stack.PopBottom();
-
-                    ctx.Path.MoveTo(ctx.CurrentLocation.X + dx, ctx.CurrentLocation.Y);
-                    ctx.CurrentLocation = ctx.CurrentLocation.MoveX(dx);
-
+                    ctx.AddHorizontalMoveTo(dx);
                     ctx.Stack.Clear();
                 })
             },

--- a/src/UglyToad.PdfPig.Fonts/CompactFontFormat/CharStrings/Type2CharStrings.cs
+++ b/src/UglyToad.PdfPig.Fonts/CompactFontFormat/CharStrings/Type2CharStrings.cs
@@ -1,10 +1,10 @@
 ﻿namespace UglyToad.PdfPig.Fonts.CompactFontFormat.CharStrings
 {
+    using Core;
     using System;
     using System.Collections.Generic;
     using System.Globalization;
     using System.Text;
-    using Core;
 
     /// <summary>
     /// Stores the decoded command sequences for Type 2 CharStrings from a Compact Font Format font as well
@@ -20,7 +20,6 @@
         /// The decoded charstrings in this font.
         /// </summary>
         public IReadOnlyDictionary<string, CommandSequence> CharStrings { get; }
-
 
         public Type2CharStrings(IReadOnlyDictionary<string, CommandSequence> charStrings)
         {
@@ -70,7 +69,7 @@
         private static Type2Glyph Run(CommandSequence sequence, double defaultWidthX, double nominalWidthX)
         {
             var context = new Type2BuildCharContext();
-            
+
             var hasRunStackClearingCommand = false;
             for (var i = -1; i < sequence.Values.Count; i++)
             {
@@ -224,7 +223,7 @@
         /// <summary>
         /// The path of the glyph.
         /// </summary>
-        public PdfSubpath Path { get; }
+        public IReadOnlyList<PdfSubpath> Path { get; }
 
         /// <summary>
         /// The width of the glyph as a difference from the nominal width X for the font. Optional.
@@ -234,7 +233,7 @@
         /// <summary>
         /// Create a new <see cref="Type2Glyph"/>.
         /// </summary>
-        public Type2Glyph(PdfSubpath path, double? width)
+        public Type2Glyph(IReadOnlyList<PdfSubpath> path, double? width)
         {
             Path = path ?? throw new ArgumentNullException(nameof(path));
             Width = width;

--- a/src/UglyToad.PdfPig.Fonts/CompactFontFormat/CompactFontFormatFont.cs
+++ b/src/UglyToad.PdfPig.Fonts/CompactFontFormat/CompactFontFormatFont.cs
@@ -1,12 +1,12 @@
 ﻿namespace UglyToad.PdfPig.Fonts.CompactFontFormat
 {
-    using System;
-    using System.Collections.Generic;
     using Charsets;
     using CharStrings;
     using Core;
     using Dictionaries;
     using Encodings;
+    using System;
+    using System.Collections.Generic;
     using Type1.CharStrings;
 
     /// <summary>
@@ -69,7 +69,7 @@
             }
 
             var glyph = type2CharStrings.Generate(characterName, (double)defaultWidthX, (double)nominalWidthX);
-            var rectangle = glyph.Path.GetBoundingRectangle();
+            var rectangle = PdfSubpath.GetBoundingRectangle(glyph.Path);
             if (rectangle.HasValue)
             {
                 return rectangle;
@@ -77,7 +77,55 @@
 
             var defaultBoundingBox = TopDictionary.FontBoundingBox;
             return new PdfRectangle(0, 0, glyph.Width.GetValueOrDefault(), defaultBoundingBox.Height);
+        }
 
+        /// <summary>
+        /// Get the pdfpath for the character with the given name.
+        /// </summary>
+        /// <param name="characterName"></param>
+        /// <param name="path"></param>
+        /// <returns></returns>
+        public bool TryGetPath(string characterName, out IReadOnlyList<PdfSubpath> path)
+        {
+            var defaultWidthX = GetDefaultWidthX(characterName);
+            var nominalWidthX = GetNominalWidthX(characterName);
+
+            if (CharStrings.TryGetFirst(out var _))
+            {
+                throw new NotImplementedException("Type 1 CharStrings in a CFF font are currently unsupported.");
+            }
+
+            if (!CharStrings.TryGetSecond(out var type2CharStrings))
+            {
+                path = null;
+                return false;
+            }
+
+            path = type2CharStrings.Generate(characterName, (double)defaultWidthX, (double)nominalWidthX).Path;
+            return true;
+        }
+
+        /// <summary>
+        /// GetCharacterPath
+        /// </summary>
+        /// <param name="characterName"></param>
+        /// <returns></returns>
+        public IReadOnlyList<PdfSubpath> GetCharacterPath(string characterName)
+        {
+            var defaultWidthX = GetDefaultWidthX(characterName);
+            var nominalWidthX = GetNominalWidthX(characterName);
+
+            if (CharStrings.TryGetFirst(out var _))
+            {
+                throw new NotImplementedException("Type 1 CharStrings in a CFF font are currently unsupported.");
+            }
+
+            if (!CharStrings.TryGetSecond(out var type2CharStrings))
+            {
+                return null;
+            }
+
+            return type2CharStrings.Generate(characterName, (double)defaultWidthX, (double)nominalWidthX).Path;
         }
 
         /// <summary>

--- a/src/UglyToad.PdfPig.Fonts/GlyphList.cs
+++ b/src/UglyToad.PdfPig.Fonts/GlyphList.cs
@@ -15,7 +15,7 @@
 
         private readonly IReadOnlyDictionary<string, string> nameToUnicode;
         private readonly IReadOnlyDictionary<string, string> unicodeToName;
-        
+
         private readonly Dictionary<string, string> oddNameToUnicodeCache = new Dictionary<string, string>();
 
         private static readonly Lazy<GlyphList> LazyAdobeGlyphList = new Lazy<GlyphList>(() => GlyphListFactory.Get("glyphlist"));
@@ -138,9 +138,9 @@
             else if (name.StartsWith("u") && name.Length == 5)
             {
                 // test for an alternate Unicode name representation uXXXX
-                    var codePoint = int.Parse(name.Substring(1), NumberStyles.HexNumber, CultureInfo.InvariantCulture);
+                var codePoint = int.Parse(name.Substring(1), NumberStyles.HexNumber, CultureInfo.InvariantCulture);
 
-                    if (codePoint > 0xD7FF && codePoint < 0xE000)
+                if (codePoint > 0xD7FF && codePoint < 0xE000)
                 {
                     throw new InvalidFontFormatException(
                         $"Unicode character name with disallowed code area: {name}");
@@ -159,4 +159,3 @@
         }
     }
 }
-

--- a/src/UglyToad.PdfPig.Fonts/TrueType/Glyphs/GlyphPoint.cs
+++ b/src/UglyToad.PdfPig.Fonts/TrueType/Glyphs/GlyphPoint.cs
@@ -1,5 +1,7 @@
 ﻿namespace UglyToad.PdfPig.Fonts.TrueType.Glyphs
 {
+    using UglyToad.PdfPig.Core;
+
     internal struct GlyphPoint
     {
         public short X { get; }
@@ -8,16 +10,19 @@
 
         public bool IsOnCurve { get; }
 
-        public GlyphPoint(short x, short y, bool isOnCurve) 
+        public bool IsEndOfContour { get; }
+
+        public GlyphPoint(short x, short y, bool isOnCurve, bool isEndOfContour)
         {
             X = x;
             Y = y;
             IsOnCurve = isOnCurve;
+            IsEndOfContour = isEndOfContour;
         }
 
         public override string ToString()
         {
-            return $"({X}, {Y}) | {IsOnCurve}";
+            return $"({X}, {Y}) | {IsOnCurve} | {IsEndOfContour}";
         }
     }
 }

--- a/src/UglyToad.PdfPig.Fonts/TrueType/Glyphs/IGlyphDescription.cs
+++ b/src/UglyToad.PdfPig.Fonts/TrueType/Glyphs/IGlyphDescription.cs
@@ -1,6 +1,7 @@
 ﻿namespace UglyToad.PdfPig.Fonts.TrueType.Glyphs
 {
     using Core;
+    using System.Collections.Generic;
 
     internal interface IGlyphDescription : IMergeableGlyph, ITransformableGlyph
     {
@@ -15,6 +16,8 @@
         GlyphPoint[] Points { get; }
 
         bool IsEmpty { get; }
+
+        bool TryGetGlyphPath(out IReadOnlyList<PdfSubpath> subpaths);
 
         IGlyphDescription DeepClone();
     }

--- a/src/UglyToad.PdfPig.Fonts/TrueType/Parser/TableRegister.cs
+++ b/src/UglyToad.PdfPig.Fonts/TrueType/Parser/TableRegister.cs
@@ -9,7 +9,7 @@
     public class TableRegister
     {
         /// <summary>
-        /// This table contains global information about the font. 
+        /// This table contains global information about the font.
         /// </summary>
         public HeaderTable HeaderTable { get; }
 

--- a/src/UglyToad.PdfPig.Fonts/TrueType/Tables/GlyphDataTable.cs
+++ b/src/UglyToad.PdfPig.Fonts/TrueType/Tables/GlyphDataTable.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.Collections.Generic;
+    using System.Linq;
     using Core;
     using Glyphs;
     using Parser;
@@ -25,9 +26,9 @@
 
         private readonly Lazy<IReadOnlyList<IGlyphDescription>> glyphs;
         public IReadOnlyList<IGlyphDescription> Glyphs => glyphs.Value;
-        
-        public GlyphDataTable(TrueTypeHeaderTable directoryTable, IReadOnlyList<uint> glyphOffsets, 
-            PdfRectangle maxGlyphBounds, 
+
+        public GlyphDataTable(TrueTypeHeaderTable directoryTable, IReadOnlyList<uint> glyphOffsets,
+            PdfRectangle maxGlyphBounds,
             TrueTypeDataBytes tableBytes)
         {
             this.glyphOffsets = glyphOffsets;
@@ -69,7 +70,7 @@
                 bounds = new PdfRectangle(0, 0, 0, 0);
                 return true;
             }
-            
+
             tableBytes.Seek(offset);
 
             // ReSharper disable once UnusedVariable
@@ -91,7 +92,7 @@
 
             var bytes = data.ReadByteArray((int)table.Length);
 
-            return new GlyphDataTable(table, tableRegister.IndexToLocationTable.GlyphOffsets, 
+            return new GlyphDataTable(table, tableRegister.IndexToLocationTable.GlyphOffsets,
                 tableRegister.HeaderTable.Bounds,
                 new TrueTypeDataBytes(bytes));
         }
@@ -164,7 +165,7 @@
             if (contourCount == 0)
             {
                 return new Glyph(true, EmptyArray<byte>.Instance, EmptyArray<ushort>.Instance,
-                    EmptyArray<GlyphPoint>.Instance, 
+                    EmptyArray<GlyphPoint>.Instance,
                     new PdfRectangle(0, 0, 0, 0));
             }
 
@@ -188,11 +189,25 @@
             var yCoordinates = ReadCoordinates(data, pointCount, flags, SimpleGlyphFlags.YSingleByte,
                 SimpleGlyphFlags.ThisYIsTheSame);
 
+            int endPtIndex = endPointsOfContours.Length - 1;
+            int endPtOfContourIndex = -1;
             var points = new GlyphPoint[xCoordinates.Length];
+
             for (var i = xCoordinates.Length - 1; i >= 0; i--)
             {
+                if (endPtOfContourIndex == -1)
+                {
+                    endPtOfContourIndex = endPointsOfContours[endPtIndex];
+                }
+                bool endPt = endPtOfContourIndex == i;
+                if (endPt && endPtIndex > 0)
+                {
+                    endPtIndex--;
+                    endPtOfContourIndex = -1;
+                }
+
                 var isOnCurve = (flags[i] & SimpleGlyphFlags.OnCurve) == SimpleGlyphFlags.OnCurve;
-                points[i] = new GlyphPoint(xCoordinates[i], yCoordinates[i], isOnCurve);
+                points[i] = new GlyphPoint(xCoordinates[i], yCoordinates[i], isOnCurve, endPt);
             }
 
             return new Glyph(true, instructions, endPointsOfContours, points, bounds);
@@ -209,12 +224,12 @@
             data.Seek(compositeLocation.Position);
 
             var components = new List<CompositeComponent>();
-            
+
             // First recursively find all components and ensure they are available.
             CompositeGlyphFlags flags;
             do
             {
-                flags = (CompositeGlyphFlags) data.ReadUnsignedShort();
+                flags = (CompositeGlyphFlags)data.ReadUnsignedShort();
                 var glyphIndex = data.ReadUnsignedShort();
 
                 var childGlyph = glyphs[glyphIndex];
@@ -232,7 +247,7 @@
 
                     glyphs[glyphIndex] = childGlyph;
                 }
-                
+
                 short arg1, arg2;
                 if (HasFlag(flags, CompositeGlyphFlags.Args1And2AreWords))
                 {
@@ -276,7 +291,6 @@
                 {
                     // TODO: Not implemented, it is unclear how to do this.
                 }
-
             } while (HasFlag(flags, CompositeGlyphFlags.MoreComponents));
 
             // Now build the final glyph from the components.
@@ -381,12 +395,12 @@
             /// Stores the position after reading the contour count and bounds.
             /// </summary>
             public long Position { get; }
-            
+
             public PdfRectangle Bounds { get; }
-            
+
             public TemporaryCompositeLocation(long position, PdfRectangle bounds, short contourCount)
             {
-                if (contourCount >= 0 )
+                if (contourCount >= 0)
                 {
                     throw new ArgumentException($"A composite glyph should not have a positive contour count. Got: {contourCount}.", nameof(contourCount));
                 }

--- a/src/UglyToad.PdfPig.Fonts/TrueType/TrueTypeFont.cs
+++ b/src/UglyToad.PdfPig.Fonts/TrueType/TrueTypeFont.cs
@@ -112,7 +112,7 @@
             {
                 return false;
             }
-            
+
             if (!TableRegister.GlyphTable.TryGetGlyphBounds(index, out boundingBox))
             {
                 return false;
@@ -124,6 +124,28 @@
             }
 
             return true;
+        }
+
+        /// <summary>
+        /// Try to get the bounding box for a glyph representing the specified character code if present.
+        /// </summary>
+        public bool TryGetPath(int characterCode, out IReadOnlyList<PdfSubpath> path) => TryGetPath(characterCode, null, out path);
+
+        /// <summary>
+        /// Try to get the path for a glyph representing the specified character code if present.
+        /// Uses a custom mapping of character code to glyph index.
+        /// </summary>
+        public bool TryGetPath(int characterCode, Func<int, int?> characterCodeToGlyphId, out IReadOnlyList<PdfSubpath> path)
+        {
+            path = EmptyArray<PdfSubpath>.Instance;
+
+            if (!TryGetGlyphIndex(characterCode, characterCodeToGlyphId, out var index)
+                || TableRegister.GlyphTable == null)
+            {
+                return false;
+            }
+
+            return TableRegister.GlyphTable.Glyphs[index].TryGetGlyphPath(out path);
         }
 
         /// <summary>

--- a/src/UglyToad.PdfPig.Fonts/Type1/CharStrings/Commands/PathConstruction/ClosePathCommand.cs
+++ b/src/UglyToad.PdfPig.Fonts/Type1/CharStrings/Commands/PathConstruction/ClosePathCommand.cs
@@ -17,7 +17,7 @@
         
         public static void Run(Type1BuildCharContext context)
         {
-            context.Path.CloseSubpath();
+            context.Path[context.Path.Count - 1].CloseSubpath();
             context.Stack.Clear();
         }
     }

--- a/src/UglyToad.PdfPig.Fonts/Type1/CharStrings/Commands/PathConstruction/HLineToCommand.cs
+++ b/src/UglyToad.PdfPig.Fonts/Type1/CharStrings/Commands/PathConstruction/HLineToCommand.cs
@@ -22,7 +22,7 @@
             var deltaX = context.Stack.PopBottom();
             var x = context.CurrentPosition.X + deltaX;
 
-            context.Path.LineTo(x, context.CurrentPosition.Y);
+            context.Path[context.Path.Count - 1].LineTo(x, context.CurrentPosition.Y);
             context.CurrentPosition = new PdfPoint(x, context.CurrentPosition.Y);
 
             context.Stack.Clear();

--- a/src/UglyToad.PdfPig.Fonts/Type1/CharStrings/Commands/PathConstruction/HMoveToCommand.cs
+++ b/src/UglyToad.PdfPig.Fonts/Type1/CharStrings/Commands/PathConstruction/HMoveToCommand.cs
@@ -31,7 +31,9 @@
                 var x = context.CurrentPosition.X + deltaX;
                 var y = context.CurrentPosition.Y;
                 context.CurrentPosition = new PdfPoint(x, y);
-                context.Path.MoveTo(x, y);
+
+                context.Path.Add(new PdfSubpath());
+                context.Path[context.Path.Count - 1].MoveTo(x, y);
             }
 
             context.Stack.Clear();

--- a/src/UglyToad.PdfPig.Fonts/Type1/CharStrings/Commands/PathConstruction/HvCurveToCommand.cs
+++ b/src/UglyToad.PdfPig.Fonts/Type1/CharStrings/Commands/PathConstruction/HvCurveToCommand.cs
@@ -34,7 +34,7 @@
             var x3 = x2;
             var y3 = y2 + dy3;
 
-            context.Path.BezierCurveTo(x1, y1, x2, y2, x3, y3);
+            context.Path[context.Path.Count - 1].BezierCurveTo(x1, y1, x2, y2, x3, y3);
             context.CurrentPosition = new PdfPoint(x3, y3);
 
             context.Stack.Clear();

--- a/src/UglyToad.PdfPig.Fonts/Type1/CharStrings/Commands/PathConstruction/RLineToCommand.cs
+++ b/src/UglyToad.PdfPig.Fonts/Type1/CharStrings/Commands/PathConstruction/RLineToCommand.cs
@@ -25,7 +25,7 @@
             var x = context.CurrentPosition.X + deltaX;
             var y = context.CurrentPosition.Y + deltaY;
 
-            context.Path.LineTo(x, y);
+            context.Path[context.Path.Count - 1].LineTo(x, y);
             context.CurrentPosition = new PdfPoint(x, y);
 
             context.Stack.Clear();

--- a/src/UglyToad.PdfPig.Fonts/Type1/CharStrings/Commands/PathConstruction/RMoveToCommand.cs
+++ b/src/UglyToad.PdfPig.Fonts/Type1/CharStrings/Commands/PathConstruction/RMoveToCommand.cs
@@ -37,7 +37,9 @@
                 var x = context.CurrentPosition.X + deltaX;
                 var y = context.CurrentPosition.Y + deltaY;
                 context.CurrentPosition = new PdfPoint(x, y);
-                context.Path.MoveTo(x, y);
+
+                context.Path.Add(new PdfSubpath());
+                context.Path[context.Path.Count - 1].MoveTo(x, y);
             }
 
             context.Stack.Clear();

--- a/src/UglyToad.PdfPig.Fonts/Type1/CharStrings/Commands/PathConstruction/RelativeRCurveToCommand.cs
+++ b/src/UglyToad.PdfPig.Fonts/Type1/CharStrings/Commands/PathConstruction/RelativeRCurveToCommand.cs
@@ -37,7 +37,7 @@
             var x3 = x2 + dx3;
             var y3 = y2 + dy3;
 
-            context.Path.BezierCurveTo(x1, y1, x2, y2, x3, y3);
+            context.Path[context.Path.Count - 1].BezierCurveTo(x1, y1, x2, y2, x3, y3);
 
             context.CurrentPosition = new PdfPoint(x3, y3);
 

--- a/src/UglyToad.PdfPig.Fonts/Type1/CharStrings/Commands/PathConstruction/VLineToCommand.cs
+++ b/src/UglyToad.PdfPig.Fonts/Type1/CharStrings/Commands/PathConstruction/VLineToCommand.cs
@@ -22,7 +22,7 @@
             var deltaY = context.Stack.PopBottom();
             var y = context.CurrentPosition.Y + deltaY;
 
-            context.Path.LineTo(context.CurrentPosition.X, y);
+            context.Path[context.Path.Count - 1].LineTo(context.CurrentPosition.X, y);
             context.CurrentPosition = new PdfPoint(context.CurrentPosition.X, y);
 
             context.Stack.Clear();

--- a/src/UglyToad.PdfPig.Fonts/Type1/CharStrings/Commands/PathConstruction/VMoveToCommand.cs
+++ b/src/UglyToad.PdfPig.Fonts/Type1/CharStrings/Commands/PathConstruction/VMoveToCommand.cs
@@ -33,7 +33,9 @@
                 var x = context.CurrentPosition.X;
 
                 context.CurrentPosition = new PdfPoint(x, y);
-                context.Path.MoveTo(x, y);
+
+                context.Path.Add(new PdfSubpath());
+                context.Path[context.Path.Count - 1].MoveTo(x, y);
             }
 
             context.Stack.Clear();

--- a/src/UglyToad.PdfPig.Fonts/Type1/CharStrings/Commands/PathConstruction/VhCurveToCommand.cs
+++ b/src/UglyToad.PdfPig.Fonts/Type1/CharStrings/Commands/PathConstruction/VhCurveToCommand.cs
@@ -35,7 +35,7 @@
             var x3 = x2 + dx3;
             var y3 = y2;
 
-            context.Path.BezierCurveTo(x1, y1, x2, y2, x3, y3);
+            context.Path[context.Path.Count - 1].BezierCurveTo(x1, y1, x2, y2, x3, y3);
             context.CurrentPosition = new PdfPoint(x3, y3);
 
             context.Stack.Clear();

--- a/src/UglyToad.PdfPig.Fonts/Type1/CharStrings/Commands/Type1BuildCharContext.cs
+++ b/src/UglyToad.PdfPig.Fonts/Type1/CharStrings/Commands/Type1BuildCharContext.cs
@@ -2,12 +2,13 @@
 {
     using System;
     using System.Collections.Generic;
+    using System.Linq;
     using Core;
 
     internal class Type1BuildCharContext
     {
-        private readonly Func<int, PdfSubpath> characterByIndexFactory;
-        private readonly Func<string, PdfSubpath> characterByNameFactory;
+        private readonly Func<int, IReadOnlyList<PdfSubpath>> characterByIndexFactory;
+        private readonly Func<string, IReadOnlyList<PdfSubpath>> characterByNameFactory;
         public IReadOnlyDictionary<int, Type1CharStrings.CommandSequence> Subroutines { get; }
 
         public double WidthX { get; set; }
@@ -20,7 +21,7 @@
 
         public bool IsFlexing { get; set; }
 
-        public PdfSubpath Path { get; private set; } = new PdfSubpath();
+        public List<PdfSubpath> Path { get; private set; } = new List<PdfSubpath>();
 
         public PdfPoint CurrentPosition { get; set; }
 
@@ -31,8 +32,8 @@
         public List<PdfPoint> FlexPoints { get; } = new List<PdfPoint>();
 
         public Type1BuildCharContext(IReadOnlyDictionary<int, Type1CharStrings.CommandSequence> subroutines,
-            Func<int, PdfSubpath> characterByIndexFactory,
-            Func<string, PdfSubpath> characterByNameFactory)
+            Func<int, IReadOnlyList<PdfSubpath>> characterByIndexFactory,
+            Func<string, IReadOnlyList<PdfSubpath>> characterByNameFactory)
         {
             this.characterByIndexFactory = characterByIndexFactory ?? throw new ArgumentNullException(nameof(characterByIndexFactory));
             this.characterByNameFactory = characterByNameFactory ?? throw new ArgumentNullException(nameof(characterByNameFactory));
@@ -44,19 +45,19 @@
             FlexPoints.Add(point);
         }
 
-        public PdfSubpath GetCharacter(int characterCode)
+        public IReadOnlyList<PdfSubpath> GetCharacter(int characterCode)
         {
             return characterByIndexFactory(characterCode);
         }
 
-        public PdfSubpath GetCharacter(string characterName)
+        public IReadOnlyList<PdfSubpath> GetCharacter(string characterName)
         {
             return characterByNameFactory(characterName);
         }
 
-        public void SetPath(PdfSubpath path)
+        public void SetPath(IReadOnlyList<PdfSubpath> path)
         {
-            Path = path ?? throw new ArgumentNullException(nameof(path));
+            Path = path.ToList() ?? throw new ArgumentNullException(nameof(path));
         }
 
         public void ClearFlexPoints()

--- a/src/UglyToad.PdfPig.Fonts/Type1/CharStrings/Type1CharStringParser.cs
+++ b/src/UglyToad.PdfPig.Fonts/Type1/CharStrings/Type1CharStringParser.cs
@@ -1,35 +1,39 @@
 ﻿namespace UglyToad.PdfPig.Fonts.Type1.CharStrings
 {
-    using System;
-    using System.Collections.Generic;
     using Commands;
     using Commands.Arithmetic;
     using Commands.Hint;
     using Commands.PathConstruction;
     using Commands.StartFinishOutline;
     using Core;
-    using Parser;
+    using System;
+    using System.Collections.Generic;
 
     /// <summary>
     /// Decodes a set of CharStrings to their corresponding Type 1 BuildChar operations.
     /// </summary>
     /// <remarks>
-    /// A charstring is an encrypted sequence of unsigned 8-bit bytes that encode integers and commands. 
+    /// <para>
+    /// A charstring is an encrypted sequence of unsigned 8-bit bytes that encode integers and commands.
     /// Type 1 BuildChar, when interpreting a charstring, will first decrypt it and then will decode
-    /// its bytes one at a time in sequence. 
-    /// 
+    /// its bytes one at a time in sequence.
+    /// </para>
+    /// <para>
     /// The value in a byte indicates a command, a number, or subsequent bytes that are to be interpreted
     /// in a special way.
-    /// 
+    /// </para>
+    /// <para>
     /// Once the bytes are decoded into numbers and commands, the execution of these numbers and commands proceeds in a
-    /// manner similar to the operation of the PostScript language. Type 1 BuildChar uses its own operand stack, 
+    /// manner similar to the operation of the PostScript language. Type 1 BuildChar uses its own operand stack,
     /// called the Type 1 BuildChar operand stack, that is distinct from the PostScript interpreter operand stack.
-    ///  
+    /// </para>
+    /// <para>
     /// This stack holds up to 24 numeric entries. A number, decoded from a charstring, is pushed onto the Type 1
     /// BuildChar operand stack. A command expects its arguments in order on this operand stack with all arguments generally taken
-    /// from the bottom of the stack (first argument bottom-most); 
+    /// from the bottom of the stack (first argument bottom-most);
     /// however, some commands, particularly the subroutine commands, normally work from the top of the stack. If a command returns
     /// results, they are pushed onto the Type 1 BuildChar operand stack (last result topmost).
+    /// </para>
     /// </remarks>
     internal static class Type1CharStringParser
     {

--- a/src/UglyToad.PdfPig.Fonts/Type1/CharStrings/Type1CharStrings.cs
+++ b/src/UglyToad.PdfPig.Fonts/Type1/CharStrings/Type1CharStrings.cs
@@ -10,7 +10,7 @@
     {
         private readonly IReadOnlyDictionary<int, string> charStringIndexToName;
         private readonly object locker = new object();
-        private readonly Dictionary<string, PdfSubpath> glyphs = new Dictionary<string, PdfSubpath>();
+        private readonly Dictionary<string, IReadOnlyList<PdfSubpath>> glyphs = new Dictionary<string, IReadOnlyList<PdfSubpath>>();
 
         public IReadOnlyDictionary<string, CommandSequence> CharStrings { get; }
 
@@ -24,9 +24,9 @@
             Subroutines = subroutines ?? throw new ArgumentNullException(nameof(subroutines));
         }
 
-        public bool TryGenerate(string name, out PdfSubpath path)
+        public bool TryGenerate(string name, out IReadOnlyList<PdfSubpath> path)
         {
-            path = default(PdfSubpath);
+            path = new List<PdfSubpath>();
             lock (locker)
             {
                 if (glyphs.TryGetValue(name, out path))
@@ -54,7 +54,7 @@
             return true;
         }
 
-        private PdfSubpath Run(CommandSequence sequence)
+        private IReadOnlyList<PdfSubpath> Run(CommandSequence sequence)
         {
             var context = new Type1BuildCharContext(Subroutines, i =>
             {

--- a/src/UglyToad.PdfPig.Fonts/Type1/Type1FontProgram.cs
+++ b/src/UglyToad.PdfPig.Fonts/Type1/Type1FontProgram.cs
@@ -1,9 +1,9 @@
 ﻿namespace UglyToad.PdfPig.Fonts.Type1
 {
-    using System;
-    using System.Collections.Generic;
     using CharStrings;
     using Core;
+    using System;
+    using System.Collections.Generic;
     using Tokens;
 
     /// <summary>
@@ -62,14 +62,8 @@
         /// </summary>
         public PdfRectangle? GetCharacterBoundingBox(string characterName)
         {
-            if (!CharStrings.TryGenerate(characterName, out var glyph))
-            {
-                return null;
-            }
-
-            var bbox = glyph.GetBoundingRectangle();
-
-            return bbox;
+            var glyph = GetCharacterPath(characterName);
+            return PdfSubpath.GetBoundingRectangle(glyph);
         }
 
         /// <summary>
@@ -95,6 +89,18 @@
             var f = ((NumericToken)array.Data[5]).Double;
 
             return TransformationMatrix.FromValues(a, b, c, d, e, f);
+        }
+
+        /// <summary>
+        /// Get the pdfpath for the character with the given name.
+        /// </summary>
+        public IReadOnlyList<PdfSubpath> GetCharacterPath(string characterName)
+        {
+            if (!CharStrings.TryGenerate(characterName, out var glyph))
+            {
+                return null;
+            }
+            return glyph;
         }
     }
 }

--- a/src/UglyToad.PdfPig.Tests/Fonts/TrueType/Parser/TrueTypeFontParserTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Fonts/TrueType/Parser/TrueTypeFontParserTests.cs
@@ -2,13 +2,18 @@
 namespace UglyToad.PdfPig.Tests.Fonts.TrueType.Parser
 {
     using System;
+    using System.Collections.Generic;
+    using System.Drawing;
     using System.Globalization;
+    using System.Linq;
     using System.Text;
     using System.Text.RegularExpressions;
     using PdfPig.Core;
     using PdfPig.Fonts.TrueType;
     using PdfPig.Fonts.TrueType.Parser;
     using PdfPig.Fonts.TrueType.Tables;
+    using UglyToad.PdfPig.Fonts.TrueType.Glyphs;
+    using UglyToad.PdfPig.Graphics;
     using Xunit;
 
     public class TrueTypeFontParserTests
@@ -183,7 +188,7 @@ namespace UglyToad.PdfPig.Tests.Fonts.TrueType.Parser
             var font = TrueTypeFontParser.Parse(input);
 
             var robotoGlyphs = Encoding.ASCII.GetString(TrueTypeTestHelper.GetFileBytes("Roboto-Regular.GlyphData.txt"));
-            var lines = robotoGlyphs.Split(new[] {"\r\n", "\r", "\n"}, StringSplitOptions.RemoveEmptyEntries);
+            var lines = robotoGlyphs.Split(new[] { "\r\n", "\r", "\n" }, StringSplitOptions.RemoveEmptyEntries);
 
             for (var i = 0; i < lines.Length; i++)
             {
@@ -205,9 +210,16 @@ namespace UglyToad.PdfPig.Tests.Fonts.TrueType.Parser
                 {
                     Assert.Equal(width, glyph.Bounds.Width);
                 }
-                
+
                 Assert.Equal(height, glyph.Bounds.Height);
                 Assert.Equal(points, glyph.Points.Length);
+                if (points > 0)
+                {
+                    Assert.True(glyph.Points[glyph.Points.Length - 1].IsEndOfContour);
+                    Assert.True(glyph.TryGetGlyphPath(out var subpaths));
+
+                    // TODO - more tests on path
+                }
             }
         }
 
@@ -226,4 +238,3 @@ namespace UglyToad.PdfPig.Tests.Fonts.TrueType.Parser
         }
     }
 }
-

--- a/src/UglyToad.PdfPig.Tests/Fonts/Type1/Type1FontParserTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Fonts/Type1/Type1FontParserTests.cs
@@ -63,7 +63,7 @@
             foreach (var charString in result.CharStrings.CharStrings)
             {
                 Assert.True(result.CharStrings.TryGenerate(charString.Key, out var path));
-                builder.AppendLine(path.ToFullSvg(0));
+                //builder.AppendLine(path.ToFullSvg(0)); // TODO - to restore
             }
 
             builder.Append("</body></html>");

--- a/src/UglyToad.PdfPig.Tests/Writer/PdfTextRemoverTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Writer/PdfTextRemoverTests.cs
@@ -1,6 +1,6 @@
-﻿using UglyToad.PdfPig.Tests.Integration;
+﻿using System.IO;
+using UglyToad.PdfPig.Tests.Integration;
 using UglyToad.PdfPig.Writer;
-using System.IO;
 using Xunit;
 
 namespace UglyToad.PdfPig.Tests.Writer
@@ -18,7 +18,8 @@ namespace UglyToad.PdfPig.Tests.Writer
             using (var document = PdfDocument.Open(filePath))
             {
                 var withoutText = PdfTextRemover.RemoveText(filePath);
-                File.WriteAllBytes(@"C:\temp\_tx.pdf", withoutText);
+                WriteFile($"{nameof(TextRemoverRemovesText)}_{file}", withoutText);
+
                 using (var documentWithoutText = PdfDocument.Open(withoutText))
                 {
                     Assert.Equal(document.NumberOfPages, documentWithoutText.NumberOfPages);
@@ -27,8 +28,26 @@ namespace UglyToad.PdfPig.Tests.Writer
                         Assert.NotEqual(document.GetPage(i).Text, string.Empty);
                         Assert.Equal(documentWithoutText.GetPage(i).Text, string.Empty);
                     }
-
                 }
+            }
+        }
+
+        private static void WriteFile(string name, byte[] bytes)
+        {
+            try
+            {
+                if (!Directory.Exists("Writer"))
+                {
+                    Directory.CreateDirectory("Writer");
+                }
+
+                var output = Path.Combine("Writer", $"{name}");
+
+                File.WriteAllBytes(output, bytes);
+            }
+            catch
+            {
+                // ignored.
             }
         }
     }

--- a/src/UglyToad.PdfPig.sln
+++ b/src/UglyToad.PdfPig.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.27130.2010
+# Visual Studio Version 17
+VisualStudioVersion = 17.3.32819.101
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "UglyToad.PdfPig", "UglyToad.PdfPig\UglyToad.PdfPig.csproj", "{57D0610C-87D3-4E0B-B7C2-EC8B765A8288}"
 EndProject
@@ -18,9 +18,9 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "UglyToad.PdfPig.Core", "Ugl
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "UglyToad.PdfPig.DocumentLayoutAnalysis", "UglyToad.PdfPig.DocumentLayoutAnalysis\UglyToad.PdfPig.DocumentLayoutAnalysis.csproj", "{60126BCA-6C52-48A9-A0A6-51796C8B0BE7}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "UglyToad.PdfPig.Tokens", "UglyToad.PdfPig.Tokens\UglyToad.PdfPig.Tokens.csproj", "{D840FF69-4250-4B05-9829-5ABEC43EC82C}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "UglyToad.PdfPig.Tokens", "UglyToad.PdfPig.Tokens\UglyToad.PdfPig.Tokens.csproj", "{D840FF69-4250-4B05-9829-5ABEC43EC82C}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "UglyToad.PdfPig.Tokenization", "UglyToad.PdfPig.Tokenization\UglyToad.PdfPig.Tokenization.csproj", "{FD005C50-CD2C-497E-8F7E-6D791091E9B0}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "UglyToad.PdfPig.Tokenization", "UglyToad.PdfPig.Tokenization\UglyToad.PdfPig.Tokenization.csproj", "{FD005C50-CD2C-497E-8F7E-6D791091E9B0}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/src/UglyToad.PdfPig/Graphics/PdfPath.cs
+++ b/src/UglyToad.PdfPig/Graphics/PdfPath.cs
@@ -1,7 +1,6 @@
 ﻿namespace UglyToad.PdfPig.Graphics
 {
     using System.Collections.Generic;
-    using System.Linq;
     using UglyToad.PdfPig.Core;
     using UglyToad.PdfPig.Graphics.Colors;
     using UglyToad.PdfPig.Graphics.Core;
@@ -128,22 +127,7 @@
         /// <returns>For paths which don't define any geometry this returns <see langword="null"/>.</returns>
         public PdfRectangle? GetBoundingRectangle()
         {
-            if (this.Count == 0)
-            {
-                return null;
-            }
-
-            var bboxes = this.Select(x => x.GetBoundingRectangle()).Where(x => x.HasValue).Select(x => x.Value).ToList();
-            if (bboxes.Count == 0)
-            {
-                return null;
-            }
-
-            var minX = bboxes.Min(x => x.Left);
-            var minY = bboxes.Min(x => x.Bottom);
-            var maxX = bboxes.Max(x => x.Right);
-            var maxY = bboxes.Max(x => x.Top);
-            return new PdfRectangle(minX, minY, maxX, maxY);
+            return PdfSubpath.GetBoundingRectangle(this);
         }
     }
 }

--- a/src/UglyToad.PdfPig/Parser/PageFactory.cs
+++ b/src/UglyToad.PdfPig/Parser/PageFactory.cs
@@ -87,7 +87,7 @@
                     pdfScanner,
                     filterProvider,
                     resourceStore);
-                 // ignored for now, is it possible? check the spec...
+                // ignored for now, is it possible? check the spec...
             }
             else if (DirectObjectFinder.TryGet<ArrayToken>(contents, pdfScanner, out var array))
             {

--- a/src/UglyToad.PdfPig/PdfFonts/CidFonts/ICidFont.cs
+++ b/src/UglyToad.PdfPig/PdfFonts/CidFonts/ICidFont.cs
@@ -2,10 +2,12 @@
 {
     using Core;
     using Geometry;
+    using System.Collections.Generic;
+    using System;
     using Tokens;
 
     /// <summary>
-    /// A CID font contains glyph descriptions accessed by 
+    /// A CID font contains glyph descriptions accessed by
     /// CID (character identifier) as character selectors.
     /// </summary>
     /// <remarks>
@@ -51,5 +53,35 @@
         PdfVector GetPositionVector(int characterIdentifier);
 
         PdfVector GetDisplacementVector(int characterIdentifier);
+
+        /// <summary>
+        /// Returns the glyph path for the given character code.
+        /// </summary>
+        /// <param name="characterCode">Character code in a PDF. Not to be confused with unicode.</param>
+        /// <param name="path">The glyph path for the given character code.</param>
+        bool TryGetPath(int characterCode, out IReadOnlyList<PdfSubpath> path);
+
+        /// <summary>
+        /// Returns the glyph path for the given character code.
+        /// </summary>
+        /// <param name="characterCode">Character code in a PDF. Not to be confused with unicode.</param>
+        /// <param name="characterCodeToGlyphId"></param>
+        /// <param name="path">The glyph path for the given character code.</param>
+        bool TryGetPath(int characterCode, Func<int, int?> characterCodeToGlyphId, out IReadOnlyList<PdfSubpath> path);
+
+        /// <summary>
+        /// Returns the normalised glyph path for the given character code in a PDF.
+        /// </summary>
+        /// <param name="characterCode">Character code in a PDF. Not to be confused with unicode.</param>
+        /// <param name="path">The normalized glyph path for the given character code.</param>
+        bool TryGetNormalisedPath(int characterCode, out IReadOnlyList<PdfSubpath> path);
+
+        /// <summary>
+        /// Returns the normalised glyph path for the given character code in a PDF.
+        /// </summary>
+        /// <param name="characterCode">Character code in a PDF. Not to be confused with unicode.</param>
+        /// <param name="characterCodeToGlyphId"></param>
+        /// <param name="path">The normalized glyph path for the given character code.</param>
+        bool TryGetNormalisedPath(int characterCode, Func<int, int?> characterCodeToGlyphId, out IReadOnlyList<PdfSubpath> path);
     }
 }

--- a/src/UglyToad.PdfPig/PdfFonts/CidFonts/ICidFontProgram.cs
+++ b/src/UglyToad.PdfPig/PdfFonts/CidFonts/ICidFontProgram.cs
@@ -1,6 +1,7 @@
 ﻿namespace UglyToad.PdfPig.PdfFonts.CidFonts
 {
     using System;
+    using System.Collections.Generic;
     using Core;
 
     /// <summary>
@@ -17,6 +18,10 @@
         bool TryGetBoundingAdvancedWidth(int characterIdentifier, Func<int, int?> characterCodeToGlyphId, out double width);
 
         bool TryGetBoundingAdvancedWidth(int characterIdentifier, out double width);
+
+        bool TryGetPath(int characterName, out IReadOnlyList<PdfSubpath> path);
+
+        bool TryGetPath(int characterCode, Func<int, int?> characterCodeToGlyphId, out IReadOnlyList<PdfSubpath> path);
 
         int GetFontMatrixMultiplier();
     }

--- a/src/UglyToad.PdfPig/PdfFonts/CidFonts/PdfCidCompactFontFormatFont.cs
+++ b/src/UglyToad.PdfPig/PdfFonts/CidFonts/PdfCidCompactFontFormatFont.cs
@@ -1,6 +1,7 @@
 ﻿namespace UglyToad.PdfPig.PdfFonts.CidFonts
 {
     using System;
+    using System.Collections.Generic;
     using Core;
     using Fonts.CompactFontFormat;
 
@@ -62,7 +63,6 @@
             return true;
         }
 
-
         public bool TryGetBoundingBox(int characterIdentifier, Func<int, int?> characterCodeToGlyphId, out PdfRectangle boundingBox)
         {
             throw new NotImplementedException();
@@ -105,6 +105,32 @@
             }
 #endif
             return fontCollection.FirstFont;
+        }
+
+        public bool TryGetPath(int characterCode, out IReadOnlyList<PdfSubpath> path)
+        {
+            path = EmptyArray<PdfSubpath>.Instance;
+
+            var font = GetFont();
+
+            if (font.Encoding == null)
+            {
+                return false;
+            }
+
+            var characterName = GetCharacterName(characterCode);
+
+            if (font.TryGetPath(characterName, out path))
+            {
+                return true;
+            }
+
+            return false;
+        }
+
+        public bool TryGetPath(int characterCode, Func<int, int?> characterCodeToGlyphId, out IReadOnlyList<PdfSubpath> path)
+        {
+            throw new NotImplementedException();
         }
     }
 }

--- a/src/UglyToad.PdfPig/PdfFonts/CidFonts/PdfCidTrueTypeFont.cs
+++ b/src/UglyToad.PdfPig/PdfFonts/CidFonts/PdfCidTrueTypeFont.cs
@@ -1,6 +1,7 @@
 ﻿namespace UglyToad.PdfPig.PdfFonts.CidFonts
 {
     using System;
+    using System.Collections.Generic;
     using Core;
     using Fonts.TrueType;
     using Fonts.TrueType.Tables;
@@ -10,7 +11,7 @@
         private readonly TrueTypeFont font;
 
         public FontDetails Details { get; }
-        
+
         public PdfCidTrueTypeFont(TrueTypeFont font)
         {
             this.font = font ?? throw new ArgumentNullException(nameof(font));
@@ -33,5 +34,10 @@
             => font.TryGetAdvanceWidth(characterIdentifier, characterCodeToGlyphId, out width);
 
         public int GetFontMatrixMultiplier() => font.GetUnitsPerEm();
+
+        public bool TryGetPath(int characterCode, out IReadOnlyList<PdfSubpath> path) => font.TryGetPath(characterCode, out path);
+
+        public bool TryGetPath(int characterCode, Func<int, int?> characterCodeToGlyphId, out IReadOnlyList<PdfSubpath> path)
+            => font.TryGetPath(characterCode, characterCodeToGlyphId, out path);
     }
 }

--- a/src/UglyToad.PdfPig/PdfFonts/CidFonts/Type0CidFont.cs
+++ b/src/UglyToad.PdfPig/PdfFonts/CidFonts/Type0CidFont.cs
@@ -131,5 +131,37 @@
         {
             return verticalWritingMetrics.GetDisplacementVector(characterIdentifier);
         }
+
+        public bool TryGetPath(int characterCode, out IReadOnlyList<PdfSubpath> path)
+        {
+            path = null;
+            if (fontProgram == null)
+            {
+                return false;
+            }
+
+            return fontProgram.TryGetPath(characterCode, out path);
+        }
+
+        public bool TryGetPath(int characterCode, Func<int, int?> characterCodeToGlyphId, out IReadOnlyList<PdfSubpath> path)
+        {
+            path = null;
+            if (fontProgram == null)
+            {
+                return false;
+            }
+
+            return fontProgram.TryGetPath(characterCode, characterCodeToGlyphId, out path);
+        }
+
+        public bool TryGetNormalisedPath(int characterCode, out IReadOnlyList<PdfSubpath> path)
+        {
+            return TryGetPath(characterCode, out path);
+        }
+
+        public bool TryGetNormalisedPath(int characterCode, Func<int, int?> characterCodeToGlyphId, out IReadOnlyList<PdfSubpath> path)
+        {
+            return TryGetPath(characterCode, characterCodeToGlyphId, out path);
+        }
     }
 }

--- a/src/UglyToad.PdfPig/PdfFonts/CidFonts/Type2CidFont.cs
+++ b/src/UglyToad.PdfPig/PdfFonts/CidFonts/Type2CidFont.cs
@@ -1,6 +1,8 @@
 ﻿namespace UglyToad.PdfPig.PdfFonts.CidFonts
 {
+    using System;
     using System.Collections.Generic;
+    using System.Linq;
     using Core;
     using Geometry;
     using Tokens;
@@ -113,6 +115,35 @@
         public PdfVector GetDisplacementVector(int characterIdentifier)
         {
             return verticalWritingMetrics.GetDisplacementVector(characterIdentifier);
+        }
+
+        public bool TryGetPath(int characterCode, out IReadOnlyList<PdfSubpath> path) => TryGetPath(characterCode, cidToGid.GetGlyphIndex, out path);
+
+        public bool TryGetPath(int characterCode, Func<int, int?> characterCodeToGlyphId, out IReadOnlyList<PdfSubpath> path)
+        {
+            path = null;
+            if (fontProgram == null)
+            {
+                return false;
+            }
+
+            return fontProgram.TryGetPath(characterCode, characterCodeToGlyphId, out path);
+        }
+
+        public bool TryGetNormalisedPath(int characterCode, out IReadOnlyList<PdfSubpath> path)
+        {
+            if (!TryGetPath(characterCode, out path))
+            {
+                return false;
+            }
+
+            path = FontMatrix.Transform(path).ToList();
+            return true;
+        }
+
+        public bool TryGetNormalisedPath(int characterCode, Func<int, int?> characterCodeToGlyphId, out IReadOnlyList<PdfSubpath> path)
+        {
+            throw new NotImplementedException();
         }
     }
 }

--- a/src/UglyToad.PdfPig/PdfFonts/Composite/Type0Font.cs
+++ b/src/UglyToad.PdfPig/PdfFonts/Composite/Type0Font.cs
@@ -1,14 +1,15 @@
 ﻿namespace UglyToad.PdfPig.PdfFonts.Composite
 {
-    using System;
-    using System.Collections.Generic;
     using CidFonts;
     using Cmap;
     using Core;
     using Geometry;
+    using System;
+    using System.Collections.Generic;
     using Tokens;
     using Util.JetBrains.Annotations;
     using Debug = System.Diagnostics.Debug;
+
     /// <summary>
     /// Defines glyphs using a CIDFont
     /// </summary>
@@ -49,7 +50,7 @@
             CidFont = cidFont ?? throw new ArgumentNullException(nameof(cidFont));
             CMap = cmap ?? throw new ArgumentNullException(nameof(cmap));
             ToUnicode = new ToUnicodeCMap(toUnicodeCMap);
-            Details = cidFont.Details?.WithName(Name.Data) 
+            Details = cidFont.Details?.WithName(Name.Data)
                       ?? FontDetails.GetDefault(Name.Data);
         }
 
@@ -71,7 +72,7 @@
             var HaveCMap = ToUnicode.CanMapToUnicode;
             if (HaveCMap == false)
             {
-                var HaveUnicode2CMap = (ucs2CMap is null == false); 
+                var HaveUnicode2CMap = (ucs2CMap is null == false);
                 if (HaveUnicode2CMap)
                 {
                     // Have both ucs2Map and CMap convert to unicode by
@@ -87,7 +88,6 @@
                     {
                         return value != null;
                     }
-
                 }
                 if (HaveUnicode2CMap) // 2022-12-24 @fnatzke left as fall-back. Possible?
                 {
@@ -160,6 +160,18 @@
             var characterIdentifier = CMap.ConvertToCid(characterCode);
 
             return CidFont.GetDisplacementVector(characterIdentifier).Scale(1 / 1000.0);
+        }
+
+        /// <inheritdoc/>
+        public bool TryGetPath(int characterCode, out IReadOnlyList<PdfSubpath> path)
+        {
+            return CidFont.TryGetPath(characterCode, out path);
+        }
+
+        /// <inheritdoc/>
+        public bool TryGetNormalisedPath(int characterCode, out IReadOnlyList<PdfSubpath> path)
+        {
+            return CidFont.TryGetNormalisedPath(characterCode, out path);
         }
     }
 }

--- a/src/UglyToad.PdfPig/PdfFonts/IFont.cs
+++ b/src/UglyToad.PdfPig/PdfFonts/IFont.cs
@@ -1,12 +1,13 @@
 ﻿namespace UglyToad.PdfPig.PdfFonts
 {
     using Core;
+    using System.Collections.Generic;
     using Tokens;
 
     internal interface IFont
     {
         NameToken Name { get; }
-        
+
         bool IsVertical { get; }
 
         FontDetails Details { get; }
@@ -18,5 +19,19 @@
         CharacterBoundingBox GetBoundingBox(int characterCode);
 
         TransformationMatrix GetFontMatrix();
+
+        /// <summary>
+        /// Returns the glyph path for the given character code.
+        /// </summary>
+        /// <param name="characterCode">Character code in a PDF. Not to be confused with unicode.</param>
+        /// <param name="path">The glyph path for the given character code.</param>
+        bool TryGetPath(int characterCode, out IReadOnlyList<PdfSubpath> path);
+
+        /// <summary>
+        /// Returns the normalised glyph path for the given character code in a PDF.
+        /// </summary>
+        /// <param name="characterCode">Character code in a PDF. Not to be confused with unicode.</param>
+        /// <param name="path">The normalized glyph path for the given character code.</param>
+        bool TryGetNormalisedPath(int characterCode, out IReadOnlyList<PdfSubpath> path);
     }
 }

--- a/src/UglyToad.PdfPig/PdfFonts/Parser/Parts/CidFontFactory.cs
+++ b/src/UglyToad.PdfPig/PdfFonts/Parser/Parts/CidFontFactory.cs
@@ -114,11 +114,11 @@
             switch (descriptor.FontFile.FileType)
             {
                 case DescriptorFontFile.FontFileType.TrueType:
-                {
-                    var input = new TrueTypeDataBytes(new ByteArrayInputBytes(fontFile));
-                    var ttf = TrueTypeFontParser.Parse(input);
-                    return new PdfCidTrueTypeFont(ttf);
-                }
+                    {
+                        var input = new TrueTypeDataBytes(new ByteArrayInputBytes(fontFile));
+                        var ttf = TrueTypeFontParser.Parse(input);
+                        return new PdfCidTrueTypeFont(ttf);
+                    }
                 case DescriptorFontFile.FontFileType.FromSubtype:
                     {
                         if (!DirectObjectFinder.TryGet(descriptor.FontFile.ObjectKey, pdfScanner, out StreamToken str))
@@ -145,7 +145,7 @@
                             var ttf = TrueTypeFontParser.Parse(new TrueTypeDataBytes(new ByteArrayInputBytes(bytes)));
                             return new PdfCidTrueTypeFont(ttf);
                         }
-                        
+
                         throw new PdfDocumentFormatException($"Unexpected subtype for CID font: {subtypeName}.");
                     }
                 default:

--- a/src/UglyToad.PdfPig/PdfFonts/Simple/TrueTypeSimpleFont.cs
+++ b/src/UglyToad.PdfPig/PdfFonts/Simple/TrueTypeSimpleFont.cs
@@ -1,13 +1,14 @@
 ﻿namespace UglyToad.PdfPig.PdfFonts.Simple
 {
-    using System;
-    using System.Collections.Generic;
     using Cmap;
     using Composite;
     using Core;
     using Fonts;
     using Fonts.Encodings;
     using Fonts.TrueType;
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
     using Tokens;
     using Util.JetBrains.Annotations;
 
@@ -57,7 +58,7 @@
             Name = name;
             IsVertical = false;
             ToUnicode = new ToUnicodeCMap(toUnicodeCMap);
-            Details = descriptor?.ToDetails(Name?.Data) 
+            Details = descriptor?.ToDetails(Name?.Data)
                       ?? FontDetails.GetDefault(Name?.Data);
         }
 
@@ -321,6 +322,29 @@
 
             return widths[index];
         }
+
+        /// <inheritdoc/>
+        public bool TryGetPath(int characterCode, out IReadOnlyList<PdfSubpath> path)
+        {
+            if (font == null)
+            {
+                path = EmptyArray<PdfSubpath>.Instance;
+                return false;
+            }
+
+            return font.TryGetPath(characterCode, CharacterCodeToGlyphId, out path);
+        }
+
+        /// <inheritdoc/>
+        public bool TryGetNormalisedPath(int characterCode, out IReadOnlyList<PdfSubpath> path)
+        {
+            if (!TryGetPath(characterCode, out path))
+            {
+                return false;
+            }
+
+            path = GetFontMatrix().Transform(path).ToList();
+            return true;
+        }
     }
 }
-

--- a/src/UglyToad.PdfPig/PdfFonts/Simple/TrueTypeStandard14FallbackSimpleFont.cs
+++ b/src/UglyToad.PdfPig/PdfFonts/Simple/TrueTypeStandard14FallbackSimpleFont.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.Collections.Generic;
+    using System.Linq;
     using Core;
     using Fonts;
     using Fonts.AdobeFontMetrics;
@@ -130,6 +131,29 @@
             }
 
             return DefaultTransformation;
+        }
+
+        /// <inheritdoc/>
+        public bool TryGetPath(int characterCode, out IReadOnlyList<PdfSubpath> path)
+        {
+            path = null;
+            if (font == null)
+            {
+                return false;
+            }
+            return font.TryGetPath(characterCode, out path);
+        }
+
+        /// <inheritdoc/>
+        public bool TryGetNormalisedPath(int characterCode, out IReadOnlyList<PdfSubpath> path)
+        {
+            if (!TryGetPath(characterCode, out path))
+            {
+                return false;
+            }
+
+            path = GetFontMatrix().Transform(path).ToList();
+            return true;
         }
 
         public class MetricOverrides

--- a/src/UglyToad.PdfPig/PdfFonts/Simple/Type1FontSimple.cs
+++ b/src/UglyToad.PdfPig/PdfFonts/Simple/Type1FontSimple.cs
@@ -1,6 +1,7 @@
 ﻿namespace UglyToad.PdfPig.PdfFonts.Simple
 {
     using System.Collections.Generic;
+    using System.Linq;
     using Cmap;
     using Composite;
     using Core;
@@ -43,7 +44,7 @@
 
         public FontDetails Details { get; }
 
-        public Type1FontSimple(NameToken name, int firstChar, int lastChar, double[] widths, FontDescriptor fontDescriptor, Encoding encoding, 
+        public Type1FontSimple(NameToken name, int firstChar, int lastChar, double[] widths, FontDescriptor fontDescriptor, Encoding encoding,
             CMap toUnicodeCMap,
             Union<Type1Font, CompactFontFormatFontCollection> fontProgram)
         {
@@ -72,7 +73,7 @@
             fontMatrix = matrix;
 
             Name = name;
-            Details = fontDescriptor?.ToDetails(name?.Data) 
+            Details = fontDescriptor?.ToDetails(name?.Data)
                       ?? FontDetails.GetDefault(name?.Data);
         }
 
@@ -116,7 +117,7 @@
             }
 
             var name = encoding.GetName(characterCode);
-            
+
             try
             {
                 value = GlyphList.AdobeGlyphList.NameToUnicode(name);
@@ -135,7 +136,7 @@
             {
                 return box;
             }
-            
+
             var boundingBox = GetBoundingBoxInGlyphSpace(characterCode);
 
             var matrix = fontMatrix;
@@ -144,7 +145,7 @@
 
             var width = GetWidth(characterCode, boundingBox);
 
-            var result = new CharacterBoundingBox(boundingBox, width/1000.0);
+            var result = new CharacterBoundingBox(boundingBox, width / 1000.0);
 
             cachedBoundingBoxes[characterCode] = result;
 
@@ -167,7 +168,7 @@
 
             return boundingBox.Width;
         }
-        
+
         private PdfRectangle GetBoundingBoxInGlyphSpace(int characterCode)
         {
             if (characterCode < firstChar || characterCode > lastChar)
@@ -183,25 +184,24 @@
             PdfRectangle? rect = null;
             if (fontProgram.TryGetFirst(out var t1Font))
             {
-                 var name = encoding.GetName(characterCode);
-                    rect = t1Font.GetCharacterBoundingBox(name);
+                var name = encoding.GetName(characterCode);
+                rect = t1Font.GetCharacterBoundingBox(name);
             }
             else if (fontProgram.TryGetSecond(out var cffFont))
             {
-                    var first = cffFont.FirstFont;
-                    string characterName;
-                    if (encoding != null)
-                    {
-                        characterName = encoding.GetName(characterCode);
-                    }
-                    else
-                    {
-                        characterName = cffFont.GetCharacterName(characterCode);
-                    }
+                var first = cffFont.FirstFont;
+                string characterName;
+                if (encoding != null)
+                {
+                    characterName = encoding.GetName(characterCode);
+                }
+                else
+                {
+                    characterName = cffFont.GetCharacterName(characterCode);
+                }
 
-                    rect = first.GetCharacterBoundingBox(characterName);
+                rect = first.GetCharacterBoundingBox(characterName);
             }
-
 
             if (!rect.HasValue)
             {
@@ -215,6 +215,62 @@
         public TransformationMatrix GetFontMatrix()
         {
             return fontMatrix;
+        }
+
+        /// <inheritdoc/>
+        public bool TryGetPath(int characterCode, out IReadOnlyList<PdfSubpath> path)
+        {
+            path = null;
+            IReadOnlyList<PdfSubpath> tempPath = null;
+            if (characterCode < firstChar || characterCode > lastChar)
+            {
+                return false;
+            }
+
+            if (fontProgram == null)
+            {
+                return false;
+            }
+
+            if (fontProgram.TryGetFirst(out var t1Font))
+            {
+                var name = encoding.GetName(characterCode);
+                tempPath = t1Font.GetCharacterPath(name);
+            }
+            else if (fontProgram.TryGetSecond(out var cffFont))
+            {
+                var first = cffFont.FirstFont;
+                string characterName;
+                if (encoding != null)
+                {
+                    characterName = encoding.GetName(characterCode);
+                }
+                else
+                {
+                    characterName = cffFont.GetCharacterName(characterCode);
+                }
+
+                tempPath = first.GetCharacterPath(characterName);
+            }
+
+            if (tempPath != null)
+            {
+                path = tempPath;
+                return true;
+            }
+
+            return false;
+        }
+
+        /// <inheritdoc/>
+        public bool TryGetNormalisedPath(int characterCode, out IReadOnlyList<PdfSubpath> path)
+        {
+            if (TryGetPath(characterCode, out path))
+            {
+                path = fontMatrix.Transform(path).ToList();
+                return true;
+            }
+            return false;
         }
     }
 }

--- a/src/UglyToad.PdfPig/PdfFonts/Simple/Type1Standard14Font.cs
+++ b/src/UglyToad.PdfPig/PdfFonts/Simple/Type1Standard14Font.cs
@@ -1,12 +1,13 @@
-﻿// ReSharper disable CompareOfFloatsByEqualityOperator
+﻿//// ReSharper disable CompareOfFloatsByEqualityOperator
 namespace UglyToad.PdfPig.PdfFonts.Simple
 {
-    using System;
-    using System.Diagnostics;
     using Core;
     using Fonts;
     using Fonts.AdobeFontMetrics;
     using Fonts.Encodings;
+    using System;
+    using System.Collections.Generic;
+    using System.Diagnostics;
     using Tokens;
 
     /// <summary>
@@ -119,6 +120,26 @@ namespace UglyToad.PdfPig.PdfFonts.Simple
         public TransformationMatrix GetFontMatrix()
         {
             return fontMatrix;
+        }
+
+        /// <summary>
+        /// <inheritdoc/>
+        /// <para>Not implemeted.</para>
+        /// </summary>
+        public bool TryGetPath(int characterCode, out IReadOnlyList<PdfSubpath> path)
+        {
+            // https://github.com/apache/pdfbox/blob/trunk/pdfbox/src/main/java/org/apache/pdfbox/pdmodel/font/Standard14Fonts.java
+            path = null;
+            return false;
+        }
+
+        /// <summary>
+        /// <inheritdoc/>
+        /// <para>Not implemeted.</para>
+        /// </summary>
+        public bool TryGetNormalisedPath(int characterCode, out IReadOnlyList<PdfSubpath> path)
+        {
+            return TryGetPath(characterCode, out path);
         }
     }
 }

--- a/src/UglyToad.PdfPig/PdfFonts/Simple/Type3Font.cs
+++ b/src/UglyToad.PdfPig/PdfFonts/Simple/Type3Font.cs
@@ -5,6 +5,7 @@
     using Core;
     using Fonts;
     using Fonts.Encodings;
+    using System.Collections.Generic;
     using Tokens;
 
     internal class Type3Font : IFont
@@ -57,9 +58,7 @@
 
             var name = encoding.GetName(characterCode);
 
-            var listed = GlyphList.AdobeGlyphList.NameToUnicode(name);
-
-            value = listed;
+            value = GlyphList.AdobeGlyphList.NameToUnicode(name);
 
             return true;
         }
@@ -88,6 +87,25 @@
         public TransformationMatrix GetFontMatrix()
         {
             return fontMatrix;
+        }
+
+        /// <summary>
+        /// <inheritdoc/>
+        /// <para>Type 3 fonts do not use vector paths. Always returns <c>false</c>.</para>
+        /// </summary>
+        public bool TryGetPath(int characterCode, out IReadOnlyList<PdfSubpath> path)
+        {
+            path = null;
+            return false;
+        }
+
+        /// <summary>
+        /// <inheritdoc/>
+        /// <para>Type 3 fonts do not use vector paths. Always returns <c>false</c>.</para>
+        /// </summary>
+        public bool TryGetNormalisedPath(int characterCode, out IReadOnlyList<PdfSubpath> path)
+        {
+            return TryGetPath(characterCode, out path);
         }
     }
 }


### PR DESCRIPTION
- Implement TryGetPath and TryGetNormalisedPath for fonts
- Substiture PdfSubpath by List<PdfSubpath> where necessary
- Fix PdfTextRemoverTests.cs

You can check the [pdf-to-image-skia](https://github.com/UglyToad/PdfPig/tree/pdf-to-image-skia) branch and the new test project for some rendering of these fonts.

fix #501 should also be good now (not sure if related) as letters are rendered correctly

@fnatzke [pdf-to-image-skia](https://github.com/UglyToad/PdfPig/tree/pdf-to-image-skia) might be of interest to you too (does not use skia yet, still system.drawing)

Below are renders examples - only vector based letters are rendered and color is forced to b&w 
![Baring_Amy Tay_Finance Manager-1 pdf_1_system-drawing](https://user-images.githubusercontent.com/38405645/217063221-3c9af672-1842-4d3b-8972-dd0d37014474.jpg)

![Pig Production Handbook_1_system-drawing](https://user-images.githubusercontent.com/38405645/217063258-4f3d2d07-16a6-4bdb-85a3-b7db4f21ef6a.jpg)

![pop-bugzilla37292 pdf_1_system-drawing](https://user-images.githubusercontent.com/38405645/217063275-7fac08d1-65bd-4490-99aa-7333e3233b1f.jpg)

![Motor Insurance claim form_1_system-drawing](https://user-images.githubusercontent.com/38405645/217063312-fd682f19-ce8a-4cda-9261-ca8e17d69ef3.jpg)

![Type0 Font_1_system-drawing](https://user-images.githubusercontent.com/38405645/217063335-5deb00c3-70c4-4dec-9815-84989563b7c1.jpg)

![cat-genetics pdf_1_system-drawing](https://user-images.githubusercontent.com/38405645/217063564-5683b352-4991-4c41-a79f-4ae0bc355f7b.jpg)

![byz_1_system-drawing](https://user-images.githubusercontent.com/38405645/217063718-9e319d30-f976-41ea-b15e-5741b5b1ad19.jpg)
