### PR TITLE
Support adding outline bookmarks to existing pdf document

### DIFF
--- a/src/UglyToad.PdfPig.Tests/PublicApiScannerTests.cs
+++ b/src/UglyToad.PdfPig.Tests/PublicApiScannerTests.cs
@@ -208,6 +208,7 @@
                 "UglyToad.PdfPig.Outline.BookmarkNode",
                 "UglyToad.PdfPig.Outline.DocumentBookmarkNode",
                 "UglyToad.PdfPig.Outline.ExternalBookmarkNode",
+                "UglyToad.PdfPig.Outline.UriBookmarkNode",
                 "UglyToad.PdfPig.Outline.Destinations.ExplicitDestination",
                 "UglyToad.PdfPig.Outline.Destinations.ExplicitDestinationCoordinates",
                 "UglyToad.PdfPig.Outline.Destinations.ExplicitDestinationType",

--- a/src/UglyToad.PdfPig/Outline/UriBookmarkNode.cs
+++ b/src/UglyToad.PdfPig/Outline/UriBookmarkNode.cs
@@ -1,0 +1,33 @@
+﻿namespace UglyToad.PdfPig.Outline
+{
+    using System;
+    using System.Collections.Generic;
+
+    /// <inheritdoc />
+    /// <summary>
+    /// A node in the <see cref="Bookmarks" /> of a PDF document which corresponds
+    /// to a uniform resource identifier on the Internet.
+    /// </summary>
+    public class UriBookmarkNode : BookmarkNode
+    {
+        /// <summary>
+        /// The uniform resource identifier to resolve.
+        /// </summary>
+        public string Uri { get; }
+
+        /// <inheritdoc />
+        /// <summary>
+        /// Create a new <see cref="ExternalBookmarkNode" />.
+        /// </summary>
+        public UriBookmarkNode(string title, int level, string uri, IReadOnlyList<BookmarkNode> children) : base(title, level, children)
+        {
+            Uri = uri ?? throw new ArgumentNullException(nameof(uri));
+        }
+
+        /// <inheritdoc />
+        public override string ToString()
+        {
+            return $"URI '{Uri}', {Level}, {Title}";
+        }
+    }
+}


### PR DESCRIPTION
- Adds the ability to create and modify outlines of a PDF document through the `PdfDocumentBuilder` interface.
- Adds a new `UriBookmarkNode` type to represent the `URI` action, allow outlines to point to URLs on the web, that supports both read and write.
- Writing `ExternalBookmarkNode` is not implemented because the current interface lacks the required `/D` key that specifies the destination in the external file to jump to, and we don't seem to need the feature.

Fixes https://github.com/UglyToad/PdfPig/issues/156

Once this is shipped, we can switch from `iTextSharp` to `PdfPig`: https://github.com/dotnet/docfx/issues/4250