### PR TITLE
Make some necessary classes public

### DIFF
--- a/src/UglyToad.PdfPig.Tests/PublicApiScannerTests.cs
+++ b/src/UglyToad.PdfPig.Tests/PublicApiScannerTests.cs
@@ -92,11 +92,13 @@
                 "UglyToad.PdfPig.Filters.IFilterProvider",
                 "UglyToad.PdfPig.Functions.FunctionTypes",
                 "UglyToad.PdfPig.Functions.PdfFunction",
+                "UglyToad.PdfPig.PdfFonts.CharacterBoundingBox",
                 "UglyToad.PdfPig.PdfFonts.DescriptorFontFile",
                 "UglyToad.PdfPig.PdfFonts.FontDescriptor",
                 "UglyToad.PdfPig.PdfFonts.FontDescriptorFlags",
                 "UglyToad.PdfPig.PdfFonts.FontDetails",
                 "UglyToad.PdfPig.PdfFonts.FontStretch",
+                "UglyToad.PdfPig.PdfFonts.IFont",
                 "UglyToad.PdfPig.Geometry.GeometryExtensions",
                 "UglyToad.PdfPig.Graphics.Colors.CMYKColor",
                 "UglyToad.PdfPig.Graphics.Colors.ColorSpace",
@@ -199,6 +201,7 @@
                 "UglyToad.PdfPig.Graphics.Operations.TextState.Type3SetGlyphWidth",
                 "UglyToad.PdfPig.Graphics.Operations.TextState.Type3SetGlyphWidthAndBoundingBox",
                 "UglyToad.PdfPig.Graphics.TextMatrices",
+                "UglyToad.PdfPig.Graphics.XObjectContentRecord",
                 "UglyToad.PdfPig.Images.ColorSpaceDetailsByteConverter",
                 "UglyToad.PdfPig.Logging.ILog",
                 "UglyToad.PdfPig.Outline.Bookmarks",
@@ -227,7 +230,9 @@
                 "UglyToad.PdfPig.Writer.PdfWriterType",
                 "UglyToad.PdfPig.Writer.PdfPageBuilder",
                 "UglyToad.PdfPig.Writer.TokenWriter",
-                "UglyToad.PdfPig.XObjects.XObjectImage"
+                "UglyToad.PdfPig.XObjects.XObjectImage",
+                "UglyToad.PdfPig.XObjects.XObjectImage",
+                "UglyToad.PdfPig.XObjects.XObjectType"
             };
 
             foreach (var publicTypeName in publicTypeNames)

--- a/src/UglyToad.PdfPig/Functions/PdfFunctionType0.cs
+++ b/src/UglyToad.PdfPig/Functions/PdfFunctionType0.cs
@@ -348,8 +348,6 @@
                 // Successive values are adjacent in the bit stream; there is no padding at byte boundaries.
                 var bits = new BitArray(FunctionStream.Data.ToArray());
 
-                System.Diagnostics.Debug.Assert(bits.Length == arraySize * nOut * bitsPerSample);
-
                 for (int i = 0; i < arraySize; i++)
                 {
                     samples[i] = new int[nOut];

--- a/src/UglyToad.PdfPig/Functions/Type4/Parser.cs
+++ b/src/UglyToad.PdfPig/Functions/Type4/Parser.cs
@@ -201,7 +201,6 @@
 
             private void ScanNewLine()
             {
-                System.Diagnostics.Debug.Assert(state == State.NEWLINE);
                 char ch = CurrentChar();
                 buffer.Append(ch);
                 if (ch == CR && Peek() == LF)
@@ -215,7 +214,6 @@
 
             private void ScanWhitespace()
             {
-                System.Diagnostics.Debug.Assert(state == State.WHITESPACE);
                 buffer.Append(CurrentChar());
 
                 bool loop = true;
@@ -239,7 +237,6 @@
 
             private void ScanComment()
             {
-                System.Diagnostics.Debug.Assert(state == State.COMMENT);
                 buffer.Append(CurrentChar());
 
                 bool loop = true;
@@ -264,7 +261,6 @@
 
             private void ScanToken()
             {
-                System.Diagnostics.Debug.Assert(state == State.TOKEN);
                 char ch = CurrentChar();
                 buffer.Append(ch);
                 switch (ch)

--- a/src/UglyToad.PdfPig/Graphics/IOperationContext.cs
+++ b/src/UglyToad.PdfPig/Graphics/IOperationContext.cs
@@ -69,11 +69,6 @@
         PdfPoint? CloseSubpath();
 
         /// <summary>
-        /// Add the current subpath to the path.
-        /// </summary>
-        void AddCurrentSubpath();
-
-        /// <summary>
         /// Stroke the current path.
         /// </summary>
         /// <param name="close">Whether to also close the path.</param>

--- a/src/UglyToad.PdfPig/Graphics/XObjectContentRecord.cs
+++ b/src/UglyToad.PdfPig/Graphics/XObjectContentRecord.cs
@@ -8,20 +8,38 @@
     using Util.JetBrains.Annotations;
     using XObjects;
 
-    internal class XObjectContentRecord
+    /// <summary>
+    /// An XObject content record.
+    /// </summary>
+    public class XObjectContentRecord
     {
+        /// <summary>
+        /// The XObject type.
+        /// </summary>
         public XObjectType Type { get; }
 
+        /// <summary>
+        /// The XObject stream.
+        /// </summary>
         [NotNull]
         public StreamToken Stream { get; }
 
+        /// <summary>
+        /// The applied transformation.
+        /// </summary>
         public TransformationMatrix AppliedTransformation { get; }
 
+        /// <summary>
+        /// The default rendering intent.
+        /// </summary>
         public RenderingIntent DefaultRenderingIntent { get; }
 
+        /// <summary>
+        /// The default color space.
+        /// </summary>
         public ColorSpace DefaultColorSpace { get; }
 
-        public XObjectContentRecord(XObjectType type, StreamToken stream, TransformationMatrix appliedTransformation,
+        internal XObjectContentRecord(XObjectType type, StreamToken stream, TransformationMatrix appliedTransformation,
             RenderingIntent defaultRenderingIntent,
             ColorSpace defaultColorSpace)
         {

--- a/src/UglyToad.PdfPig/PdfFonts/CharacterBoundingBox.cs
+++ b/src/UglyToad.PdfPig/PdfFonts/CharacterBoundingBox.cs
@@ -2,13 +2,22 @@
 {
     using Core;
 
-    internal class CharacterBoundingBox
+    /// <summary>
+    /// Character bounding box.
+    /// </summary>
+    public class CharacterBoundingBox
     {
+        /// <summary>
+        /// The glyph bounds.
+        /// </summary>
         public PdfRectangle GlyphBounds { get; }
 
+        /// <summary>
+        /// THe width.
+        /// </summary>
         public double Width { get; }
 
-        public CharacterBoundingBox(PdfRectangle bounds, double width)
+        internal CharacterBoundingBox(PdfRectangle bounds, double width)
         {
             GlyphBounds = bounds;
             Width = width;

--- a/src/UglyToad.PdfPig/PdfFonts/IFont.cs
+++ b/src/UglyToad.PdfPig/PdfFonts/IFont.cs
@@ -4,20 +4,44 @@
     using System.Collections.Generic;
     using Tokens;
 
-    internal interface IFont
+    /// <summary>
+    /// Font base interface.
+    /// </summary>
+    public interface IFont
     {
+        /// <summary>
+        /// The font name.
+        /// </summary>
         NameToken Name { get; }
 
+        /// <summary>
+        /// Is the font vertical.
+        /// </summary>
         bool IsVertical { get; }
 
+        /// <summary>
+        /// The font details.
+        /// </summary>
         FontDetails Details { get; }
 
+        /// <summary>
+        /// Read the character code.
+        /// </summary>
         int ReadCharacterCode(IInputBytes bytes, out int codeLength);
 
+        /// <summary>
+        /// Try get the unicode value.
+        /// </summary>
         bool TryGetUnicode(int characterCode, out string value);
 
+        /// <summary>
+        /// Get the font bounding box.
+        /// </summary>
         CharacterBoundingBox GetBoundingBox(int characterCode);
 
+        /// <summary>
+        /// Get the font transformation matrix.
+        /// </summary>
         TransformationMatrix GetFontMatrix();
 
         /// <summary>

--- a/src/UglyToad.PdfPig/XObjects/XObjectType.cs
+++ b/src/UglyToad.PdfPig/XObjects/XObjectType.cs
@@ -1,9 +1,23 @@
 ﻿namespace UglyToad.PdfPig.XObjects
 {
-    internal enum XObjectType
+    /// <summary>
+    /// XObject type.
+    /// </summary>
+    public enum XObjectType
     {
+        /// <summary>
+        /// Image.
+        /// </summary>
         Image,
+
+        /// <summary>
+        /// Form.
+        /// </summary>
         Form,
+
+        /// <summary>
+        /// PostScript.
+        /// </summary>
         PostScript
     }
 }


### PR DESCRIPTION
I want to make it easier to review my previous PR https://github.com/UglyToad/PdfPig/pull/555 (that I will drop later on)

This is the first step where we just make some classes public, next step will be to create `BaseStreamProcessor<T>` and update `ContentStreamProcessor` to inherite.

I'm doing that following the latest merge - I want to make sure nothing is lost will doing step 2

(also removing some assert I added in a previous PR)