### PR TITLE
AlphaConstants and more named graphics state

### DIFF
--- a/src/UglyToad.PdfPig/Graphics/ContentStreamProcessor.cs
+++ b/src/UglyToad.PdfPig/Graphics/ContentStreamProcessor.cs
@@ -789,6 +789,65 @@
                 currentGraphicsState.FontState.FontSize = (double)sizeToken.Data;
                 activeExtendedGraphicsStateFont = resourceStore.GetFontDirectly(fontReference);
             }
+
+            if (state.TryGet(NameToken.Ais, pdfScanner, out BooleanToken aisToken))
+            {
+                // The alpha source flag (“alpha is shape”), specifying
+                // whether the current soft mask and alpha constant are to be interpreted as
+                // shape values (true) or opacity values (false).
+                currentGraphicsState.AlphaSource = aisToken.Data;
+            }
+
+            if (state.TryGet(NameToken.Ca, pdfScanner, out NumericToken caToken))
+            {
+                // (Optional; PDF 1.4) The current stroking alpha constant, specifying the constant
+                // shape or constant opacity value to be used for stroking operations in the
+                // transparent imaging model (see “Source Shape and Opacity” on page 526 and
+                // “Constant Shape and Opacity” on page 551).
+                currentGraphicsState.AlphaConstantStroking = caToken.Data;
+            }
+
+            if (state.TryGet(NameToken.CaNs, pdfScanner, out NumericToken cansToken))
+            {
+                // (Optional; PDF 1.4) The current stroking alpha constant, specifying the constant
+                // shape or constant opacity value to be used for NON-stroking operations in the
+                // transparent imaging model (see “Source Shape and Opacity” on page 526 and
+                // “Constant Shape and Opacity” on page 551).
+                currentGraphicsState.AlphaConstantNonStroking = cansToken.Data;
+            }
+
+            if (state.TryGet(NameToken.Op, pdfScanner, out BooleanToken OPToken))
+            {
+                // (Optional) A flag specifying whether to apply overprint (see Section 4.5.6,
+                // “Overprint Control”). In PDF 1.2 and earlier, there is a single overprint
+                // parameter that applies to all painting operations. Beginning with PDF 1.3,
+                // there are two separate overprint parameters: one for stroking and one for all
+                // other painting operations. Specifying an OP entry sets both parameters unless there
+                // is also an op entry in the same graphics state parameter dictionary,
+                // in which case the OP entry sets only the overprint parameter for stroking.
+                currentGraphicsState.Overprint = OPToken.Data;
+            }
+
+            if (state.TryGet(NameToken.OpNs, pdfScanner, out BooleanToken opToken))
+            {
+                // (Optional; PDF 1.3) A flag specifying whether to apply overprint (see Section
+                // 4.5.6, “Overprint Control”) for painting operations other than stroking. If
+                // this entry is absent, the OP entry, if any, sets this parameter.
+                currentGraphicsState.NonStrokingOverprint = opToken.Data;
+            }
+
+            if (state.TryGet(NameToken.Opm, pdfScanner, out NumericToken opmToken))
+            {
+                // (Optional; PDF 1.3) The overprint mode (see Section 4.5.6, “Overprint Control”).
+                currentGraphicsState.OverprintMode = opmToken.Data;
+            }
+
+            if (state.TryGet(NameToken.Sa, pdfScanner, out BooleanToken saToken))
+            {
+                // (Optional) A flag specifying whether to apply automatic stroke adjustment
+                // (see Section 6.5.4, “Automatic Stroke Adjustment”).
+                currentGraphicsState.StrokeAdjustment = saToken.Data;
+            }
         }
 
         public void BeginInlineImage()

--- a/src/UglyToad.PdfPig/Graphics/CurrentGraphicsState.cs
+++ b/src/UglyToad.PdfPig/Graphics/CurrentGraphicsState.cs
@@ -61,7 +61,12 @@ namespace UglyToad.PdfPig.Graphics
         /// <summary>
         /// Opacity value to be used for transparent imaging.
         /// </summary>
-        public decimal AlphaConstant { get; set; } = 1;
+        public decimal AlphaConstantStroking { get; set; } = 1;
+
+        /// <summary>
+        /// Opacity value to be used for transparent imaging.
+        /// </summary>
+        public decimal AlphaConstantNonStroking { get; set; } = 1;
 
         /// <summary>
         /// Should soft mask and alpha constant values be interpreted as shape (<see langword="true"/>) or opacity (<see langword="false"/>) values?
@@ -129,7 +134,8 @@ namespace UglyToad.PdfPig.Graphics
                 CapStyle = CapStyle,
                 MiterLimit = MiterLimit,
                 Flatness = Flatness,
-                AlphaConstant = AlphaConstant,
+                AlphaConstantStroking = AlphaConstantStroking,
+                AlphaConstantNonStroking = AlphaConstantNonStroking,
                 AlphaSource = AlphaSource,
                 NonStrokingOverprint = NonStrokingOverprint,
                 OverprintMode = OverprintMode,


### PR DESCRIPTION
Update CurrentGraphicsState with `AlphaConstantNonStroking` and `AlphaConstantStroking` and implement more named graphics state

Previous commited in a the `pdf to image rendering` branch by @fnatzke, see https://github.com/UglyToad/PdfPig/pull/515

I've kept the commit small, doing the straightforward named tokens only and not adding `AlphaColor`. `AlphaColor` is not a pdf concept, so it's up for discussion to add it or not in an other PR