### PR TITLE
Address Issue 532 Support DCTDecode filter

### DIFF
--- a/src/UglyToad.PdfPig.Tests/Integration/SinglePageLibreOfficeImages.cs
+++ b/src/UglyToad.PdfPig.Tests/Integration/SinglePageLibreOfficeImages.cs
@@ -71,9 +71,15 @@
             using (var document = PdfDocument.Open(GetFilePath(), ParsingOptions.LenientParsingOff))
             {
                 var page = document.GetPage(1);
-                foreach (var image in page.GetImages())
+                var images = page.GetImages().ToArray();
+                var numberOfImages = images.Length;
+                for(int imageIndex=0; imageIndex<numberOfImages;imageIndex++)
                 {
-                    if (image.TryGetBytes(out var bytes))
+
+                    //TODO: Update test to attempt TryGetBytes on image 2 when ProgressDct implmented in DCTDecode.
+                    var isDCTDecodeFilterSupporting = imageIndex != 2; // Image 2 uses ProgressDct not yet implemented.
+                    var image = images[imageIndex];
+                    if (isDCTDecodeFilterSupporting && image.TryGetBytes(out var bytes))
                     {
                         Assert.NotNull(bytes);
                     }

--- a/src/UglyToad.PdfPig.Tests/PublicApiScannerTests.cs
+++ b/src/UglyToad.PdfPig.Tests/PublicApiScannerTests.cs
@@ -203,6 +203,7 @@
                 "UglyToad.PdfPig.Graphics.TextMatrices",
                 "UglyToad.PdfPig.Graphics.XObjectContentRecord",
                 "UglyToad.PdfPig.Images.ColorSpaceDetailsByteConverter",
+                "UglyToad.PdfPig.Images.Jpg.Jpg",
                 "UglyToad.PdfPig.Logging.ILog",
                 "UglyToad.PdfPig.Outline.Bookmarks",
                 "UglyToad.PdfPig.Outline.BookmarkNode",

--- a/src/UglyToad.PdfPig/Filters/DctDecodeFilter.cs
+++ b/src/UglyToad.PdfPig/Filters/DctDecodeFilter.cs
@@ -2,18 +2,24 @@
 {
     using System;
     using System.Collections.Generic;
+    using System.Linq;
     using Tokens;
 
     internal class DctDecodeFilter : IFilter
     {
         /// <inheritdoc />
-        public bool IsSupported { get; } = false;
+        public bool IsSupported { get; } = true; // actually this is only partially supported. 8bit only. 1 and 3 component only. Be better to provide the stream for inspection to answer correctly. 
 
         /// <inheritdoc />
         public byte[] Decode(IReadOnlyList<byte> input, DictionaryToken streamDictionary, int filterIndex)
         {
-            throw new NotSupportedException("The DST (Discrete Cosine Transform) Filter indicates data is encoded in JPEG format. " +
-                                            "This filter is not currently supported but the raw data can be supplied to JPEG supporting libraries.");
+            //throw new NotSupportedException("The DST (Discrete Cosine Transform) Filter indicates data is encoded in JPEG format. " +
+            //                                "This filter is not currently supported but the raw data can be supplied to JPEG supporting libraries.");
+
+            var ab = input.ToArray();
+            var jpg = Images.Jpg.Jpg.Parse(ab, streamDictionary);
+            var decodedBytes = jpg.Data;
+            return decodedBytes;
         }
     }
 }

--- a/src/UglyToad.PdfPig/Images/Jpg/Helpers/BitReader.cs
+++ b/src/UglyToad.PdfPig/Images/Jpg/Helpers/BitReader.cs
@@ -1,0 +1,179 @@
+﻿namespace UglyToad.PdfPig.Images.Jpg.Helpers
+{
+    using System;    
+    using System.IO;
+    using System.Diagnostics;
+    using JpegMarker = Parts.JpegMarker;
+
+    internal class BitReader : IDisposable
+    {
+        //private int count = 0;
+        //private int index = 0;
+        internal Stream stream;
+        const byte FrameMarker = 255;
+
+        public BitReader(byte[] data) { stream = new MemoryStream(data); }
+        public BitReader(Stream stream) { this.stream = stream; }
+         
+      
+        internal int EnsureData(int bitCount)
+        {
+            //int todo = ((bitCount - count) + 7) / 8;
+            //for (int i = 0; i < todo; i++)
+            //{
+            //    byte newbyte;
+            //    if (stream.Position == stream.Length)
+            //    {
+            //        // readed the end of the stream. pad bit request with 0xff 
+            //        newbyte = 0xff;
+            //        index = index << 8; // Roll left one byte. Least most byte (lsb) 'available' as a 'free slot' for new byte.
+            //        index |= newbyte;   // 'place' new byte in the 'free slot' 
+            //        count += 8;
+            //        continue;
+            //    }
+            //    newbyte = (byte)stream.ReadByte();
+            //    index = index << 8; // Roll left one byte. Least most byte (lsb) 'available' as a 'free slot' for new byte.
+            //    index |= newbyte;   // 'place' new byte in the 'free slot' 
+            //    count += 8;
+            //    if (newbyte == FrameMarker) // Check for new frame marker (ending data from old frame)                 
+            //    {
+            //        if (stream.Position != stream.Length)
+            //        {
+            //            var marker = (byte)stream.ReadByte();
+            //            switch (marker)
+            //            {
+            //                case 0x00:
+            //                case 0xFF:
+            //                    break;
+            //                case (byte)JpegMarker.EndOfImage: break;
+            //                default:
+            //                    if ((marker & 0xF8) != 0xD0)
+            //                        throw new Exception(); // Syntax
+            //                    else
+            //                    {
+            //                        index = (index << 8) | marker;
+            //                        count += 8;
+            //                    }
+            //                    break;
+            //            }
+            //        }
+            //        else
+            //        {
+            //            throw new Exception(); // Syntax
+            //        }
+            //    }
+            //}
+            //var ret = (index >> (count - bitCount)) & ((1 << bitCount) - 1);            
+            //return ret;
+            return ShowBits(bitCount);
+        }
+
+        //public int Peek(int bitCount)
+        //{
+        //    EnsureData(bitCount);
+        //    int mask = ((1 << count) - 1) ^ ((1 << (count - bitCount)) - 1);
+        //    return (int)(index & mask) >> (count - bitCount);
+        //}
+
+        public int Read(int bitCount)
+        {
+            //EnsureData(bitCount);
+            //int mask = ((1 << count) - 1) ^ ((1 << (count - bitCount)) - 1);
+            //int val = (int)(index & mask) >> (count - bitCount);
+            //count -= bitCount;
+            //return val;
+            return GetBits(bitCount);
+        }
+
+        public void Skip(int bitCount)
+        {
+            //EnsureData(bitCount);
+            //count -= bitCount;
+            SkipBits(bitCount);
+        }
+         
+        #region Implementation2
+        public int BufBits;
+        public int Buf;
+
+        public void Align()
+        {
+            BufBits &= 0xF8;
+        }
+        private void SkipBits( int bits)
+        {
+            if (BufBits < bits) { ShowBits(bits); }
+            BufBits -= bits;
+        }
+
+        private int GetBits(  int bits)
+        {
+            int res = ShowBits( bits);
+            SkipBits( bits);
+            return res;
+        }
+
+        private int ShowBits( int bits)
+        {
+            byte newbyte;
+            if (bits == 0) { return 0; }
+
+            while (BufBits < bits)
+            {
+                if (stream.Position == stream.Length)
+                {
+                    Buf = (Buf << 8) | 0xFF;
+                    BufBits += 8;
+                    continue;
+                }
+
+                newbyte = (byte)stream.ReadByte(); 
+                
+                BufBits += 8;
+                Buf = (Buf << 8) | newbyte;
+
+                if (newbyte == 0xFF)
+                {
+                    if (stream.Position != stream.Length)
+                    {
+                        byte marker = (byte)stream.ReadByte();
+ 
+                        switch (marker)
+                        {
+                            case 0x00:
+                            case 0xFF:
+                                break;
+
+                            case 0xD9:
+                                //data.Remaining = 0;
+                                break;
+
+                            default:
+                                if ((marker & 0xF8) != 0xD0) { throw new Exception(); }
+                                else
+                                {
+                                    Buf = (Buf << 8) | marker;
+                                    BufBits += 8;
+                                }
+                                break;
+                        }
+                    }
+                    else { throw new Exception(); }
+                }
+            }
+
+            return (Buf >> (BufBits - bits)) & ((1 << bits) - 1);
+        }
+        #endregion
+
+        public void Dispose()
+        {
+            if (stream == null)
+            {
+                return;
+            }
+
+            stream.Dispose();
+        }
+    }
+}

--- a/src/UglyToad.PdfPig/Images/Jpg/Helpers/ColorSpaceHint.cs
+++ b/src/UglyToad.PdfPig/Images/Jpg/Helpers/ColorSpaceHint.cs
@@ -1,0 +1,320 @@
+﻿using static UglyToad.PdfPig.Images.Jpg.Helpers.Context;
+
+namespace UglyToad.PdfPig.Images.Jpg.Helpers
+{
+    using System;
+    
+    using System.Diagnostics;
+    using System.Net.NetworkInformation;
+    using ContextForColorSpaceHints = Context.ContextForColorSpaceHints;
+    using J_COLOR_SPACE = Helpers.Context.J_COLOR_SPACE;
+    internal class ColorSpaceHints
+    {
+        internal static void Get(ContextForColorSpaceHints context)
+        {
+            // Guess the input colorspace, and set output colorspace accordingly. 
+            // DCTDecode dictionary may override guesses.
+
+            switch (context.ncomp)
+            {
+                case 1:
+                    {
+                        context.jpeg_color_space = J_COLOR_SPACE.JCS_GRAYSCALE;
+                        context.out_color_space = J_COLOR_SPACE.JCS_GRAYSCALE;
+                    }
+                    break;
+                case 3:
+                    if (context.hasApp0segment)
+                    {
+                        /* JFIF implies YCbCr */
+                        context.jpeg_color_space = J_COLOR_SPACE.JCS_YCbCr;
+                    }
+                    else if (context.hasAdobeSegment)
+                    {
+                        FromAdobeSegment(context, J_COLOR_SPACE.JCS_YCbCr);
+                    }
+                    else
+                    {
+                        // Saw no special markers, try to guess from the component IDs
+                        FromComponentIds(context);
+                    }
+                    // Always guess RGB is proper output colorspace. 
+                    context.out_color_space = J_COLOR_SPACE.JCS_RGB;
+                    break;
+                case 4:
+                    if (context.hasAdobeSegment)
+                    {
+                        FromAdobeSegment(context, J_COLOR_SPACE.JCS_YCCK);
+                    }
+                    else
+                    {
+                        // No special markers, assume straight CMYK. 
+                        context.jpeg_color_space = J_COLOR_SPACE.JCS_CMYK;
+                    }
+                    context.out_color_space = J_COLOR_SPACE.JCS_CMYK;
+                    break;
+                default:
+                    context.jpeg_color_space = J_COLOR_SPACE.JCS_UNKNOWN;
+                    context.out_color_space = J_COLOR_SPACE.JCS_UNKNOWN;
+                    break;
+            }
+        }
+        internal static void FromAdobeSegment(ContextForColorSpaceHints context, J_COLOR_SPACE defaultInputColorSpace)
+        {
+            switch (context.colorTransformCode)
+            {
+                case 0:
+                    context.jpeg_color_space = J_COLOR_SPACE.JCS_RGB;
+                    break;
+                case 1:
+                    context.jpeg_color_space = J_COLOR_SPACE.JCS_YCbCr;
+                    break;
+                default:
+                    Debug.WriteLine($"Warning: Jpg Adobe Segment Colorspace Code is unknown. Got: {context.colorTransformCode}. Expected: 0, 1. Assume input colorspace is {defaultInputColorSpace}.");
+                    context.jpeg_color_space = defaultInputColorSpace;
+                    break;
+            }
+        }
+
+        internal static void FromComponentIds(ContextForColorSpaceHints context)
+        {
+            int cid0 = context.comp[0].cid;
+            int cid1 = context.comp[1].cid;
+            int cid2 = context.comp[2].cid;
+
+            if (cid0 == 1 && cid1 == 2 && cid2 == 3)            // assume JFIF w/out marker
+            {
+                context.jpeg_color_space = J_COLOR_SPACE.JCS_YCbCr;
+            }
+            else if (cid0 == 82 && cid1 == 71 && cid2 == 66)    // ASCII 'R', 'G', 'B' */
+            {
+                context.jpeg_color_space = J_COLOR_SPACE.JCS_RGB;
+            }
+            else                                                // assume it's YCbCr 
+            {
+                Debug.WriteLine($"Warning: Jpg Unknown input colorpace. Assume YCbCr.");
+                context.jpeg_color_space = J_COLOR_SPACE.JCS_YCbCr; // assume it's YCbCr 
+            }
+        }
+
+        internal static uint GetPitch(uint bitsPerComponent,
+                                     uint numberOfComponents,
+                                     int width)
+        {
+            if (bitsPerComponent == 0) { throw new ArgumentException(nameof(bitsPerComponent)); }
+            if (numberOfComponents == 0) { throw new ArgumentException(nameof(numberOfComponents)); }
+            if (width == 0) { throw new ArgumentException(nameof(width)); }
+
+            uint pitch = bitsPerComponent;
+            pitch *= numberOfComponents;
+            pitch *= (uint)width;
+            pitch += 7;
+            pitch /= 8;
+            return pitch;
+        }
+
+        internal static int CalculateBitsPerPixel(uint bitsPerComponent, uint numberOfComponents)
+        {
+            if (bitsPerComponent == 0)
+            {
+                throw new Exception($"Jpg Expected bits per pixel not to be zero.");
+            }
+            uint bitsPerPixel = bitsPerComponent * numberOfComponents;
+            if (bitsPerPixel == 1)
+            {
+                return 1;
+            }
+            if (bitsPerPixel <= 8)
+            {
+                return 8;
+            }
+            return 24;
+        }
+
+
+        public enum FXDIB_Format : UInt16
+        {
+            kInvalid = 0,
+            k1bppRgb = 0x001,
+            k8bppRgb = 0x008,
+            kRgb = 0x018,
+            kRgb32 = 0x020,
+            k1bppMask = 0x101,
+            k8bppMask = 0x108,
+            kArgb = 0x220,
+        };
+
+
+        public static FXDIB_Format MakeRGBFormat(int bitsPerPixel)
+        {
+            switch (bitsPerPixel)
+            {
+                case 1:
+                    return FXDIB_Format.k1bppRgb;
+                case 8:
+                    return FXDIB_Format.k8bppRgb;
+                case 24:
+                    return FXDIB_Format.kRgb;
+                case 32:
+                    return FXDIB_Format.kRgb32;
+                default:
+                    return FXDIB_Format.kInvalid;
+            }
+        }
+
+        public static int GetBppFromFormat(FXDIB_Format format)
+        {
+            return ((UInt16)(format)) & 0xff;
+        }
+
+
+        uint CalculatePitch32y(int bitsPerPixel, int width)
+        {
+            if (bitsPerPixel > 32)
+            {
+                throw new Exception($"Jpg bits per pixel > 32. Got: {bitsPerPixel}.");
+            }
+            if (width <=0)
+            {
+                throw new Exception($"Jpg width <=0. Got: {width}.");
+            }
+            uint pitch = (uint)bitsPerPixel;
+            pitch *= (uint)width;
+            pitch += 31;
+            pitch /= 32;  // quantized to number of 32-bit words.
+            pitch *= 4;   // and then back to bytes, (not just /8 in one step).
+            return pitch;
+        }
+
+       
+
+        public static void LoadPalette(Context context)
+        {
+            if (context.ColorSpace is null || context.ColorspaceFamily == ColorSpaceFamily.kPattern)
+            {
+                return;
+            }
+            if (context.BitsPerComponent>32)
+            {
+                throw new Exception($"Jpg Bits Per Component > 32. Got {context.BitsPerComponent}");
+            }
+
+            if (context.ncomp > 3)
+            {
+                throw new Exception($"Jpg Number of components >3. Got {context.ncomp}");
+            }
+            uint bits = (uint)context.BitsPerComponent;
+            bits *= (uint)context.ncomp;
+            if (bits > 8)
+            {
+                return;
+            }
+
+            if (bits == 1)
+            {
+                if (context.m_bDefaultDecode && (context.ColorspaceFamily ==  ColorSpaceFamily.kDeviceGray||
+                            context.ColorspaceFamily == ColorSpaceFamily.kDeviceRGB))
+                {
+                    return;
+                }
+                //if (context.ColorSpace->CountComponents() > 3)
+                //{
+                //    return;
+                //}
+            }
+        }
+            /*
+             * 
+      if (!m_pColorSpace || m_Family == CPDF_ColorSpace::Family::kPattern)
+        return;
+
+      if (m_bpc == 0)
+        return;
+
+      // Use FX_SAFE_UINT32 just to be on the safe side, in case |m_bpc| or
+      // |m_nComponents| somehow gets a bad value.
+      FX_SAFE_UINT32 safe_bits = m_bpc;
+      safe_bits *= m_nComponents;
+      uint32_t bits = safe_bits.ValueOrDefault(255);
+      if (bits > 8)
+        return;
+
+      if (bits == 1) {
+        if (m_bDefaultDecode && (m_Family == CPDF_ColorSpace::Family::kDeviceGray ||
+                                 m_Family == CPDF_ColorSpace::Family::kDeviceRGB)) {
+          return;
+        }
+        if (m_pColorSpace->CountComponents() > 3) {
+          return;
+        }
+        float color_values[3];
+        std::fill(std::begin(color_values), std::end(color_values),
+                  m_CompData[0].m_DecodeMin);
+
+        float R = 0.0f;
+        float G = 0.0f;
+        float B = 0.0f;
+        m_pColorSpace->GetRGB(color_values, &R, &G, &B);
+
+        FX_ARGB argb0 = ArgbEncode(255, FXSYS_roundf(R * 255),
+                                   FXSYS_roundf(G * 255), FXSYS_roundf(B * 255));
+        FX_ARGB argb1;
+        const CPDF_IndexedCS* indexed_cs = m_pColorSpace->AsIndexedCS();
+        if (indexed_cs && indexed_cs->GetMaxIndex() == 0) {
+          // If an indexed color space's hival value is 0, only 1 color is specified
+          // in the lookup table. Another color should be set to 0xFF000000 by
+          // default to set the range of the color space.
+          argb1 = 0xFF000000;
+        } else {
+          color_values[0] += m_CompData[0].m_DecodeStep;
+          color_values[1] += m_CompData[0].m_DecodeStep;
+          color_values[2] += m_CompData[0].m_DecodeStep;
+          m_pColorSpace->GetRGB(color_values, &R, &G, &B);
+          argb1 = ArgbEncode(255, FXSYS_roundf(R * 255), FXSYS_roundf(G * 255),
+                             FXSYS_roundf(B * 255));
+        }
+
+        if (argb0 != 0xFF000000 || argb1 != 0xFFFFFFFF) {
+          SetPaletteArgb(0, argb0);
+          SetPaletteArgb(1, argb1);
+        }
+        return;
+      }
+      if (m_bpc == 8 && m_bDefaultDecode &&
+          m_pColorSpace ==
+              CPDF_ColorSpace::GetStockCS(CPDF_ColorSpace::Family::kDeviceGray)) {
+        return;
+      }
+
+      int palette_count = 1 << bits;
+      // Using at least 16 elements due to the call m_pColorSpace->GetRGB().
+      std::vector<float> color_values(std::max(m_nComponents, 16u));
+      for (int i = 0; i < palette_count; i++) {
+        int color_data = i;
+        for (uint32_t j = 0; j < m_nComponents; j++) {
+          int encoded_component = color_data % (1 << m_bpc);
+          color_data /= 1 << m_bpc;
+          color_values[j] = m_CompData[j].m_DecodeMin +
+                            m_CompData[j].m_DecodeStep * encoded_component;
+        }
+        float R = 0;
+        float G = 0;
+        float B = 0;
+        if (m_nComponents == 1 && m_Family == CPDF_ColorSpace::Family::kICCBased &&
+            m_pColorSpace->CountComponents() > 1) {
+          int nComponents = m_pColorSpace->CountComponents();
+          std::vector<float> temp_buf(nComponents);
+          for (int k = 0; k < nComponents; ++k)
+            temp_buf[k] = color_values[0];
+          m_pColorSpace->GetRGB(temp_buf, &R, &G, &B);
+        } else {
+          m_pColorSpace->GetRGB(color_values, &R, &G, &B);
+        }
+        SetPaletteArgb(i, ArgbEncode(255, FXSYS_roundf(R * 255),
+                                     FXSYS_roundf(G * 255), FXSYS_roundf(B * 255)));
+      }
+    }
+             */
+
+        }
+}

--- a/src/UglyToad.PdfPig/Images/Jpg/Helpers/Context.cs
+++ b/src/UglyToad.PdfPig/Images/Jpg/Helpers/Context.cs
@@ -1,0 +1,385 @@
+﻿// ReSharper disable UnusedVariable
+namespace UglyToad.PdfPig.Images.Jpg.Helpers
+{
+    using HuffmanTreeNode = Parts.HuffmanTreeNode;
+    using Component = Parts.Component;
+    using UglyToad.PdfPig.Images.Jpg.Parts.Exif;
+    using System.Collections.Generic;
+
+    internal class Context
+    {
+        public int BitsPerComponent { get; set; }
+        public bool HasImageMask { get; set; }
+
+        public object ColorSpace { get; set; }
+        public ColorSpaceFamily ColorspaceFamily { get; set; }
+
+        public bool m_bDefaultDecode { get; set; } = false;
+
+        //public byte[] posb;         // C#: Because we don't have fancy pointers.
+        public Result error;
+        public int pos;
+        public int size;
+        public int length;
+        public int width, height;
+        public int mbwidth, mbheight;
+        public int mbsizex, mbsizey;
+        public int ncomp;
+        public Component[] comp;
+        public int qtused, qtavail;
+        public byte[][] qtab;
+        public HuffmanTreeNode[][] vlctab;
+        public int buf, bufbits;
+        public int[] block;
+        public int rstinterval;
+        public byte[] rgb;
+
+        public List<string> Comments = new List<string>();
+
+        #region Adobe App Segment Values
+        public bool hasAdobeSegment = false;
+        public int colorTransformCode;
+        public int versionDctEncodeDecode;
+        public int flag0;
+        public int flag1;
+        #endregion
+
+        #region App0 Segment
+        public bool hasApp0segment = false;
+        public int App0versionMajor;
+        public int App0versionMinor;
+        public int App0density_unit;
+        public int App0X_density;
+        public int App0Y_density;
+        #endregion
+
+        public J_COLOR_SPACE jpeg_color_space = J_COLOR_SPACE.JCS_UNKNOWN;
+        public J_COLOR_SPACE out_color_space = J_COLOR_SPACE.JCS_UNKNOWN;
+
+        #region Decompress parameters
+        /* Decompression parameters. */
+        // ReSharper disable UnusedVariable
+#pragma warning disable 414
+        int scale_num = 1;         /* 1:1 scaling */
+        int scale_denom = 1;
+        double output_gamma = 1.0;
+        bool buffered_image = false;
+        bool raw_data_out = false;
+        J_DCT_METHOD dct_method = J_DCT_METHOD.JDCT_ISLOW;
+        bool do_fancy_upsampling = true;
+        bool do_block_smoothing = true;
+        bool quantize_colors = false;
+        /* We set these in case application only sets quantize_colors. */
+        J_DITHER_MODE dither_mode = J_DITHER_MODE.JDITHER_FS;
+        bool two_pass_quantize = false;
+        int desired_number_of_colors = 256;
+        //JSAMPARRAY colormap = NULL; /* ptr to one image row of pixel samples. */
+        /* Initialize for no mode change in buffered-image mode. */
+        bool enable_1pass_quant = false;
+        bool enable_external_quant = false;
+        bool enable_2pass_quant = false;
+#pragma warning restore 414
+        // ReSharper restore UnusedVariable
+        #endregion
+
+
+        public enum Result
+        {
+            OK = 0,         // no error, decoding successful
+            NO_JPEG,        // not a JPEG file
+            UNSUPPORTED,    // unsupported format
+            OUT_OF_MEM,     // out of memory
+            INTERNAL_ERROR, // internal error
+            SYNTAX_ERROR,   // syntax error
+            FINISHED,       // used internally, will never be reported
+        };
+
+        public enum J_COLOR_SPACE
+        {
+            JCS_UNKNOWN,            /* error/unspecified */
+            JCS_GRAYSCALE,          /* monochrome */
+            JCS_RGB,                /* red/green/blue as specified by the RGB_RED,                             RGB_GREEN, RGB_BLUE, and RGB_PIXELSIZE macros */
+            JCS_YCbCr,              /* Y/Cb/Cr (also known as YUV) */
+            JCS_CMYK,               /* C/M/Y/K */
+            JCS_YCCK,               /* Y/Cb/Cr/K */
+            JCS_EXT_RGB,            /* red/green/blue */
+            JCS_EXT_RGBX,           /* red/green/blue/x */
+            JCS_EXT_BGR,            /* blue/green/red */
+            JCS_EXT_BGRX,           /* blue/green/red/x */
+            JCS_EXT_XBGR,           /* x/blue/green/red */
+            JCS_EXT_XRGB,           /* x/red/green/blue */
+            /* When out_color_space it set to JCS_EXT_RGBX, JCS_EXT_BGRX, JCS_EXT_XBGR,
+               or JCS_EXT_XRGB during decompression, the X byte is undefined, and in
+               order to ensure the best performance, libjpeg-turbo can set that byte to
+               whatever value it wishes.  Use the following colorspace constants to
+               ensure that the X byte is set to 0xFF, so that it can be interpreted as an
+               opaque alpha channel. */
+            JCS_EXT_RGBA,           /* red/green/blue/alpha */
+            JCS_EXT_BGRA,           /* blue/green/red/alpha */
+            JCS_EXT_ABGR,           /* alpha/blue/green/red */
+            JCS_EXT_ARGB,           /* alpha/red/green/blue */
+            JCS_RGB565              /* 5-bit red/6-bit green/5-bit blue */
+        };
+
+        /* Dithering options for decompression. */
+
+        enum J_DITHER_MODE
+        {
+            JDITHER_NONE,           /* no dithering */
+            JDITHER_ORDERED,        /* simple ordered dither */
+            JDITHER_FS              /* Floyd-Steinberg error diffusion dither */
+        };
+
+
+        /* DCT/IDCT algorithm options. */
+
+        enum J_DCT_METHOD
+        {
+            JDCT_ISLOW,             /* accurate integer method */
+            JDCT_IFAST,             /* less accurate integer method [legacy feature] */
+            JDCT_FLOAT              /* floating-point method [legacy feature] */
+        };
+
+        public enum ColorSpaceFamily
+        {
+            kUnknown = 0,
+            kDeviceGray = 1,
+            kDeviceRGB = 2,
+            kDeviceCMYK = 3,
+            kCalGray = 4,
+            kCalRGB = 5,
+            kLab = 6,
+            kICCBased = 7,
+            kSeparation = 8,
+            kDeviceN = 9,
+            kIndexed = 10,
+            kPattern = 11,
+        };
+
+        internal class ContextForSOF0
+        {
+            private Context context;
+            internal int width { set { context.width = value; } }
+            internal int height { set { context.height = value; } }
+            internal Component[] comp { set { context.comp = value; } }
+            internal byte[] rgb { set { context.rgb = value; } }
+
+            internal int ncomp { set { context.ncomp = value; } }
+
+
+            internal int mbwidth { set { context.mbwidth = value; } }
+            internal int mbheight { set { context.mbheight = value; } }
+
+            internal int mbsizex { set { context.mbsizex = value; } }
+            internal int mbsizey { set { context.mbsizey = value; } }
+
+            internal int qtused { set { context.qtused = value; } }
+             
+            internal ContextForSOF0(Context context)
+            {
+                this.context = context;
+            }
+        }
+
+        internal class ContextForSOF2
+        {
+            private Context context;
+            internal int width { set { context.width = value; } }
+            internal int height { set { context.height = value; } }
+            internal Component[] comp { set { context.comp = value; } }
+            internal byte[] rgb { set { context.rgb = value; } }
+
+            internal int ncomp { set { context.ncomp = value; } }
+
+
+            internal int mbwidth { set { context.mbwidth = value; } }
+            internal int mbheight { set { context.mbheight = value; } }
+
+            internal int mbsizex { set { context.mbsizex = value; } }
+            internal int mbsizey { set { context.mbsizey = value; } }
+
+            internal int qtused { set { context.qtused = value; } }
+
+            internal ContextForSOF2(Context context)
+            {
+                this.context = context;
+            }
+        }
+        internal class ContextForStartOfScan
+        {
+            private Context context;
+
+            public Component[] comp => context.comp;
+            public int ncomp => context.ncomp;
+
+            public HuffmanTreeNode[][] vlctab => context.vlctab;
+
+            public int rstinterval => context.rstinterval;
+
+            public int mbwidth => context.mbwidth;
+
+            public int mbheight => context.mbheight;
+
+            public byte[][] qtab => context.qtab;
+             
+
+            internal ContextForStartOfScan(Context context)
+            {
+                this.context = context;
+
+            }
+        }
+
+        internal class ContextForDefineHuffmanTables
+        {
+            private Context context;
+
+            public Component[] comp => context.comp;
+            public int ncomp => context.ncomp;
+
+            public HuffmanTreeNode[][] vlctab { get { return context.vlctab; } set { context.vlctab = value; } }
+
+            internal ContextForDefineHuffmanTables(Context context)
+            {
+                this.context = context;
+
+            }
+        }
+
+        internal class ContextForQuantizationTableSpecification
+        {
+            private Context context;
+
+
+            public byte[][] qtab { get { return context.qtab; } set { context.qtab = value; } }
+
+            public int qtavail { get { return context.qtavail; } set { context.qtavail = value; } }
+
+
+            internal ContextForQuantizationTableSpecification(Context context)
+            {
+                this.context = context;
+
+            }
+        }
+        internal class ContextForDefineRestartInterval
+        {
+            private Context context;
+              
+            public int rstinterval { get { return context.rstinterval; } set { context.rstinterval = value; } }
+
+
+            internal ContextForDefineRestartInterval(Context context)
+            {
+                this.context = context;
+            }
+        }
+
+        internal class ContextForAdobeAppSegment
+        {
+            private Context context;
+
+            public bool hasAdobeSegment { set { context.hasAdobeSegment = value; } }
+            public int colorTransformCode { set { context.colorTransformCode = value; } }
+            public int versionDctEncodeDecode { set { context.versionDctEncodeDecode = value; } }
+            public int flag0 { set { context.flag0 = value; } }
+            public int flag1 { set { context.flag1 = value; } }
+             
+            internal ContextForAdobeAppSegment(Context context)
+            {
+                this.context = context;
+            }
+        }
+
+        internal class ContextForApp0JFIFSegment
+        {
+            private Context context;
+
+            public bool hasApp0segment { set { context.hasApp0segment = value; } }
+            public int App0versionMajor { set { context.App0versionMajor = value; } }
+            public int App0versionMinor { set { context.App0versionMinor = value; } }
+            public int App0density_unit { set { context.App0density_unit = value; } }
+            public int App0X_density { set { context.App0X_density = value; } }
+            public int App0Y_density { set { context.App0Y_density = value; } }
+
+            internal ContextForApp0JFIFSegment(Context context)
+            {
+                this.context = context;
+            }
+        }
+
+        internal class ContextForApp1Segment
+        {
+            private Context context;
+
+            public ExifImageProperties ExifImageProperties { get; set; }
+
+            public System.Xml.XmlDocument XMP { get; set; }
+
+            internal ContextForApp1Segment(Context context)
+            {
+                this.context = context;
+            }
+        }
+
+        internal class ContextForColorSpaceHints
+        {
+            private Context context;
+
+            public bool hasAdobeSegment => context.hasAdobeSegment;
+            public bool hasApp0segment => context.hasApp0segment;
+
+            public int colorTransformCode => context.colorTransformCode;
+
+            public Component[] comp => context.comp;
+
+            public int ncomp => context.ncomp;
+
+            public J_COLOR_SPACE jpeg_color_space { set { context.jpeg_color_space = value; } }
+            public J_COLOR_SPACE out_color_space { set { context.out_color_space = value; } }
+
+            internal ContextForColorSpaceHints(Context context)
+            {
+                this.context = context;
+            }
+        }
+
+        public Context()
+        {
+            //this.posb = null;
+            this.comp = new Component[3];
+            this.block = new int[64];
+            this.qtab = new byte[4][];
+            this.vlctab = new HuffmanTreeNode[4][];
+            for (byte i = 0; i < 4; i++)
+            {
+                this.qtab[i] = new byte[64];
+                this.vlctab[i] = new HuffmanTreeNode[65536];
+                if (i < this.comp.Length)
+                {
+                    this.comp[i] = new Component();
+                }
+            }
+
+
+        }
+        internal ContextForDefineHuffmanTables ForDefineHuffmanTables => new ContextForDefineHuffmanTables(this);
+        internal ContextForSOF0 ForStartOfFrame => new ContextForSOF0(this);
+        internal ContextForSOF2 ForStart2fFrame => new ContextForSOF2(this);
+        internal ContextForStartOfScan ForStartOfScan => new ContextForStartOfScan(this);
+
+        internal ContextForQuantizationTableSpecification ForDefineQuantizationTable => new ContextForQuantizationTableSpecification(this);
+
+        internal ContextForDefineRestartInterval ForDefineRestartInterval => new ContextForDefineRestartInterval(this);
+
+        internal ContextForAdobeAppSegment ForAdobeAppSegement => new ContextForAdobeAppSegment(this);
+
+        internal ContextForApp0JFIFSegment ForApp0JFIFSegement => new ContextForApp0JFIFSegment(this);
+
+        internal ContextForApp1Segment ForApp1Segement => new ContextForApp1Segment(this);
+
+        internal ContextForColorSpaceHints ForColorSpaceHints => new ContextForColorSpaceHints(this);
+      
+
+    }
+}

--- a/src/UglyToad.PdfPig/Images/Jpg/Helpers/ConvertScan.cs
+++ b/src/UglyToad.PdfPig/Images/Jpg/Helpers/ConvertScan.cs
@@ -75,6 +75,25 @@
                     component.stride = component.width;
                 }
             }
+            if (context.ncomp == 1 && context.comp[0].pixels.Length != context.comp[0].width * context.comp[0].height)
+            {
+                if (context.comp[0].pixels.Length > context.comp[0].width * context.comp[0].height)
+                {
+                    //Truncate block. Seperfulous scan lines at bottom removed.
+                    var component = context.comp[0];
+                    var newSize = context.comp[0].width * context.comp[0].height;
+                    var newPixels = new byte[newSize];
+
+                    Buffer.BlockCopy(
+                        component.pixels,
+                        0,
+                        newPixels,
+                        0,
+                        newPixels.Length);
+
+                    component.pixels = newPixels;
+                }
+            }
             return true;
         }
 

--- a/src/UglyToad.PdfPig/Images/Jpg/Helpers/ConvertScan.cs
+++ b/src/UglyToad.PdfPig/Images/Jpg/Helpers/ConvertScan.cs
@@ -1,0 +1,163 @@
+﻿namespace UglyToad.PdfPig.Images.Jpg.Helpers
+{
+    using System;
+    using Parts;
+
+    internal static class ConvertScan
+    { 
+        public static bool Convert(Context context)
+        {
+            int i;
+            Component c;
+            for (i = 0; i < context.ncomp; ++i)
+            {
+                c = context.comp[i];
+                while ((c.width < context.width) || (c.height < context.height))
+                {
+                    if (c.width < context.width)
+                    {
+                        var isSuccess =  UpsampleH(c);
+                        if (isSuccess == false) return false;
+                    }
+                    if (c.height < context.height)
+                    {
+                        var isSuccess = UpsampleV(c);
+                        if (isSuccess == false) return false;
+                    }
+                }
+                if ((c.width < context.width) || (c.height < context.height)) { throw new Exception(); } //internal ;
+            }   
+            if (context.ncomp == 3)
+            {
+                // convert to RGB
+                int x, yy;
+                int prgb = 0, py = 0, pcb = 0, pcr = 0;
+                for (yy = context.height; yy != 0; --yy)
+                {
+                    for (x = 0; x < context.width; ++x)
+                    {
+                        int y = context.comp[0].pixels[py + x] << 8;
+                        int cb = context.comp[1].pixels[pcb + x] - 128;
+                        int cr = context.comp[2].pixels[pcr + x] - 128;
+                        context.rgb[prgb++] = njClip((y + 359 * cr + 128) >> 8);
+                        context.rgb[prgb++] = njClip((y - 88 * cb - 183 * cr + 128) >> 8);
+                        context.rgb[prgb++] = njClip((y + 454 * cb + 128) >> 8);
+                    }
+                    py += context.comp[0].stride;
+                    pcb += context.comp[1].stride;
+                    pcr += context.comp[2].stride;
+                }
+            }
+            else if (context.comp[0].width != context.comp[0].stride)
+            {
+                // grayscale -> only remove stride  (from NanJpeg.Net)
+                var component = context.comp[0];
+                byte[] Data;
+                
+                int d = component.stride - component.width;
+                if (d == 0) { Data = component.pixels; }
+                else
+                {
+                    int w = component.width;
+                    int h = component.height;
+
+                    Data = new byte[w * h];
+                    for (int y = 0; y < component.height; y++)
+                    {
+                        Buffer.BlockCopy(
+                            component.pixels,
+                            y * component.stride,
+                            Data,
+                            y * component.width,
+                            component.width);
+                    }
+                    component.pixels = Data;
+                    component.stride = component.width;
+                }
+            }
+            return true;
+        }
+
+        public static bool UpsampleH(Component c)
+        {
+            int xmax = c.width - 3;
+            byte[] outv;
+            int lin = 0, lout = 0;
+            int x, y;
+            outv = new byte[(c.width * c.height) << 1];
+            if (outv == null) throw new OutOfMemoryException();
+            for (y = c.height; y != 0; --y)
+            {
+                outv[lout] = CF(CF2A * c.pixels[lin] + CF2B * c.pixels[lin + 1]);
+                outv[lout + 1] = CF(CF3X * c.pixels[lin] + CF3Y * c.pixels[lin + 1] + CF3Z * c.pixels[lin + 2]);
+                outv[lout + 2] = CF(CF3A * c.pixels[lin] + CF3B * c.pixels[lin + 1] + CF3C * c.pixels[lin + 2]);
+                for (x = 0; x < xmax; ++x)
+                {
+                    outv[lout + (x << 1) + 3] = CF(CF4A * c.pixels[lin + x] + CF4B * c.pixels[lin + x + 1] + CF4C * c.pixels[lin + x + 2] + CF4D * c.pixels[lin + x + 3]);
+                    outv[lout + (x << 1) + 4] = CF(CF4D * c.pixels[lin + x] + CF4C * c.pixels[lin + x + 1] + CF4B * c.pixels[lin + x + 2] + CF4A * c.pixels[lin + x + 3]);
+                }
+                lin += c.stride;
+                lout += c.width << 1;
+                outv[lout + -3] = CF(CF3A * c.pixels[lin - 1] + CF3B * c.pixels[lin - 2] + CF3C * c.pixels[lin - 3]);
+                outv[lout + -2] = CF(CF3X * c.pixels[lin - 1] + CF3Y * c.pixels[lin - 2] + CF3Z * c.pixels[lin - 3]);
+                outv[lout + -1] = CF(CF2A * c.pixels[lin - 1] + CF2B * c.pixels[lin - 2]);
+            }
+            c.width <<= 1;
+            c.stride = c.width;
+            c.pixels = outv;
+            return true;
+        }
+        public static bool UpsampleV(Component c)
+        {
+            int w = c.width, s1 = c.stride, s2 = s1 + s1;
+            byte[] outv;
+            int cin, cout;
+            int x, y;
+            outv = new byte[(c.width * c.height) << 1];
+            if (outv == null) throw new OutOfMemoryException();
+            for (x = 0; x < w; ++x)
+            {
+                cin = x;
+                cout = x;
+                outv[cout] = CF(CF2A * c.pixels[cin] + CF2B * c.pixels[cin + s1]); cout += w;
+                outv[cout] = CF(CF3X * c.pixels[cin] + CF3Y * c.pixels[cin + s1] + CF3Z * c.pixels[cin + s2]); cout += w;
+                outv[cout] = CF(CF3A * c.pixels[cin] + CF3B * c.pixels[cin + s1] + CF3C * c.pixels[cin + s2]); cout += w;
+                cin += s1;
+                for (y = c.height - 3; y != 0; --y)
+                {
+                    outv[cout] = CF(CF4A * c.pixels[cin + -s1] + CF4B * c.pixels[cin] + CF4C * c.pixels[cin + s1] + CF4D * c.pixels[cin + s2]); cout += w;
+                    outv[cout] = CF(CF4D * c.pixels[cin + -s1] + CF4C * c.pixels[cin] + CF4B * c.pixels[cin + s1] + CF4A * c.pixels[cin + s2]); cout += w;
+                    cin += s1;
+                }
+                cin += s1;
+                outv[cout] = CF(CF3A * c.pixels[cin] + CF3B * c.pixels[cin - s1] + CF3C * c.pixels[cin - s2]); cout += w;
+                outv[cout] = CF(CF3X * c.pixels[cin] + CF3Y * c.pixels[cin - s1] + CF3Z * c.pixels[cin - s2]); cout += w;
+                outv[cout] = CF(CF2A * c.pixels[cin] + CF2B * c.pixels[cin - s1]);
+            }
+            c.height <<= 1;
+            c.stride = c.width;
+            c.pixels = outv;
+            return true;
+        }
+        private static readonly int CF4A = (-9);
+        private static readonly int CF4B = (111);
+        private static readonly int CF4C = (29);
+        private static readonly int CF4D = (-3);
+        private static readonly int CF3A = (28);
+        private static readonly int CF3B = (109);
+        private static readonly int CF3C = (-9);
+        private static readonly int CF3X = (104);
+        private static readonly int CF3Y = (27);
+        private static readonly int CF3Z = (-3);
+        private static readonly int CF2A = (139);
+        private static readonly int CF2B = (-11);
+        private static byte CF(int x)
+        {
+            return njClip(((x) + 64) >> 7);
+        }
+        private static byte njClip(int x)
+        {
+            return (byte)((x < 0) ? 0 : ((x > 0xFF) ? 0xFF : (byte)x));
+        }
+    }
+}

--- a/src/UglyToad.PdfPig/Images/Jpg/Helpers/JpgBinaryStreamReader.cs
+++ b/src/UglyToad.PdfPig/Images/Jpg/Helpers/JpgBinaryStreamReader.cs
@@ -1,0 +1,127 @@
+﻿namespace UglyToad.PdfPig.Images.Jpg
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Diagnostics;
+    using System.IO;
+    using System.Text;
+     
+    internal class JpgBinaryStreamReader : BinaryReader
+    {
+        //private static bool isOnDebug = false;
+        private long remaining;
+
+        public JpgBinaryStreamReader(Stream stream) : base(stream) { this.remaining = stream.Length; }
+
+
+        public class JpgBinaryStreamExhaustedException:Exception
+        {
+           
+            public JpgBinaryStreamReader reader { get; private set; }
+
+            public JpgBinaryStreamExhaustedException(JpgBinaryStreamReader reader, string message) : base(message)  
+            {
+                this.reader = reader;
+            }
+
+            public JpgBinaryStreamExhaustedException(JpgBinaryStreamReader reader)
+            {
+                this.reader = reader;
+            }
+            
+        }
+            
+
+
+        public long Seek(long offset, SeekOrigin origin)
+        {
+            return base.BaseStream.Seek(offset, origin);
+        }
+
+        public void Skip(int n)
+        {
+            Seek(n, SeekOrigin.Current);
+        }
+
+        public void JumpBack(int n)
+        {
+            Seek(-1 * n, SeekOrigin.Current);            
+        }
+
+        public long Remaining => base.BaseStream.Length - Seek(0, SeekOrigin.Current);
+
+        public bool isAtEnd => base.PeekChar() == -1;
+
+        public new byte ReadByte()
+        {
+            return ReadByteOrThrow();
+        }
+
+        public byte ReadByteOrThrow()
+        {
+            int i = base.ReadByte();
+            if (i == -1)
+            {
+                throw new JpgBinaryStreamExhaustedException(this, "ReadByte()");
+            }
+
+            return (byte)i;
+        }
+        public short ReadShort()
+        {
+            byte msb = ReadByteOrThrow();            
+            byte lsb = ReadByteOrThrow();
+            return (short)((msb << 8) + lsb);
+        }
+
+        public Int16 ReadInt16BE() => ReadShort();  
+        
+
+        public class FrameHeader
+        {
+            JpgBinaryStreamReader reader;
+            public long startOfBlockOffset { get; private set; }
+            public long pos => reader.Seek(0, SeekOrigin.Current);
+            public int length { get; private set; }  //  Lf - Frame header length
+            public int remaining { get;private set; }
+
+            public FrameHeader(JpgBinaryStreamReader reader)
+            {
+                this.reader = reader;
+                startOfBlockOffset = reader.Seek(0, SeekOrigin.Current);
+                length = reader.ReadShort();
+                length -= 2;
+                remaining = length;
+                //if (isOnDebug) { Debug.WriteLine($"JpgBinaryStreamReader.FrameHeader() buffer offset: {startOfBlockOffset} length{length}");}
+            }
+
+            public void Skip(int n)
+            {                
+                if (n>remaining) throw new Exception(); // Frame exhausted
+                if (n > reader.remaining) throw new Exception(); // Frame exhausted
+                reader.Skip(n);
+                remaining -= n; // remaining in block 
+            }
+
+            public byte ReadByte()
+            {
+                remaining -= 1;
+                if (remaining < 0) throw new Exception();
+                return (byte)reader.ReadByteOrThrow();
+            }
+
+            public short ReadShort()
+            {
+                remaining -= 2;
+                if (remaining < 0) throw new Exception();
+                return reader.ReadShort();
+            }
+            public Int16 ReadInt16BE() => ReadShort();
+        }
+         
+        public FrameHeader DecodeFrameHeader()
+        {            
+            return new FrameHeader(this);
+        }
+    } 
+}

--- a/src/UglyToad.PdfPig/Images/Jpg/Helpers/NaturalOrder.cs
+++ b/src/UglyToad.PdfPig/Images/Jpg/Helpers/NaturalOrder.cs
@@ -1,0 +1,19 @@
+﻿namespace UglyToad.PdfPig.Images.Jpg.Helpers
+{     
+    internal static class JpgNaturalOrder
+    {
+        // Zig-zag sequence of quantized DCT coefficients
+        // see Figure A.6 Page 30 JPEG ISO/IEC 10918-1 : 1993(E)  Table B.1
+        // https://www.w3.org/Graphics/JPEG/itu-t81.pdf
+        internal static readonly byte[] ZigZagSequenceOfQuantizedDCTCoefficients = new byte[] {
+             0,  1,  8, 16,  9,  2,  3, 10,
+            17, 24, 32, 25, 18, 11,  4,  5,
+            12, 19, 26, 33, 40, 48, 41, 34,
+            27, 20, 13,  6,  7, 14, 21, 28,
+            35, 42, 49, 56, 57, 50, 43, 36,
+            29, 22, 15, 23, 30, 37, 44, 51,
+            58, 59, 52, 45, 38, 31, 39, 46,
+            53, 60, 61, 54, 47, 55, 62, 63
+        };
+    }
+}

--- a/src/UglyToad.PdfPig/Images/Jpg/Helpers/Parser.cs
+++ b/src/UglyToad.PdfPig/Images/Jpg/Helpers/Parser.cs
@@ -67,8 +67,9 @@
             var NumberOfScans = 0;
             var NumberOfIntervalResets = 0;
             var NumberOfEndOfImage = 0;
+#if DEBUG
             var isOnDebug = UglyToad.PdfPig.Images.Jpg.Jpg.isOnDebug;
-
+#endif
             PdfDictionary.Parse(dictionary,context);
 
             while (reader.isAtEnd == false)
@@ -165,6 +166,7 @@
                     case JpegMarker.ApplicationSpecific13:                    
                     case JpegMarker.ApplicationSpecific15:
                         {
+#if DEBUG
                             if (isOnDebug)
                             {
                                 var appBuffer = new byte[length-2];
@@ -172,6 +174,7 @@
                                 var appData = new System.Text.ASCIIEncoding().GetString(appBuffer);
                             }
                             else
+#endif
                             {
                                 reader.Skip(length - 2);
                             }
@@ -194,6 +197,7 @@
                         }
                         break;
                     case JpegMarker.Comment:
+#if DEBUG
                         if (isOnDebug)
                         {
                             var appBuffer = new byte[length - 2];
@@ -202,6 +206,7 @@
                             context.Comments.Add(comment);
                         }
                         else
+#endif
                         {
                             reader.Skip(length - 2);
                         }
@@ -259,7 +264,9 @@
         private const byte MarkerStart = 0xFF;  //  called "Fill Marker" (0xFF) in TN5116 Page 7
         private static (bool isMakerValid, JpegMarker marker, int length) ParseSegmentMarker(JpgBinaryStreamReader reader, bool skipData = false)
         {
+#if DEBUG
             var isOnDebug = UglyToad.PdfPig.Images.Jpg.Jpg.isOnDebug;
+#endif
             // A marker segment consists of a marker followed by a sequence of related parameters.
             // For most segments the first parameter in a marker segment is the two - byte length parameter.
             // This length parameter encodes the number of bytes in the marker segment,
@@ -320,7 +327,9 @@
                     case JpegMarker.Restart6:
                     case JpegMarker.Restart7:
                     case JpegMarker.TemporaryPrivateUseInArithmeticCoding:
+#if DEBUG
                         if (isOnDebug) { Debug.WriteLine($"Jpg Marker: {jpegMarker} (0x{marker:X})"); }  // No length markers
+#endif
                         break;
                     default:
                         {
@@ -336,7 +345,9 @@
                                 throw new Exception($"Jpg invalid segment length. Expected < remaining bytes in file ({reader.Remaining}). Got {length}.");
                             }
                             reader.JumpBack(2);
+#if DEBUG
                             if (isOnDebug) { Debug.WriteLine($"Jpg Marker: {jpegMarker} (0x{marker:X}) length: {length}"); } // All others have length
+#endif
                         }
                         break;
                 }

--- a/src/UglyToad.PdfPig/Images/Jpg/Helpers/Parser.cs
+++ b/src/UglyToad.PdfPig/Images/Jpg/Helpers/Parser.cs
@@ -1,0 +1,350 @@
+﻿namespace UglyToad.PdfPig.Images.Jpg.Helpers
+{
+    using System;
+    using System.Diagnostics;
+    using System.IO;
+     
+    using Images.Jpg.Parts;
+    using Dht = Parts.DefineHuffmanTable;
+    using Dqt = Parts.DefineQuantizationTable;
+    using Sof0 = Parts.StartOfFrame0BaselineDCT;
+    using Sof2 = Parts.StartOfFrame2ProgressDctFrame;
+    using SOS = Parts.StartOfScan;
+    using DictionaryToken = Tokens.DictionaryToken;
+    using UglyToad.PdfPig.Filters;
+
+    /// <summary>
+    /// Decode a byte stream contain a simple JPEG 1 (T.871) sequential DCT-base image.    
+    /// </summary>
+    internal class Parser
+    {
+        // Jpeg 1 Parser
+        // the most common jpeg. JPEG Interchange Format (JFIF)
+        // See Adobe Technical Note TN.5116 for additional handling inside a PDF.
+
+        // ITU-T81 4.5 Modes of operation
+        // There are four distinct modes of operation under which the various coding processes are defined:
+        //      1. sequential DCT-based,
+        //      2. progressive DCT-based,
+        //      3. lossless, and
+        //      4. hierarchical.
+        // Note only mode 1 is implemented. To be done Baseline vs Extended sequential DCT.
+
+        // ITU-T81 4.5 Table 1 Essential characteristics
+        // Baseline (all DCT-based decoders)
+        //    Sequential
+        //    Huffman coding: 2 AC and 2 DC tables
+        //    Decoders shall process scans with 1, 2, 3, and 4 components
+        //    Interleaved and non-interleaved scans
+
+        // 8 bit only (16bit or others is not support)
+        // **NOT** supported: JPEG2000, JFIF, Exif
+
+        // Based on NanoJPEG  (https://keyj.emphy.de/nanojpeg/)
+        // decodes baseline JPEG only, no progressive or lossless JPEG
+        // supports 8-bit grayscale and YCbCr images, no 16 bit, CMYK or other color spaces
+        // supports any power-of-two chroma subsampling ratio
+        // supports restart markers
+
+        // Addition assistance from C# port at https://github.com/JBildstein/NanoJpeg.Net
+
+        // adds support for reading App14 "Adobe" Application Segment
+        // there is no shared data and so can be called multiple times (say of different threads)
+
+        public static Jpg Parse(byte[] ab, DictionaryToken dictionary)
+        {
+            using (var ms = new MemoryStream(ab))
+            using (var reader = new JpgBinaryStreamReader(ms))
+            {
+                return new Parser().Parse(reader, dictionary);                
+            }            
+        }
+         
+        private Jpg Parse(JpgBinaryStreamReader reader, DictionaryToken dictionary)
+        {
+            var context = new Context();
+            var NumberOfStartOfImage = 0;
+            var NumberOfScans = 0;
+            var NumberOfIntervalResets = 0;
+            var NumberOfEndOfImage = 0;
+            var isOnDebug = UglyToad.PdfPig.Images.Jpg.Jpg.isOnDebug;
+
+            PdfDictionary.Parse(dictionary,context);
+
+            while (reader.isAtEnd == false)
+            {            
+                (var isMarkerValid, var marker, int length) = ParseSegmentMarker(reader, true);
+                if (reader.isAtEnd)
+                {
+                    if (NumberOfEndOfImage==0)
+                    {
+                        Debug.WriteLine($"Jpg End of stream without EndOfImage marker (0xD9).");
+                    }
+                    break;
+                }
+                if (isMarkerValid == false)
+                {
+                    Debug.WriteLine($"Jpg Failed to find marker.");
+                    break;
+                }
+                 
+
+                /*  TN.5116 - PDF guidance for Jpg in PDF
+                 *  Acceptable markers:
+                 *     The SOF0, SOF1, DHT, RSTm, EOI, SOS, DQT, DRI, and COM markers are properly decoded.
+                 *     APPn (application-specific) markers are skipped over harmlessly except for the Adobe reserved marker described later
+                 *  
+                 *  These markers (if present) generate a rejection:
+                 *     These markers are not decoded: SOF2-SOF15, DAC, DNL, DHP, EXP, JPGn, TEM, and RESn. 
+                 *     If any occurs in a compressed image, it will be rejected. 
+                 *     With the exception of DNL, none of these markers is useful in a Baseline DCT or Extended sequential DCT image.      
+                 */
+
+                switch (marker)
+                {
+                    case JpegMarker.Unknown: break;
+                    case JpegMarker.StartOfImage: NumberOfStartOfImage++;  break;
+                    case JpegMarker.EndOfImage:
+                        {
+                            ValidateStartOfImageMarker(marker, NumberOfStartOfImage);
+                            NumberOfEndOfImage++;                             
+                        }
+                        break;
+                    case JpegMarker.StartOfFrame0BaselineDctFrame:
+                        {
+                            ValidateStartOfImageMarker(marker, NumberOfStartOfImage);
+                            Sof0.ParseSof0(reader, context.ForStartOfFrame); break;
+                        }
+                    case JpegMarker.StartOfFrame2ProgressiveDctFrame:
+                        {
+                            ValidateStartOfImageMarker(marker, NumberOfStartOfImage);
+                            Sof2.ParseSof2(reader, context.ForStartOfFrame); break;
+                        }
+                    case JpegMarker.DefineHuffmanTable:
+                        {
+                            ValidateStartOfImageMarker(marker, NumberOfStartOfImage);
+                            Dht.ParseDht(reader, context.ForDefineHuffmanTables);
+                        }
+                        break;                    
+                    case JpegMarker.DefineQuantizationTable:
+                        {
+                            ValidateStartOfImageMarker(marker, NumberOfStartOfImage);
+                            Dqt.ParseDqt(reader, context.ForDefineQuantizationTable);
+                            break;
+                        }
+                    case JpegMarker.StartOfScan:
+                        {
+                            ValidateStartOfImageMarker(marker, NumberOfStartOfImage);
+                            NumberOfScans++;
+                            SOS.ParseSos(reader, context.ForStartOfScan);
+                        }
+                        break;
+                    case JpegMarker.DefineRestartInterval:
+                        {
+                            NumberOfIntervalResets++;
+                            ValidateStartOfImageMarker(marker, NumberOfStartOfImage);
+                            DefineRestartInterval.ParseDefineRestartInterval(reader,context.ForDefineRestartInterval); 
+                        }
+                        break;
+
+                    case JpegMarker.ApplicationSpecific1:
+                        ValidateStartOfImageMarker(marker, NumberOfStartOfImage);
+                        App1.Parse(reader, context.ForApp1Segement);
+                        break;
+                    case JpegMarker.ApplicationSpecific2:
+                    case JpegMarker.ApplicationSpecific3:
+                    case JpegMarker.ApplicationSpecific4:
+                    case JpegMarker.ApplicationSpecific5:
+                    case JpegMarker.ApplicationSpecific6:
+                    case JpegMarker.ApplicationSpecific7:
+                    case JpegMarker.ApplicationSpecific8:
+                    case JpegMarker.ApplicationSpecific9:
+                    case JpegMarker.ApplicationSpecific10:
+                    case JpegMarker.ApplicationSpecific11:
+                    case JpegMarker.ApplicationSpecific12:
+                    case JpegMarker.ApplicationSpecific13:                    
+                    case JpegMarker.ApplicationSpecific15:
+                        {
+                            if (isOnDebug)
+                            {
+                                var appBuffer = new byte[length-2];
+                                reader.Read(appBuffer, 0, length-2);
+                                var appData = new System.Text.ASCIIEncoding().GetString(appBuffer);
+                            }
+                            else
+                            {
+                                reader.Skip(length - 2);
+                            }
+                        }
+                        break;
+                    case JpegMarker.ApplicationSpecific0:   // JFIF or JFXX
+                        {
+                            ValidateStartOfImageMarker(marker, NumberOfStartOfImage);
+                            App0JFIF.Parse(reader,context.ForApp0JFIFSegement);
+                        }
+                        break;
+                    case JpegMarker.ApplicationSpecific14:  // Adobe
+                        {
+                            ValidateStartOfImageMarker(marker, NumberOfStartOfImage);
+                            if (NumberOfScans>0)
+                            {
+                                Debug.WriteLine($"Jpg Adobe Application segment marker (0xEE) after StartOfScan (0xDA).");
+                            }
+                            AppAdobe.ParseAppAdobe(reader,context.ForAdobeAppSegement);
+                        }
+                        break;
+                    case JpegMarker.Comment:
+                        if (isOnDebug)
+                        {
+                            var appBuffer = new byte[length - 2];
+                            reader.Read(appBuffer, 0, length - 2);
+                            var comment = new System.Text.ASCIIEncoding().GetString(appBuffer);
+                            context.Comments.Add(comment);
+                        }
+                        else
+                        {
+                            reader.Skip(length - 2);
+                        }
+                        break;
+                    default:
+                        ValidateStartOfImageMarker(marker, NumberOfStartOfImage);
+                        throw new Exception($"Unsupported marker: {marker}");
+                }
+                 
+            }
+            if (NumberOfStartOfImage > 1)
+            {
+                Debug.WriteLine($"Jpg Too many StartOfImage marker (0xD8). Expected: 1. Got: {NumberOfStartOfImage}.");
+            }
+            if (NumberOfEndOfImage > 1)
+            {
+                Debug.WriteLine($"Jpg Too many EndOfImage markers (0xD9). Expected: 1. Got: {NumberOfEndOfImage}.");
+            }
+            if (NumberOfScans==0)
+            {
+                Debug.WriteLine($"Jpg No scan data.");
+                throw new Exception("Jpg No scan data.");
+            } else if (NumberOfScans>1)
+            {
+
+                // Images ... having more than one scan ... will not be decoded. - TN.5116 Page 8
+ 
+            }
+
+            if (context.width <= 0 || context.height <= 0 )
+            {
+                // Zero-size images ) are invalid. - N.5116 Page 8
+                throw new InvalidDataException($"Jpg width {context.width} height: {context.height}. Expected: width > 0 and height >0");
+            }
+            ConvertScan.Convert(context);
+            
+            var Width = context.width;
+            var Height = context.height;
+            var NumberOfComponents = context.ncomp;
+            var Data = NumberOfComponents == 1 ? context.comp[0].pixels : context.rgb;
+            var jpg = new Jpg(Width,Height, NumberOfComponents, Data, context.Comments);
+            return jpg;
+        }
+
+        void ValidateStartOfImageMarker(JpegMarker marker, int NumberOfStartOfImage)
+        {
+            if (NumberOfStartOfImage == 0)
+            {
+                int i = (int)marker;
+                string s = Enum.GetName(typeof(JpegMarker), marker);
+                Debug.WriteLine($"Jpg {s} marker (0x{i:X}) without StartOfImage marker (0xD8).");
+            }
+        }
+
+        private const byte MarkerStart = 0xFF;  //  called "Fill Marker" (0xFF) in TN5116 Page 7
+        private static (bool isMakerValid, JpegMarker marker, int length) ParseSegmentMarker(JpgBinaryStreamReader reader, bool skipData = false)
+        {
+            var isOnDebug = UglyToad.PdfPig.Images.Jpg.Jpg.isOnDebug;
+            // A marker segment consists of a marker followed by a sequence of related parameters.
+            // For most segments the first parameter in a marker segment is the two - byte length parameter.
+            // This length parameter encodes the number of bytes in the marker segment,
+            // including the length parameter and excluding the two-byte marker.
+            // The marker segments identified by the SOF and SOS
+            // marker codes are referred to as headers: the frame header and the scan header respectively
+            byte? marker = null;
+             
+            { 
+                byte? previous = null;              
+                while (reader.Remaining > 0)
+                {
+                    var b = reader.ReadByteOrThrow();
+                    
+                    if (!skipData)
+                    {
+                        if (!previous.HasValue && b != MarkerStart)
+                        {
+                            throw new InvalidOperationException();
+                        }
+
+                        if (b != MarkerStart)
+                        {
+                            marker = b;
+                            break;
+                        }
+                    }
+
+                    if (previous.HasValue && previous.Value == MarkerStart && b != MarkerStart)
+                    {
+                        marker = b;                         
+                        break;
+                    }
+
+                    previous = b;
+                }
+            }
+            if (marker.HasValue) 
+            {                 
+                if (Enum.IsDefined(typeof(JpegMarker), marker.Value) == false)
+                {
+                    Debug.WriteLine($"Unknown marker: 0X{marker.Value:X}");
+                    return (true, JpegMarker.Unknown, 0);
+                }
+
+                JpegMarker jpegMarker =(JpegMarker)marker.Value;
+                int length = 0;
+                switch (jpegMarker)
+                {
+                    case JpegMarker.StartOfImage:
+                    case JpegMarker.EndOfImage:
+                    case JpegMarker.Restart0:
+                    case JpegMarker.Restart1:
+                    case JpegMarker.Restart2:
+                    case JpegMarker.Restart3:
+                    case JpegMarker.Restart4:
+                    case JpegMarker.Restart5:
+                    case JpegMarker.Restart6:
+                    case JpegMarker.Restart7:
+                    case JpegMarker.TemporaryPrivateUseInArithmeticCoding:
+                        if (isOnDebug) { Debug.WriteLine($"Jpg Marker: {jpegMarker} (0x{marker:X})"); }  // No length markers
+                        break;
+                    default:
+                        {
+                            length = reader.ReadShort();
+
+                            if (length < 0)
+                            {
+                                throw new Exception($"Jpg invalid segment length. Expected >0. Got {length}.");
+                            }
+
+                            if (length > reader.Remaining)
+                            {
+                                throw new Exception($"Jpg invalid segment length. Expected < remaining bytes in file ({reader.Remaining}). Got {length}.");
+                            }
+                            reader.JumpBack(2);
+                            if (isOnDebug) { Debug.WriteLine($"Jpg Marker: {jpegMarker} (0x{marker:X}) length: {length}"); } // All others have length
+                        }
+                        break;
+                }
+                 
+                return (true, jpegMarker, length);               
+            }
+
+            return (false, JpegMarker.Unknown, 0);
+        }
+    }
+}

--- a/src/UglyToad.PdfPig/Images/Jpg/Helpers/PdfDictionary.cs
+++ b/src/UglyToad.PdfPig/Images/Jpg/Helpers/PdfDictionary.cs
@@ -1,0 +1,44 @@
+﻿namespace UglyToad.PdfPig.Images.Jpg.Helpers
+{
+    using System;
+    using System.Data;
+    using System.Diagnostics;
+    using Tokens;
+    using UglyToad.PdfPig.Parser.Parts;
+
+    internal class PdfDictionary
+    {
+        public static void Parse(DictionaryToken dictionary, Context context) {
+
+            if (dictionary is null)
+            {
+                Debug.WriteLine($"Warning: Jpg parser not provided with DictionaryToken.");
+                return;                
+            }
+            if (dictionary.TryGet(NameToken.BitsPerComponent, out NumericToken bitPerComponentToken) == false)
+            {
+                throw new DataException($"Jpg Dictionary does not contain BitsPerComponent.");
+            }
+            context.BitsPerComponent = bitPerComponentToken.Int;
+
+            var hasImageMask = false;
+            if (dictionary.TryGet(NameToken.ImageMask, out BooleanToken imageMaskToken))
+            {
+                hasImageMask = imageMaskToken.Data;                
+            }
+            context.HasImageMask = hasImageMask;
+
+
+            // Unable to get ColorSpace without scanner.
+
+            //if (dictionary.TryGet(NameToken.ColorSpace, out IndirectReferenceToken colorSpaceIndirectReferenceToken) == false)
+            //{       
+            //    throw new DataException($"");
+            //}
+            //if (!DirectObjectFinder.TryGet(colorSpaceIndirectReferenceToken, scanner, out ArrayToken arrayTokenFromIndirectReference))
+            //{
+
+            //}
+        }
+    }
+}

--- a/src/UglyToad.PdfPig/Images/Jpg/Jpg.cs
+++ b/src/UglyToad.PdfPig/Images/Jpg/Jpg.cs
@@ -1,0 +1,90 @@
+﻿namespace UglyToad.PdfPig.Images.Jpg
+{
+    using System.Collections.Generic;
+    using System.Data.SqlTypes;
+    using System.IO;
+    using System.Runtime.InteropServices.ComTypes;
+    using UglyToad.PdfPig.Tokens;
+    using Parser = UglyToad.PdfPig.Images.Jpg.Helpers.Parser;
+
+
+    /// <summary>
+    /// Jpg
+    /// </summary>
+    public class Jpg
+    {
+#if DEBUG
+        /// <summary>
+        /// isOnDebug
+        /// </summary>
+        public static bool isOnDebug = true;        // additional debug logging
+        /// <summary>
+        /// HasRestart
+        /// </summary>
+        public static bool hasRestart = false;
+        /// <summary>
+        /// hasJpgEndOfStreamWithoutEndOfImageMarker
+        /// </summary>
+        public static bool hasJpgEndOfStreamWithoutEndOfImageMarker = false;
+         
+        /// <summary>
+        /// hasAdobeAppSegment
+        /// </summary>
+        public static bool hasAdobeAppSegment = false;
+
+        /// <summary>
+        /// AdobeAppSegmentTransformCode
+        /// </summary>
+        public static int AdobeAppSegmentTransformCode = -1; // Default none
+
+
+        /// <summary>
+        /// precision - 8 bit or 16 bit Jpg
+        /// </summary>
+        public static int precision = -1;
+#endif
+        /// <summary>
+        /// Width
+        /// </summary>
+        public int Width { get; private set; }
+        /// <summary>
+        /// Height
+        /// </summary>
+        public int Height { get; private set; }
+
+        /// <summary>
+        /// Number Of Components
+        /// </summary>
+        public int NumberOfComponents { get; private set; }
+         
+        /// <summary>
+        /// Data
+        /// </summary>
+        public byte[] Data { get; private set; }
+
+        /// <summary>
+        /// Comments
+        /// </summary>
+        public List<string> Comments { get; private set; }
+
+        internal Jpg(int width, int height, int numberOfComponents, byte[] data , List<string>comments) {
+            this.Width = width;
+            this.Height = height;
+            this.Data = data;
+            this.NumberOfComponents = numberOfComponents;
+            this.Comments = comments;
+        }
+
+        /// <summary>
+        /// Parse
+        /// </summary>
+        /// <param name="ab">DCT encoded bytes to be decoded</param>
+        /// /// <param name="dictionary">Pdf Dictionary of stream to decode</param>
+        /// <returns></returns>
+        public static Jpg Parse(byte[] ab, DictionaryToken dictionary)
+        {
+            return Parser.Parse(ab, dictionary);
+        }
+    }
+}
+

--- a/src/UglyToad.PdfPig/Images/Jpg/Parts/App.cs
+++ b/src/UglyToad.PdfPig/Images/Jpg/Parts/App.cs
@@ -1,0 +1,14 @@
+﻿namespace UglyToad.PdfPig.Images.Jpg.Parts
+{
+ 
+    using System.IO;
+  
+    internal class App
+    { 
+        private void ParseApp(JpgBinaryStreamReader reader, int app)
+        {
+            int length = reader.ReadInt16BE();
+            reader.Seek(length - 2, SeekOrigin.Current);
+        } 
+    }
+}

--- a/src/UglyToad.PdfPig/Images/Jpg/Parts/App0JFIF.cs
+++ b/src/UglyToad.PdfPig/Images/Jpg/Parts/App0JFIF.cs
@@ -1,0 +1,74 @@
+﻿namespace UglyToad.PdfPig.Images.Jpg.Parts
+{
+    using Debug = System.Diagnostics.Debug;
+    using System;
+    using ContextForApp0JFIFSegment = Helpers.Context.ContextForApp0JFIFSegment;
+    internal static class App0JFIF  
+    {
+        internal static void Parse(JpgBinaryStreamReader reader, ContextForApp0JFIFSegment context )
+        {
+
+            int length = reader.ReadInt16BE();
+            if ((length >= 12 /*JFIF*/|| length >=6 /*JFXX*/) == false)
+            {
+                Debug.WriteLine($"Jpg App0 segment length is {length} Expected: >6.");
+            }
+            var pos = reader.BaseStream.Position;
+            var ab = new byte[length - 2];
+            var read = reader.Read(ab, 0, ab.Length);
+            if (read != ab.Length)
+            {
+                Debug.WriteLine($"Jpg AppA0 failed to read start of segment. Read: {read} Expected: 12.");
+                return;
+            }
+
+            // The text ‘JIFI’ as a five-character ASCII big-endian string
+            var abType = new byte[4];
+            Buffer.BlockCopy(ab, 0, abType, 0, abType.Length);
+            var segType = new System.Text.ASCIIEncoding().GetString(abType);
+            if (segType == "JFXX")
+            {
+                switch (ab[5])
+                {
+                    case 0x10:
+                        // THUMB_JPEG
+                        break;
+                    case 0x11:
+                        // THUMB_PALETTE
+                        break;
+                    case 0x13:
+                        // THUMB_RGB
+                        break;
+                    default:
+                        // JTRC_JFIF_EXTENSION
+                        break;
+                }
+                return; 
+            }
+            if (segType != "JFIF")
+            {                
+                Debug.WriteLine($"Jpg App0 Expected 'JFIF' or 'JFXX' as type in Application Specific 0 segment. Got: '{segType}'");
+                return;
+            }
+            if (length < 12 /*JFIF*/)
+            {
+                Debug.WriteLine($"Jpg App0 JFIF segment length is {length} Expected: >=12.");
+                return;
+            }
+
+            var versionMajor = ab[5];
+            var versionMinor = ab[6];
+            var density_unit = ab[7];
+            var X_density = ab[9] + (ab[8]<<8);
+            var Y_density = ab[11] + (ab[10] << 8);
+
+            context.hasApp0segment = true;
+            context.App0versionMajor = versionMajor;
+            context.App0versionMinor = versionMinor;
+            context.App0density_unit = density_unit;
+            context.App0X_density = X_density;
+            context.App0Y_density = Y_density;
+            return;
+        } 
+    }
+}

--- a/src/UglyToad.PdfPig/Images/Jpg/Parts/App1.cs
+++ b/src/UglyToad.PdfPig/Images/Jpg/Parts/App1.cs
@@ -1,0 +1,94 @@
+﻿namespace UglyToad.PdfPig.Images.Jpg.Parts
+{
+    using Debug = System.Diagnostics.Debug;
+    using System;
+    using ContextForApp1Segment = Helpers.Context.ContextForApp1Segment;
+    using Exif;
+  
+  
+
+
+    // https://dev.exiv2.org/projects/exiv2/wiki/The_Metadata_in_JPEG_files
+
+
+    internal static class App1
+    {
+        internal static void Parse(JpgBinaryStreamReader reader, ContextForApp1Segment context)
+        {
+
+            int segmentLength = reader.ReadInt16BE();
+            if ((segmentLength >= 12) == false)
+            {
+                Debug.WriteLine($"Jpg App1 segment length is {segmentLength} Expected: >12.");
+            }
+            var pos = reader.BaseStream.Position;
+            var segmentData = new byte[segmentLength - 2];
+            var read = reader.Read(segmentData, 0, segmentData.Length);
+
+            var headerType = Header(segmentData);
+
+            switch (headerType)
+            {
+                case App1HeaderType.Exif:
+                    Exif.Exif.GetExifProperties(context,segmentLength, segmentData);
+                    break;
+                case App1HeaderType.XmpMetadata:
+                    XMP.Xmp.GetXmp(context, segmentLength, segmentData);
+                    break;
+                case App1HeaderType.Xap:
+                    Debug.WriteLine($"Jpg App1 Xap Not yet implment");
+                    break;
+
+
+            }
+
+            
+
+        }
+        enum App1HeaderType
+        {
+            Exif = 1,
+            XmpMetadata = 2,
+            Xap = 3
+        };
+        private static App1HeaderType Header(byte[] segmentData)
+        {
+            // Check for Exif signature
+            {
+                const string sig = "Exif\0\0";
+                var abType = new byte[6];
+                Buffer.BlockCopy(segmentData, 0, abType, 0, abType.Length);
+                var segType = new System.Text.ASCIIEncoding().GetString(abType);
+                if (segType == sig)
+                {
+                    return App1HeaderType.Exif;
+                }
+            }
+
+            {
+                const string sig = "http://ns.adobe.com/xap/1.0/\0";
+                var abType = new byte[sig.Length];
+                Buffer.BlockCopy(segmentData, 0, abType, 0, abType.Length);
+                var segType = new System.Text.ASCIIEncoding().GetString(abType);
+                if (segType == sig)
+                {
+                    // RDF (Resource Description Framework) implemented as an application of XML
+                    // https://www.w3.org/TR/REC-rdf-syntax/
+                    // XMP 3.2
+                    return App1HeaderType.XmpMetadata;
+                }
+            }
+
+
+            {
+                var abType = new byte[10];
+                Buffer.BlockCopy(segmentData, 0, abType, 0, abType.Length);
+                var segType = new System.Text.ASCIIEncoding().GetString(abType);
+                throw new Exception($"Jpg App1 segment. Expected signature bytes of 'Exif\\0' or 'http://ns.adobe.com/xap/1.0/\\0'. Got '{segType}'.");
+            }
+
+        }
+    }
+
+   
+}

--- a/src/UglyToad.PdfPig/Images/Jpg/Parts/AppAdobe.cs
+++ b/src/UglyToad.PdfPig/Images/Jpg/Parts/AppAdobe.cs
@@ -1,0 +1,73 @@
+﻿namespace UglyToad.PdfPig.Images.Jpg.Parts
+{
+    using Debug = System.Diagnostics.Debug;
+    using System;
+    using static UglyToad.PdfPig.Images.Jpg.Helpers.Context;
+
+    internal static class AppAdobe
+    {
+        internal static void ParseAppAdobe(JpgBinaryStreamReader reader, ContextForAdobeAppSegment context)
+        {
+
+            int length = reader.ReadInt16BE();
+            if (length != 14)
+            {
+                Debug.WriteLine($"Jpg AppAdobe segment length is {length} Expected: 14.");
+            }
+            var pos = reader.BaseStream.Position;
+            var ab = new byte[length - 2];
+            var read = reader.Read(ab, 0, ab.Length);
+            if (read != ab.Length)
+            {
+                Debug.WriteLine($"Jpg AppAdobe failed to read Adobe Application-Specific JPEG segment. Read: {read} Expected: 12.");
+                return;
+            }
+
+            // The text ‘Adobe’ as a five-character ASCII big-endian string
+            var abVendor = new byte[5];
+            Buffer.BlockCopy(ab, 0, abVendor, 0, abVendor.Length);
+            var vendor = new System.Text.ASCIIEncoding().GetString(abVendor);
+            if (vendor != "Adobe")
+            {
+                // DCTDecode ignores and skips any APPE marker segment that does not begin
+                // with the ‘Adobe’ 5 - character string.
+                Debug.WriteLine($"Jpg AppAdobe Expected 'Adobe' as vendor in Adobe Application-Specific segment. Got: '{vendor}'");
+                return;
+            }
+
+            // Two-byte DCTEncode/DCTDecode version number
+            var versionDctEncodeDecode = ab[6] + (ab[5] << 8);
+
+            // Two-byte flags0 0x8000 bit: Encoder used Blend=1 downsampling
+            var flag0 = ab[8] + (ab[7] << 8);
+            // Two-byte flags1
+            var flag1 = ab[10] + (ab[9] << 8);
+            // One-byte color transform code
+            // The default is to use the YCC-to-RGB [color]transform
+            //      0 = CMYK             
+            //      1== YCCK
+            var colorTransformCode = ab[11];
+
+            // The convention for flags0 and flags1 is that 0 bits are benign.
+            // 1 bits in flags0 pass information that is possibly useful but not essential for decoding.
+            // 1 bits in flags1 pass information essential for decoding.
+            // DCTDecode could reject a compressed imageif there are 1 bits in flags1 or color transform codes that it cannot interpret
+            // The current implementation will reject only if the Picky option is non-zero.
+             
+            Debug.WriteLine($"versionDctEncodeDecode: 0x{versionDctEncodeDecode:X},flag0: 0x{flag0:X} ,flag1: 0x{flag1:X},colorTransformCode: 0x{colorTransformCode:X}");
+
+#if DEBUG
+            UglyToad.PdfPig.Images.Jpg.Jpg.hasJpgEndOfStreamWithoutEndOfImageMarker = true;
+            UglyToad.PdfPig.Images.Jpg.Jpg.hasAdobeAppSegment = true;
+            UglyToad.PdfPig.Images.Jpg.Jpg.AdobeAppSegmentTransformCode= colorTransformCode; 
+#endif
+
+            context.hasAdobeSegment = true;
+            context.versionDctEncodeDecode = versionDctEncodeDecode;
+            context.flag0 = flag0;
+            context.flag1 = flag1;
+            context.colorTransformCode = colorTransformCode;            
+            return;
+        } 
+    }
+}

--- a/src/UglyToad.PdfPig/Images/Jpg/Parts/Component.cs
+++ b/src/UglyToad.PdfPig/Images/Jpg/Parts/Component.cs
@@ -1,0 +1,28 @@
+﻿namespace UglyToad.PdfPig.Images.Jpg.Parts
+{
+    internal class Component
+    {
+        internal int cid;
+        /// <summary>
+        /// Horizontal sampling factor        
+        /// Possible Values: 1-4
+        /// Specifies the relationship between the component horizontal dimension
+        /// and maximum image dimension X; also specifies the number of horizontal data units of component
+        /// Ci in each MCU, when more than one component is encoded in a scan.
+        /// </summary>
+        internal int HSF;
+        /// <summary>
+        /// Vertical sampling factor         
+        /// Specifies the relationship between the component vertical dimension and
+        /// maximum image dimension Y; also specifies the number of vertical data units of component Ci in
+        /// each MCU, when more than one component is encoded in a scan.
+        /// </summary>
+        internal int VSF;
+        internal int width, height;
+        internal int stride;
+        internal int qtsel;
+        internal int actabsel, dctabsel;
+        internal int dcpred;
+        internal byte[] pixels;
+    }
+}

--- a/src/UglyToad.PdfPig/Images/Jpg/Parts/DefineHuffmanTable.cs
+++ b/src/UglyToad.PdfPig/Images/Jpg/Parts/DefineHuffmanTable.cs
@@ -1,0 +1,105 @@
+﻿namespace UglyToad.PdfPig.Images.Jpg.Parts
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Diagnostics;
+    using static Helpers.Context;
+   
+
+    /// <summary>
+    /// Define Huffman Table(s)
+    /// </summary>
+    internal static class DefineHuffmanTable
+    {
+
+         
+        internal static void ParseDht(JpgBinaryStreamReader reader, ContextForDefineHuffmanTables context)
+        {
+            var vlctab = context.vlctab;
+
+            
+            var frameHeader = reader.DecodeFrameHeader();  
+            var frameHeaderLength = frameHeader.length;
+           
+            byte[] counts = new byte[16];
+            while (frameHeader.remaining >= 17)
+            {
+                // Table Selector (1 byte)
+                // Tc: Table class (4 bits) Possible Values: 0 or 1
+                // 0 = DC table or lossless table, 1 = AC table.
+                //
+                // Th: Huffman table destination identifier (4 bits) Possible Values: 0 or 1 (DCT Baseline) otherwise 0-3
+                // Specifies one of four possible destinations at the decoder into which
+                // the Huffman table shall be installed.
+
+                var tableSelector = frameHeader.ReadByte();
+                
+                if ((tableSelector & 0xEC) != 0) { throw new Exception(); } // Syntax Error
+                if ((tableSelector & 0x02) != 0) { throw new Exception(); } // Unsupported
+                
+                tableSelector = (byte)((tableSelector | (tableSelector >> 3)) & 3);  // combined DC/AC + tableid value
+
+                // Li: Number of Huffman codes of length i (16 x 8 bytes) Possible Values: 0-255
+                // Specifies the number of Huffman codes for each of the 16 possible lengths 
+                // Li’s are the elements of the list BITS.
+                for (int codelen = 0; codelen < 16; codelen++)
+                {
+                    counts[codelen] = frameHeader.ReadByte();                     
+                }
+                 
+                var vlc = vlctab[tableSelector];
+
+                int remain = 65536;
+                int spread = 65536;
+                int vlcc = 0;
+
+
+                // Vi,j : Vi,j: Value associated with each Huffman code
+                // Specifies, for each i, the value associated with each Huffman
+                // code of length i. The meaning of each value is determined by the Huffman coding model. The Vi, j’s are the
+                // elements of the list HUFFVAL.
+                //  
+                // Specifies, for each i, the value associated with each Huffman
+                // code of length i. The meaning of each value is determined by the Huffman coding model. The Vi, j’s are the
+                //elements of the list HUFFVAL.
+                for (int codelen = 0; codelen < 16; codelen++)
+                {
+                    spread >>= 1;
+                    var currcnt = counts[codelen];
+                    if (currcnt == 0)
+                    {
+                        continue;   //skip
+                    }
+                    if (frameHeader.length < currcnt) { new Exception(); } //Syntax Error
+                    remain -= currcnt << (16 - (codelen + 1));
+                    
+                    if (remain < 0) { new Exception(); } // Syntax Error
+                    
+                    for (var i = 0; i < currcnt; ++i)
+                    {
+                        byte code = frameHeader.ReadByte();
+                        for (int j = spread; j != 0; --j)
+                        {
+                            if (vlcc < 65536)
+                            {                                 
+                                vlc[vlcc].bits = (byte)(codelen+1);
+                                vlc[vlcc].code = code;
+                                vlcc++;
+                            }
+                        }
+                    }                    
+                }
+                
+                while (remain-- != 0)
+                {
+                    if (vlcc < 65536)
+                    {
+                        vlc[vlcc].bits = 0;
+                        vlcc++;
+                    }
+                }
+            }
+            context.vlctab = vlctab;             
+        }
+    }
+}

--- a/src/UglyToad.PdfPig/Images/Jpg/Parts/DefineQuantizationTable.cs
+++ b/src/UglyToad.PdfPig/Images/Jpg/Parts/DefineQuantizationTable.cs
@@ -1,0 +1,97 @@
+﻿namespace UglyToad.PdfPig.Images.Jpg.Parts
+{
+    using System;
+    using System.Diagnostics;
+    using UglyToad.PdfPig.Images.Jpg.Helpers;
+    using ContextForQuantizationTableSpecification = Helpers.Context.ContextForQuantizationTableSpecification;
+
+   
+    /// <summary>
+    /// Define Quantization Table
+    /// </summary>
+    internal class DefineQuantizationTable
+    {
+        static byte[] ZZSeq => JpgNaturalOrder.ZigZagSequenceOfQuantizedDCTCoefficients;
+
+      
+        internal static void ParseDqt(JpgBinaryStreamReader reader, ContextForQuantizationTableSpecification context)
+        {
+
+            var qtab = context.qtab;
+            var qtavail = context.qtavail;
+
+            var frameHeader = reader.DecodeFrameHeader();
+
+            var Lq = frameHeader.length;
+
+            byte[] t;
+
+            while (frameHeader.remaining >= 65)
+            {
+
+                // Details - Pq and Tq (8 bits  = Pq (4 most significnat bits) + Tq (4 bits)
+
+                // Pq: Quantization table element precision   (4 bits) Possible Values: 0 (Baseline DCT)
+                // Specifies the precision of the Qk values.
+                // Value 0 indicates 8-bit Qk values;     Pq shall be zero for 8 bit sample precision.
+                // value 1 indicates 16 - bit Qk values. 
+
+                // Tq: Quantization table destination identifier  (4 bits) Possible Values: 0-3 (Baseline DCT)
+                // Specifies one of four possible destinations at the decoder into
+                // which the quantization table shall be installed.
+
+                var details = frameHeader.ReadByte();
+                var Pq = (details & 0xF0) >> 4;   // 4 most significant bits (top nibble)
+                if (Pq == 1) {                   
+                    throw new NotSupportedException("Jpg 16 bit precison is not supported only 8 bit.");     
+                }
+                else if (Pq == 0)
+                {
+                    
+                }
+                 
+                var Tq = details & 0x0F;        // 4 least significant bits (bottom nibble)
+                if (Tq is 0 or 1 or 2 or 3 == false)
+                {
+                    Debug.WriteLine($"Warning: Jpg QuantizationTableSpecification Tq (Quantization table destination identifier) is : {Tq}. Expected: 1-3");
+                }
+
+                // Qk: Quantization table element  (8 or 16 bits) Possible Values: 1-244 or 1-65535
+                // Specifies the kth element out of 64 elements, where k is the index in the zigzag ordering of the DCT coefficients.
+                // The quantization elements shall be specified in zig - zag scan order.
+
+                qtavail |= 1 << Tq;
+                t = qtab[Tq];
+                if (Pq == 0)
+                {
+                    // 8 bit - one byte per element
+                    for (int i = 0; i < 64; i++)
+                    {
+                        t[i] = frameHeader.ReadByte();
+                    }
+                } else if (Pq == 1)
+                {
+                    // 16 bit - two bytes per element                    
+                    for (int i = 0; i < 64; i++)
+                    {                        
+                        var msb = frameHeader.ReadByte(); // Most significant byte (msb)
+                        var lsb = frameHeader.ReadByte(); // Least signifiant byte (lsb)
+
+                        {
+                            var us = (msb << 8) + lsb;
+                            var result = (byte)Math.Round((255 * us) / (double)ushort.MaxValue);
+                            t[i] = result;                            
+                        }
+                    }
+                }
+                
+            }
+            if (frameHeader.remaining != 0)
+            {
+                Debug.WriteLine($"Warning: Jpg QuantizationTableSpecification buffer not exhausted. Remaining: {frameHeader.remaining}. Expected: 0");
+            }
+            context.qtab = qtab;
+            context.qtavail = qtavail;
+        }        
+    }
+}

--- a/src/UglyToad.PdfPig/Images/Jpg/Parts/DefineRestartInterval.cs
+++ b/src/UglyToad.PdfPig/Images/Jpg/Parts/DefineRestartInterval.cs
@@ -1,0 +1,32 @@
+﻿namespace UglyToad.PdfPig.Images.Jpg.Parts
+{
+    using System;
+    using System.Diagnostics;
+    using static UglyToad.PdfPig.Images.Jpg.Helpers.Context;
+ 
+    internal static class DefineRestartInterval
+    {
+        internal static void ParseDefineRestartInterval(JpgBinaryStreamReader reader, ContextForDefineRestartInterval context)
+        {
+            
+            // Lf: Frame header length (16 bits)   Possible Values: 8 + 3 × Nf
+            // Specifies the length of the frame header
+            var frameHeader = reader.DecodeFrameHeader(); // Get Length
+
+            if (frameHeader.remaining < 2) { throw new Exception($"Jpg Restart Internval Segment length expected: 2 bytes. Got: {frameHeader.remaining}"); }
+
+
+            // Ri:  Restart interval  (16 bits) Possible Values: 0-65535 (DCT Baseline) n x MCUR (Progressive DCT) (Lossless)
+            // Specifies the number of MCU in the restart interval.
+            var Ri = frameHeader.ReadInt16BE();             
+            if (Ri == 0)
+            {
+                Debug.WriteLine($"Jpg reset interval defined as 0.");
+            }
+            context.rstinterval = Ri;
+            
+             
+        }
+
+    }
+}

--- a/src/UglyToad.PdfPig/Images/Jpg/Parts/Drawing/PropertyItem.cs
+++ b/src/UglyToad.PdfPig/Images/Jpg/Parts/Drawing/PropertyItem.cs
@@ -6,7 +6,7 @@
     /// <summary>
     /// Encapsulates a metadata property to be included in an image file.
     /// </summary>
-    public sealed class PropertyItem
+    internal sealed class PropertyItem
     {
         internal PropertyItem()
         {

--- a/src/UglyToad.PdfPig/Images/Jpg/Parts/Drawing/PropertyItem.cs
+++ b/src/UglyToad.PdfPig/Images/Jpg/Parts/Drawing/PropertyItem.cs
@@ -1,0 +1,36 @@
+﻿ namespace UglyToad.PdfPig.Images.Jpg.Parts.Drawing
+{
+    using UglyToad.PdfPig.Util.JetBrains.Annotations;
+
+    // sdkinc\imaging.h
+    /// <summary>
+    /// Encapsulates a metadata property to be included in an image file.
+    /// </summary>
+    public sealed class PropertyItem
+    {
+        internal PropertyItem()
+        {
+        }
+
+        /// <summary>
+        /// Represents the ID of the property.
+        /// </summary>
+        public int Id { get; set; }
+
+        /// <summary>
+        /// Represents the length of the property.
+        /// </summary>
+        public int Len { get; set; }
+
+        /// <summary>
+        /// Represents the type of the property.
+        /// </summary>
+        public short Type { get; set; }
+
+        /// <summary>
+        /// Contains the property value.
+        /// </summary>
+        [CanBeNull]
+        public byte[] Value { get; set; }
+    }
+}

--- a/src/UglyToad.PdfPig/Images/Jpg/Parts/Exif/Exif.cs
+++ b/src/UglyToad.PdfPig/Images/Jpg/Parts/Exif/Exif.cs
@@ -1,0 +1,681 @@
+﻿namespace UglyToad.PdfPig.Images.Jpg.Parts.Exif
+{
+    using System;    
+    using System.Diagnostics;
+    using System.Linq;
+    using ContextForApp1Segment = Helpers.Context.ContextForApp1Segment;
+    using ExifTypes;
+    using ExifUtils;
+    using PropertyItem = Drawing.PropertyItem;
+
+    // https://www.media.mit.edu/pia/Research/deepview/exif.html
+
+    internal class Exif
+    {
+        internal static void GetExifProperties(ContextForApp1Segment context, int segmentLength, byte[] segmentData)
+        {
+            var dataLength = segmentLength - 6 - 2; // Length of an IFD entry
+
+            if (dataLength < 12)
+            {
+                throw new Exception($"Jpg App1 segment. Expected Exif Data length >=12. Got {dataLength}.");
+            }
+
+            var data = new byte[dataLength - 6 - 2];
+            Buffer.BlockCopy(segmentData, 6, data, 0, data.Length);
+
+            (var isBigEndian, var firstOffset) = TiffHeader(data);
+
+            uint tagNum;
+
+            uint offset = firstOffset;
+
+            /* Get the number of directory entries contained in this IFD */
+            var numberOfTags = (uint)ToUInt16(isBigEndian, data, offset);
+            if (numberOfTags == 0) return;
+            offset += 2;
+
+            // Search for ExifSubIFD offset Tag in IFD0
+            while (true)
+            {
+                if (offset > dataLength - 12) return; // check end of data segment
+
+                tagNum = (uint)ToUInt16(isBigEndian, data, offset);
+
+                if (tagNum == 0x8769) break;  // ExifSubIFD offset Tag
+                if (--numberOfTags == 0) return;
+                offset += 12;
+            }
+
+            /* Get the ExifSubIFD offset */
+            offset = ToUInt32(isBigEndian, data, offset + 8);
+
+            if (offset > dataLength - 2) return; /* check end of data segment */
+
+            /* Get the number of directory entries contained in this SubIFD */
+            numberOfTags = (uint)ToUInt16(isBigEndian, data, offset);
+            if (numberOfTags < 2) return;
+            offset += 2;
+
+            var exifProperties = new ExifImageProperties();
+
+            context.ExifImageProperties = exifProperties;
+
+            // Each IFD entry is 12 bytes broken down as:
+            // TTTT : 2 bytes : Tag Number
+            // ffff : 2 bytes : Format / Entry Type (eg. unsigned byte, short, long, rational, ascii string)
+            // NNNNNNNN : 4 bytes : Number of components
+            // DDDDDDDD : 4 bytes : Data or Offset
+            // Using ffff obtain number of bytes for entry type multiply by
+            // NNNNNNNN to get the number of bytes to store entry data.
+            // If entry data length > 4 then DDDDDDDD is an offset otherwise it is the data.
+            do
+            {
+                if (offset > dataLength - 12) return; // check if beyond end of the data buffer
+
+                /* Get Tag number */
+                tagNum = (uint)ToUInt16(isBigEndian, data, offset);
+
+                offset += 2;
+                var entryType = (Int16)ToUInt16(isBigEndian, data, offset);
+
+                (var entryTypeByteCount, var entryTypeDescription) = GetEntryTypeDetails(entryType);
+
+                offset += 2;
+                var entryNumberOfComponents = (int)ToUInt32(isBigEndian, data, offset);
+                offset += 4;
+
+                var entryDataByteCount = entryTypeByteCount * entryNumberOfComponents;
+
+                var entryValue = new byte[entryDataByteCount];
+                if (entryDataByteCount <= 4)
+                {
+                    Buffer.BlockCopy(data, (int)offset, entryValue, 0, entryValue.Length);
+                    if (isBigEndian)
+                    {
+                        entryValue = entryValue.Reverse().ToArray();
+                    }
+                }
+                else
+                {
+                    var entryDataOffset = (int)ToUInt32(isBigEndian, data, offset);
+                    Buffer.BlockCopy(data, (int)entryDataOffset, entryValue, 0, entryValue.Length);
+                }
+                offset += 4;
+
+                var propertyItem = new PropertyItem() { Id = (int)tagNum, Len = entryNumberOfComponents, Type = entryType, Value = entryValue };
+
+                Convert(propertyItem, exifProperties);
+
+            } while (--numberOfTags != 0);
+        }
+
+        static (int typeByteCount, string typeDescription) GetEntryTypeDetails(Int16 entryType)
+        {
+            switch (entryType)
+            {
+                case 1: return (1, "unsigned byte");
+                case 2: return (1, "ascii string");
+                case 3: return (2, "unsigned short");
+                case 4: return (4, "unsigned long");
+                case 5: return (8, "unsigned rational");
+                case 6: return (1, "signed byte");
+                case 7: return (1, "undefined");
+                case 8: return (2, "unsigned short");
+                case 9: return (2, "signed long");
+                case 10: return (8, "signed rational");
+                case 11: return (4, "signed float");
+                case 12: return (8, "double float");
+                default: throw new Exception($"Jpg Exif Unknown entry type 0x{entryType:X}.");
+            }
+        }
+
+      
+
+        private static (bool isBigEndian, uint offsetToFirstIFD) TiffHeader(byte[] data)
+        {
+
+            // Byte align           2 bytes either  "II" (0x49 0x49) or "MM" (0x4d 0x4d)
+            // TAG Mark             2 bytes must be 0x2A 0x00
+            // Offset to first IFD  4 bytes usually 0x00000008 - IFD0 then following immediately after TIFF Header
+
+
+            bool isBigEndian; /* Byte order */
+
+            {
+                // Byte align (byte order) : 2 bytes : Either 0x49 0X49 "II" or 0x4D 0x4D "MM" 
+                // "II" for "Intel" (Little Endian) or "MM" for "Motorola" (Big Endian)
+
+                if (data[0] == 0x49 && data[1] == 0x49) { isBigEndian = false; }
+
+                else if (data[0] == 0x4D && data[1] == 0x4D) { isBigEndian = true; }
+
+                else { throw new Exception($"Jpg App1 segment. Exif unknown byte order. Expected either 0x49 or 0x4D (twice). Got: 0X{data[0]:X} 0X{data[1]:X}"); }
+            }
+
+            {
+                /* Check Tag Mark : 2 bytes : 0x002a  */
+                var tag = ToUInt16(isBigEndian, data, 2);
+                if (tag != 0x002a)
+                {
+                    throw new Exception($"Jpg App1 segment. Exif TIFF header tag expected to be 0x002A. Got: 0X{tag:X}");
+                }
+            }
+
+            // Get first Image File Directory (IFD) offset [IFD0 (main image)] usually offset is 8.
+            var firstOffset = ToUInt32(isBigEndian, data, 4);
+
+            if (firstOffset > data.Length - 2) // check if offset beyond the end of the data buffer
+            {
+                throw new Exception($"Jpg Exif offset ({firstOffset})[0x{firstOffset:X}] of first IFD beyond the end of data buffer (buffer lerngth: {data.Length}.");
+            }
+            return (isBigEndian, firstOffset);
+        }
+
+        static UInt32 ToUInt32(bool isBigEndian, byte[] data, uint offset)
+        {
+            if (isBigEndian)
+            {
+
+                UInt64 value = 0;
+                value += (UInt64)(data[offset++] << 24);
+                value += (UInt64)(data[offset++] << 16);
+                value += (UInt64)(data[offset++] << 8);
+                value += (UInt64)(data[offset++]);
+                return (UInt32)value;
+            }
+
+            return BitConverter.ToUInt32(data, (int)offset);
+        }
+
+        static UInt16 ToUInt16(bool isBigEndian, byte[] data, uint offset)
+        {
+            if (isBigEndian)
+            {
+                UInt32 value = 0;
+                value += (UInt32)(data[offset++] << 8);
+                value += (UInt32)(data[offset++]);
+                return (UInt16)value;
+            }
+
+            return BitConverter.ToUInt16(data, (int)offset);
+        }
+
+        private static void Convert(PropertyItem property, ExifImageProperties exifProperties)
+        {
+            try
+            {
+                switch (property.Id)
+                {
+                    case 0x010e:
+                        exifProperties.ImageDescription = Utils.getStringValue(property);
+                        break;
+                    case 0x010f:
+                        exifProperties.Make = Utils.getStringValue(property);
+                        break;
+                    case 0x0110:
+                        exifProperties.Model = Utils.getStringValue(property);
+                        break;
+                    case 0x0112:
+                        exifProperties.Orientation = (Orientation)Enum.ToObject(typeof(Orientation), BitConverter.ToInt16(property.Value, 0));
+                        break;
+                    case 0x011a:
+                        exifProperties.XResolution = Utils.getNumberValueInt32(property);
+                        break;
+                    case 0x011b:
+                        exifProperties.YResolution = Utils.getNumberValueInt32(property);
+                        break;
+                    case 0x0128:
+                        exifProperties.ResolutionUnit = (ResolutionUnit)Enum.ToObject(typeof(ResolutionUnit), BitConverter.ToInt16(property.Value, 0));
+                        break;
+                    case 0x0131:
+                        exifProperties.Software = Utils.getStringValue(property);
+                        break;
+                    case 0x0132:
+                        exifProperties.DateTime = Utils.convertDateTime(property, "yyyy:MM:dd HH:mm:ss\0");
+                        break;
+                    case 0x013e:
+                        exifProperties.WhitePoint = Utils.getNumberValueInt32(property);
+                        break;
+                    case 0x013f:
+                        exifProperties.PrimaryChromaticities = Utils.getNumberValueInt32(property);
+                        break;
+                    case 0x0211:
+                        exifProperties.YCbCrCoefficients = Utils.getNumberValueInt32(property);
+                        break;
+                    case 0x0213:
+                        exifProperties.YCbCrPositioning = (YCbCrPositioning)Enum.ToObject(typeof(YCbCrPositioning), BitConverter.ToInt16(property.Value, 0));
+                        break;
+                    case 0x0214:
+                        exifProperties.ReferenceBlackWhite = Utils.getNumberValueInt32(property);
+                        break;
+                    case 0x8298:
+                        exifProperties.Copyright = Utils.getStringValue(property);
+                        break;
+                    case 0x8769:
+                        exifProperties.ExifOffset = Utils.getNumberValueInt64(property);
+                        break;
+                    case 0x829a:
+                        exifProperties.ExposureTime = (float)BitConverter.ToInt32(property.Value, 0) / (float)BitConverter.ToInt32(property.Value, 4);
+                        break;
+                    case 0x829d:
+                        exifProperties.FNumber = Utils.calcFnumber(property);
+                        break;
+                    case 0x8822:
+                        exifProperties.ExposureProgram = (ExposureProgram)Enum.ToObject(typeof(ExposureProgram), BitConverter.ToInt16(property.Value, 0));
+                        break;
+                    case 0xa403:
+                        exifProperties.WhiteBalance = (WhiteBalance)Enum.ToObject(typeof(WhiteBalance), BitConverter.ToInt16(property.Value, 0));
+                        break;
+                    case 0xa402:
+                        exifProperties.ExposureMode = (ExposureMode)Enum.ToObject(typeof(ExposureMode), BitConverter.ToInt16(property.Value, 0));
+                        break;
+                    case 0x8827:
+                        exifProperties.ISOSpeedRatings = Utils.getNumberValueInt16(property);
+                        break;
+                    case 0x9000:
+                        exifProperties.ExifVersion = Utils.getStringValue(property);
+                        break;
+                    case 0x9003:
+                        exifProperties.DateTimeOriginal = Utils.convertDateTime(property, "yyyy:MM:dd HH:mm:ss\0");
+                        break;
+                    case 0x9004:
+                        exifProperties.DateTimeDigitized = Utils.convertDateTime(property, "yyyy:MM:dd HH:mm:ss\0");
+                        break;
+                    case 0x9101:
+                        exifProperties.ComponentConfiguration = Utils.getStringValue(property);
+                        break;
+                    case 0x9102:
+                        exifProperties.CompressedBitsPerPixel = Utils.getNumberValueInt32(property);
+                        break;
+                    case 0x9201:
+                        exifProperties.ShutterSpeedValue = Utils.calcShutterSpeedValue(property);
+                        break;
+                    case 0x9202:
+                        exifProperties.ApertureValue = Utils.getNumberValueInt32(property);
+                        break;
+                    case 0x9203:
+                        exifProperties.BrightnessValue = Utils.getNumberValueInt32(property);
+                        break;
+                    case 0x9204:
+                        exifProperties.ExposureBiasValue = Utils.getNumberValueFloat(property, 4);
+                        break;
+                    case 0x9205:
+                        exifProperties.MaxApertureValue = Utils.calcFnumber(property);
+                        break;
+                    case 0x9206:
+                        exifProperties.SubjectDistance = Utils.getNumberValueInt32(property);
+                        break;
+                    case 0x9207:
+                        exifProperties.MeteringMode = (MeteringMode)Enum.ToObject(typeof(MeteringMode), BitConverter.ToInt16(property.Value, 0));
+                        break;
+                    case 0x9208:
+                        exifProperties.LightSource = (LightSource)Enum.ToObject(typeof(LightSource), BitConverter.ToInt16(property.Value, 0));
+                        break;
+                    case 0x9209:
+                        exifProperties.Flash = (Flash)Enum.ToObject(typeof(Flash), BitConverter.ToInt16(property.Value, 0));
+                        break;
+                    case 0x920a:
+                        exifProperties.FocalLength = Utils.calcFnumber(property);
+                        break;
+                    case 0x927c:
+                        exifProperties.MakerNote = Utils.getStringValue(property);
+                        break;
+                    case 0x9286:
+                        exifProperties.UserComment = Utils.getStringValue(property);
+                        break;
+                    case 0xa000:
+                        exifProperties.FlashPixVersion = Utils.getStringValue(property);
+                        break;
+                    case 0xa001:
+                        UInt16 valueColorSpace = BitConverter.ToUInt16(property.Value, 0);
+                        exifProperties.ColorSpace = (ColorSpace)Enum.ToObject(typeof(ColorSpace), valueColorSpace);
+                        break;
+                    case 0xa002:
+                        exifProperties.ExifImageWidth = Utils.getNumberValueInt16(property);
+                        break;
+                    case 0xa003:
+                        exifProperties.ExifImageHeight = Utils.getNumberValueInt16(property);
+                        break;
+                    case 0xa004:
+                        exifProperties.RelatedSoundFile = Utils.getStringValue(property);
+                        break;
+                    case 0xa005:
+                        exifProperties.ExifInteroperabilityOffset = Utils.getNumberValueInt64(property);
+                        break;
+                    case 0xa20e:
+                        exifProperties.FocalPlaneXResolution = Utils.getNumberValueInt32(property);
+                        break;
+                    case 0xa20f:
+                        exifProperties.FocalPlaneYResolution = Utils.getNumberValueInt32(property);
+                        break;
+                    case 0xa210:
+                        exifProperties.FocalPlaneResolutionUnit = (FocalPlaneResolutionUnit)Enum.ToObject(typeof(FocalPlaneResolutionUnit), BitConverter.ToInt16(property.Value, 0));
+                        break;
+                    case 0xa217:
+                        exifProperties.SensingMethod = (SensingMethod)Enum.ToObject(typeof(SensingMethod), BitConverter.ToInt16(property.Value, 0));
+                        break;
+                    case 0xa300:
+                        exifProperties.FileSource = (FileSource)Enum.ToObject(typeof(FileSource), Int32.Parse(BitConverter.ToString(property.Value)));
+                        break;
+                    case 0xa301:
+                        exifProperties.SceneType = Utils.getStringValue(property);
+                        break;
+                    case 0x0100:
+                        exifProperties.ImageWidth = Utils.getNumberValueInt16(property);
+                        break;
+                    case 0x0101:
+                        exifProperties.ImageLength = Utils.getNumberValueInt16(property);
+                        break;
+                    case 0x0102:
+                        exifProperties.BitsPerSample = Utils.getNumberValueInt16(property);
+                        break;
+                    case 0x0103:
+                        exifProperties.Compression = (Compression)Enum.ToObject(typeof(Compression), BitConverter.ToInt16(property.Value, 0));
+                        break;
+                    case 0x0106:
+                        exifProperties.PhotometricInterpretation = (PhotometricInterpretation)Enum.ToObject(typeof(PhotometricInterpretation), BitConverter.ToInt16(property.Value, 0));
+                        break;
+                    case 0x0111:
+                        exifProperties.StripOffsets = Utils.getNumberValueInt16(property);
+                        break;
+                    case 0x0115:
+                        exifProperties.SamplesPerPixel = Utils.getNumberValueInt16(property);
+                        break;
+                    case 0x0116:
+                        exifProperties.RowsPerStrip = Utils.getNumberValueInt16(property);
+                        break;
+                    case 0x0117:
+                        exifProperties.StripByteConunts = Utils.getNumberValueInt16(property);
+                        break;
+                    case 0x011c:
+                        exifProperties.PlanarConfiguration = (PlanarConfiguration)Enum.ToObject(typeof(PlanarConfiguration), BitConverter.ToInt16(property.Value, 0));
+                        break;
+                    case 0x0212:
+                        exifProperties.YCbCrSubSampling = Utils.getNumberValueInt16(property);
+                        break;
+                    case 0x00fe:
+                        exifProperties.NewSubfileType = Utils.getNumberValueInt64(property);
+                        break;
+                    case 0x00ff:
+                        exifProperties.SubfileType = Utils.getNumberValueInt16(property);
+                        break;
+                    case 0x012d:
+                        exifProperties.TransferFunction = Utils.getNumberValueInt16(property);
+                        break;
+                    case 0x013b:
+                        exifProperties.Artist = Utils.getStringValue(property);
+                        break;
+                    case 0x013d:
+                        exifProperties.Predictor = (Predictor)Enum.ToObject(typeof(Predictor), BitConverter.ToInt16(property.Value, 0));
+                        break;
+                    case 0x0142:
+                        exifProperties.TileWidth = Utils.getNumberValueInt16(property);
+                        break;
+                    case 0x0143:
+                        exifProperties.TileLength = Utils.getNumberValueInt16(property);
+                        break;
+                    case 0x0144:
+                        exifProperties.TileOffsets = Utils.getNumberValueInt64(property);
+                        break;
+                    case 0x0145:
+                        exifProperties.TileByteCounts = Utils.getNumberValueInt16(property);
+                        break;
+                    case 0x014a:
+                        exifProperties.SubIFDs = Utils.getNumberValueInt64(property);
+                        break;
+                    case 0x015b:
+                        exifProperties.JPEGTables = Utils.getStringValue(property);
+                        break;
+                    case 0x828d:
+                        exifProperties.CFARepeatPatternDim = Utils.getNumberValueInt16(property);
+                        break;
+                    case 0x828e:
+                        exifProperties.CFAPattern = property.Value;
+                        break;
+                    case 0x828f:
+                        exifProperties.BatteryLevel = Utils.getNumberValueInt32(property);
+                        break;
+                    case 0x83bb:
+                        exifProperties.IPTCNAA = Utils.getNumberValueInt64(property);
+                        break;
+                    case 0x8773:
+                        exifProperties.InterColorProfile = Utils.getStringValue(property);
+                        break;
+                    case 0x8824:
+                        exifProperties.SpectralSensitivity = Utils.getStringValue(property);
+                        break;
+                    case 0x0000:
+                        exifProperties.GPSInfo.VersionID = Utils.getNumberValueInt16(property);
+                        break;
+                    case 0x0001:
+                        exifProperties.GPSInfo.LatitudeRef = (LatitudeRef)Enum.ToObject(typeof(LatitudeRef), BitConverter.ToInt16(property.Value, 0));
+                        break;
+                    case 0x0002:
+                        exifProperties.GPSInfo.Latitude = GPSInfo.ExifGpsToFloat(exifProperties.GPSInfo.LatitudeRef.ToString(), property);
+                        break;
+                    case 0x0003:
+                        exifProperties.GPSInfo.LongitudeRef = (LongitudeRef)Enum.ToObject(typeof(LongitudeRef), BitConverter.ToInt16(property.Value, 0));
+                        break;
+                    case 0x0004:
+                        exifProperties.GPSInfo.Longitude = GPSInfo.ExifGpsToFloat(exifProperties.GPSInfo.LongitudeRef.ToString(), property);
+                        break;
+                    case 0x0005:
+                        exifProperties.GPSInfo.AltitudeRef = (AltitudeRef)Enum.ToObject(typeof(AltitudeRef), Int32.Parse(BitConverter.ToString(property.Value)));
+                        break;
+                    case 0x0006:
+                        exifProperties.GPSInfo.Altitude = (float)BitConverter.ToInt32(property.Value, 0) / (float)BitConverter.ToInt32(property.Value, 4);
+                        break;
+                    case 0x0007:
+                        //exifProperties.GPSInfo.TimeStamp = DateTime.ParseExact(${BitConverter.ToInt32(property.Value, 0).ToString().PadLeft(2, '0')}:{BitConverter.ToInt32(property.Value, 8).ToString().PadLeft(2, '0')}:{BitConverter.ToInt32(property.Value, 16).ToString().PadLeft(2, '0')}\0, HH:mm:ss\0, System.Globalization.CultureInfo.InvariantCulture);
+                        break;
+                    case 0x0008:
+                        exifProperties.GPSInfo.Satellites = Utils.getStringValue(property);
+                        break;
+                    case 0x0009:
+                        exifProperties.GPSInfo.Status = (Status)Enum.ToObject(typeof(Status), BitConverter.ToInt16(property.Value, 0));
+                        break;
+                    case 0x000a:
+                        exifProperties.GPSInfo.MeasureMode = Utils.getStringValue(property);
+                        break;
+                    case 0x000b:
+                        exifProperties.GPSInfo.DOP = Utils.getNumberValueInt32(property);
+                        break;
+                    case 0x000c:
+                        exifProperties.GPSInfo.SpeedRef = Utils.getStringValue(property);
+                        break;
+                    case 0x000d:
+                        exifProperties.GPSInfo.Speed = Utils.getNumberValueInt32(property);
+                        break;
+                    case 0x000e:
+                        exifProperties.GPSInfo.TrackRef = (TrackRef)Enum.ToObject(typeof(TrackRef), BitConverter.ToInt16(property.Value, 0));
+                        break;
+                    case 0x000f:
+                        exifProperties.GPSInfo.Track = Utils.getNumberValueInt32(property);
+                        break;
+                    case 0x0010:
+                        exifProperties.GPSInfo.ImgDirectionRef = (ImgDirectionRef)Enum.ToObject(typeof(ImgDirectionRef), BitConverter.ToInt16(property.Value, 0));
+                        break;
+                    case 0x0011:
+                        exifProperties.GPSInfo.ImgDirection = Utils.getNumberValueInt32(property);
+                        break;
+                    case 0x0012:
+                        exifProperties.GPSInfo.MapDatum = Utils.getStringValue(property);
+                        break;
+                    case 0x0013:
+                        exifProperties.GPSInfo.DestLatitudeRef = Utils.getStringValue(property);
+                        break;
+                    case 0x0014:
+                        exifProperties.GPSInfo.DestLatitude = Utils.getNumberValueInt32(property);
+                        break;
+                    case 0x0015:
+                        exifProperties.GPSInfo.DestLongitudeRef = (DestLongitudeRef)Enum.ToObject(typeof(DestLongitudeRef), BitConverter.ToInt16(property.Value, 0));
+                        break;
+                    case 0x0016:
+                        exifProperties.GPSInfo.DestLongitude = Utils.getNumberValueInt32(property);
+                        break;
+                    case 0x0017:
+                        exifProperties.GPSInfo.DestBearingRef = (DestBearingRef)Enum.ToObject(typeof(DestBearingRef), BitConverter.ToInt16(property.Value, 0));
+                        break;
+                    case 0x0018:
+                        exifProperties.GPSInfo.DestBearing = Utils.getNumberValueInt32(property);
+                        break;
+                    case 0x0019:
+                        exifProperties.GPSInfo.DestDistanceRef = (DestDistanceRef)Enum.ToObject(typeof(DestDistanceRef), BitConverter.ToInt16(property.Value, 0));
+                        break;
+                    case 0x001a:
+                        exifProperties.GPSInfo.DestDistance = Utils.getNumberValueInt32(property);
+                        break;
+                    case 0x001b:
+                        exifProperties.GPSInfo.ProcessingMethod = Utils.getStringValue(property);
+                        break;
+                    case 0x001c:
+                        exifProperties.GPSInfo.AreaInformation = Utils.getStringValue(property);
+                        break;
+                    case 0x001d:
+                        exifProperties.GPSInfo.DateStamp = Utils.convertDateTime(property, "yyyy:MM:dd\0");
+                        break;
+                    case 0x001e:
+                        exifProperties.GPSInfo.Differential = (Differential)Enum.ToObject(typeof(Differential), BitConverter.ToInt16(property.Value, 0));
+                        break;
+                    case 0x001f:
+                        exifProperties.GPSInfo.HPositioningError = Utils.getNumberValueInt32(property);
+                        break;
+                    case 0x8828:
+                        exifProperties.OECF = Utils.getStringValue(property);
+                        break;
+                    case 0x8829:
+                        exifProperties.Interlace = Utils.getNumberValueInt16(property);
+                        break;
+                    case 0x882a:
+                        exifProperties.TimeZoneOffset = Utils.getNumberValueInt16(property);
+                        break;
+                    case 0x882b:
+                        exifProperties.SelfTimerMode = Utils.getNumberValueInt16(property);
+                        break;
+                    case 0x920b:
+                        exifProperties.FlashEnergy = Utils.getNumberValueInt32(property);
+                        break;
+                    case 0x920c:
+                        exifProperties.SpatialFrequencyResponse = Utils.getStringValue(property);
+                        break;
+                    case 0x920d:
+                        exifProperties.Noise = Utils.getStringValue(property);
+                        break;
+                    case 0x9211:
+                        exifProperties.ImageNumber = Utils.getNumberValueInt64(property);
+                        break;
+                    case 0x9212:
+                        exifProperties.SecurityClassification = (SecurityClassification)Enum.ToObject(typeof(SecurityClassification), new System.Text.ASCIIEncoding().GetString(property.Value));
+                        break;
+                    case 0x9213:
+                        exifProperties.ImageHistory = Utils.getStringValue(property);
+                        break;
+                    case 0x9214:
+                        exifProperties.SubjectLocation = Utils.getNumberValueInt16(property);
+                        break;
+                    case 0x9215:
+                        exifProperties.ExposureIndex = Utils.getNumberValueInt32(property);
+                        break;
+                    case 0x9216:
+                        exifProperties.TIFFEPStandardID = property.Value;
+                        break;
+                    case 0x9290:
+                        exifProperties.SubSecTime = Utils.getStringValue(property);
+                        break;
+                    case 0x9291:
+                        exifProperties.SubSecTimeOriginal = Utils.getStringValue(property);
+                        break;
+                    case 0x9292:
+                        exifProperties.SubSecTimeDigitized = Utils.getStringValue(property);
+                        break;
+                    case 0xa20b:
+                        exifProperties.FlashEnergy = Utils.getNumberValueInt32(property);
+                        break;
+                    case 0xa20c:
+                        exifProperties.SpatialFrequencyResponse = Utils.getStringValue(property);
+                        break;
+                    case 0xa214:
+                        exifProperties.SubjectLocation = Utils.getNumberValueInt16(property);
+                        break;
+                    case 0xa215:
+                        exifProperties.ExposureIndex = Utils.getNumberValueInt32(property);
+                        break;
+                    case 0xa302:
+                        exifProperties.CFAPattern = property.Value;
+                        break;
+                    case 0x0200:
+                        exifProperties.SpecialMode = Utils.getNumberValueInt64(property);
+                        break;
+                    case 0x0201:
+                        exifProperties.JpegQual = Utils.getNumberValueInt16(property);
+                        break;
+                    case 0x0202:
+                        exifProperties.Macro = Utils.getNumberValueInt16(property);
+                        break;
+                    case 0x0203:
+                        exifProperties.Unknown = Utils.getNumberValueInt16(property);
+                        break;
+                    case 0x0204:
+                        exifProperties.DigiZoom = Utils.getNumberValueInt32(property);
+                        break;
+                    case 0x0207:
+                        exifProperties.SoftwareRelease = Utils.getStringValue(property);
+                        break;
+                    case 0x0208:
+                        exifProperties.PictInfo = Utils.getStringValue(property);
+                        break;
+                    case 0x0209:
+                        exifProperties.CameraID = Utils.getStringValue(property);
+                        break;
+                    case 0x0f00:
+                        exifProperties.DataDump = Utils.getNumberValueInt64(property);
+                        break;
+                    case 0xa404:
+                        exifProperties.DigitalZoomRatio = Utils.getNumberValueInt32(property);
+                        break;
+                    case 0xa405:
+                        exifProperties.FocalLengthIn35mmFormat = Utils.getNumberValueInt16(property);
+                        break;
+                    case 0xa406:
+                        exifProperties.SceneCaptureType = (SceneCaptureType)Enum.ToObject(typeof(SceneCaptureType), BitConverter.ToInt16(property.Value, 0));
+                        break;
+                    case 0xa407:
+                        exifProperties.GainControl = (GainControl)Enum.ToObject(typeof(GainControl), BitConverter.ToInt16(property.Value, 0));
+                        break;
+                    case 0xa408:
+                        exifProperties.Contrast = (Contrast)Enum.ToObject(typeof(Contrast), BitConverter.ToInt16(property.Value, 0));
+                        break;
+                    case 0xa409:
+                        exifProperties.Saturation = (Saturation)Enum.ToObject(typeof(Saturation), BitConverter.ToInt16(property.Value, 0));
+                        break;
+                    case 0xa40a:
+                        exifProperties.Sharpness = (Sharpness)Enum.ToObject(typeof(Sharpness), BitConverter.ToInt16(property.Value, 0));
+                        break;
+                    case 0xa40c:
+                        exifProperties.SubjectDistanceRange = (SubjectDistanceRange)Enum.ToObject(typeof(SubjectDistanceRange), BitConverter.ToInt16(property.Value, 0));
+                        break;
+                    case 0xa432:
+                        exifProperties.LensInfo = Utils.getStringValue(property);
+                        break;
+                    case 0xa433:
+                        exifProperties.LensMake = Utils.getStringValue(property);
+                        break;
+                    case 0xa434:
+                        exifProperties.LensModel = Utils.getStringValue(property);
+                        break;
+                    case 0xa435:
+                        exifProperties.LensSerialNumber = Utils.getStringValue(property);
+                        break;
+                    default:
+                        Debug.WriteLine($"Jpg Exif Unknown tag 0x{property.Id:X}");
+                        break;
+                }
+            }
+            catch (Exception ex)
+            {
+                Debug.WriteLine($"Jpg Exif unable to convert tag 0x{property.Id:X} {ex}");
+            }
+        }
+    }
+}

--- a/src/UglyToad.PdfPig/Images/Jpg/Parts/Exif/ExifImageProperties.cs
+++ b/src/UglyToad.PdfPig/Images/Jpg/Parts/Exif/ExifImageProperties.cs
@@ -1,0 +1,133 @@
+﻿namespace UglyToad.PdfPig.Images.Jpg.Parts.Exif
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Text;
+    using UglyToad.PdfPig.Images.Jpg.Parts.ExifTypes;
+
+    internal class ExifImageProperties
+    {
+        public string ImageDescription { get; set; }
+        public string Make { get; set; }
+        public string Model { get; set; }
+
+        public Orientation Orientation { get; set; }
+        public int XResolution { get; set; }
+        public int YResolution { get; set; }
+        public ResolutionUnit ResolutionUnit { get; set; }
+        public string Software { get; set; }
+        public DateTime DateTime { get; set; }
+        public int WhitePoint { get; set; }
+        public WhiteBalance WhiteBalance { get; set; }
+        public int PrimaryChromaticities { get; set; }
+        public int YCbCrCoefficients { get; set; }
+        public YCbCrPositioning YCbCrPositioning { get; set; }
+        public int ReferenceBlackWhite { get; set; }
+        public string Copyright { get; set; }
+        public long ExifOffset { get; set; }
+        public float ExposureTime { get; set; }
+        public ExposureMode ExposureMode { get; set; }
+        public float FNumber { get; set; }
+        public ExposureProgram ExposureProgram { get; set; }
+        public short ISOSpeedRatings { get; set; }
+        public string ExifVersion { get; set; }
+        public DateTime DateTimeOriginal { get; set; }
+        public DateTime DateTimeDigitized { get; set; }
+        public string ComponentConfiguration { get; set; }
+        public int CompressedBitsPerPixel { get; set; }
+        public float ShutterSpeedValue { get; set; }
+        public int ApertureValue { get; set; }
+        public int BrightnessValue { get; set; }
+        public float ExposureBiasValue { get; set; }
+        public float MaxApertureValue { get; set; }
+        public int SubjectDistance { get; set; }
+        public MeteringMode MeteringMode { get; set; }
+        public LightSource LightSource { get; set; }
+        public Flash Flash { get; set; }
+        public float FocalLength { get; set; }
+        public string MakerNote { get; set; }
+        public string UserComment { get; set; }
+        public string FlashPixVersion { get; set; }
+        public ColorSpace ColorSpace { get; set; }
+        public short ExifImageWidth { get; set; }
+        public short ExifImageHeight { get; set; }
+        public string RelatedSoundFile { get; set; }
+        public long ExifInteroperabilityOffset { get; set; }
+        public int FocalPlaneXResolution { get; set; }
+        public int FocalPlaneYResolution { get; set; }
+        public FocalPlaneResolutionUnit FocalPlaneResolutionUnit { get; set; }
+        public SensingMethod SensingMethod { get; set; }
+        public FileSource FileSource { get; set; }
+        public string SceneType { get; set; }
+        public short ImageWidth { get; set; }
+        public short ImageLength { get; set; }
+        public short BitsPerSample { get; set; }
+        public Compression Compression { get; set; }
+        public PhotometricInterpretation PhotometricInterpretation { get; set; }
+        public short StripOffsets { get; set; }
+        public short SamplesPerPixel { get; set; }
+        public short RowsPerStrip { get; set; }
+        public short StripByteConunts { get; set; }
+        public PlanarConfiguration PlanarConfiguration { get; set; }
+        public long JpegIFOffset { get; set; }
+        public long JpegIFByteCount { get; set; }
+        public short YCbCrSubSampling { get; set; }
+        public long NewSubfileType { get; set; }
+        public short SubfileType { get; set; }
+        public short TransferFunction { get; set; }
+        public string Artist { get; set; }
+        public Predictor Predictor { get; set; }
+        public short TileWidth { get; set; }
+        public short TileLength { get; set; }
+        public long TileOffsets { get; set; }
+        public short TileByteCounts { get; set; }
+        public long SubIFDs { get; set; }
+        public string JPEGTables { get; set; }
+        public short CFARepeatPatternDim { get; set; }
+        public byte[] CFAPattern { get; set; }
+        public int BatteryLevel { get; set; }
+        public long IPTCNAA { get; set; }
+        public string InterColorProfile { get; set; }
+        public string SpectralSensitivity { get; set; }
+        public GPSInfo GPSInfo { get; set; }
+        public string OECF { get; set; }
+        public short Interlace { get; set; }
+        public short TimeZoneOffset { get; set; }
+        public short SelfTimerMode { get; set; }
+        public int FlashEnergy { get; set; }
+        public string SpatialFrequencyResponse { get; set; }
+        public string Noise { get; set; }
+        public long ImageNumber { get; set; }
+        public SecurityClassification SecurityClassification { get; set; }
+        public string ImageHistory { get; set; }
+        public short SubjectLocation { get; set; }
+        public int ExposureIndex { get; set; }
+        public byte[] TIFFEPStandardID { get; set; }
+        public string SubSecTime { get; set; }
+        public string SubSecTimeOriginal { get; set; }
+        public string SubSecTimeDigitized { get; set; }
+        public long SpecialMode { get; set; }
+        public short JpegQual { get; set; }
+        public short Macro { get; set; }
+        public short Unknown { get; set; }
+        public int DigiZoom { get; set; }
+        public string SoftwareRelease { get; set; }
+        public string PictInfo { get; set; }
+        public string CameraID { get; set; }
+        public long DataDump { get; set; }
+        public int DigitalZoomRatio { get; set; }
+        public short FocalLengthIn35mmFormat { get; set; }
+        public SceneCaptureType SceneCaptureType { get; set; }
+        public GainControl GainControl { get; set; }
+        public Contrast Contrast { get; set; }
+        public Saturation Saturation { get; set; }
+        public Sharpness Sharpness { get; set; }
+        public SubjectDistanceRange SubjectDistanceRange { get; set; }
+        public InteropIndex InteropIndex { get; set; }
+        public string LensInfo { get; set; }
+        public string LensMake { get; set; }
+        public string LensModel { get; set; }
+        public string LensSerialNumber { get; set; }
+    }
+}
+ 

--- a/src/UglyToad.PdfPig/Images/Jpg/Parts/Exif/ExifTypes/ColorSpace.cs
+++ b/src/UglyToad.PdfPig/Images/Jpg/Parts/Exif/ExifTypes/ColorSpace.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Text;
+
+namespace UglyToad.PdfPig.Images.Jpg.Parts.ExifTypes
+{
+    /// <summary>
+    /// ExIf ColorSpace
+    /// </summary>
+    internal enum ColorSpace
+    {
+        /// <summary>
+        /// sRGB
+        /// </summary>
+        SRGB = 0x1,
+        /// <summary>
+        /// Adobe RGB
+        /// </summary>
+        AdobeRGB = 0x2,
+        /// <summary>
+        /// Wide Gamut RGB
+        /// </summary>
+        WideGamutRGB = 0xfffd,
+        /// <summary>
+        /// ICC Profile
+        /// </summary>
+        ICCProfile = 0xfffe,
+        /// <summary>
+        /// Uncalibrated
+        /// /// </summary>
+        Uncalibrated = 0xffff
+
+    }
+}

--- a/src/UglyToad.PdfPig/Images/Jpg/Parts/Exif/ExifTypes/ComponentsConfiguration.cs
+++ b/src/UglyToad.PdfPig/Images/Jpg/Parts/Exif/ExifTypes/ComponentsConfiguration.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Text;
+
+namespace UglyToad.PdfPig.Images.Jpg.Parts.ExifTypes
+{
+    internal enum ComponentsConfiguration
+    {
+        //NÃO IMPLEMENTADO
+    }
+}

--- a/src/UglyToad.PdfPig/Images/Jpg/Parts/Exif/ExifTypes/Compression.cs
+++ b/src/UglyToad.PdfPig/Images/Jpg/Parts/Exif/ExifTypes/Compression.cs
@@ -1,0 +1,87 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Text;
+
+namespace UglyToad.PdfPig.Images.Jpg.Parts.ExifTypes
+{
+    internal enum Compression
+    {
+        Uncompressed = 1,
+        [Description("CCITT 1D")]
+        CCITT1D = 2,
+        [Description("T4/Group 3 Fax")]
+        T4Group3Fax = 3,
+        [Description("T6/Group 4 Fax")]
+        T6Group4Fax = 4,
+        LZW = 5,
+        [Description("JPEG (old-style)")]
+        JPEGOldStyle = 6,
+        JPEG = 7,
+        [Description("Adobe Deflate")]
+        AdobeDeflate = 8,
+        [Description("JBIG B&W")]
+        JBIGBW = 9,
+        [Description("JBIG Color")]
+        JBIGColor = 10,
+        JPEG2 = 99,
+        [Description("Kodak 262")]
+        Kodak262 = 262,
+        Next = 32766,
+        [Description("Sony ARW Compressed")]
+        SonyARWCompressed = 32767,
+        [Description("Packed RAW")]
+        PackedRAW = 32769,
+        [Description("Samsung SRW Compressed")]
+        SamsungSRWCompressed = 32770,
+        CCIRLEW = 32771,
+        [Description("Samsung SRW Compressed 2")]
+        SamsungSRWCompressed2 = 32772,
+        PackBits = 32773,
+        [Description("Thunderscan")]
+        Thunderscan = 32809,
+        [Description("Kodak KDC Compressed")]
+        KodakKDCCompressed = 32867,
+        IT8CTPAD = 32895,
+        IT8LW = 32896,
+        IT8MP = 32897,
+        IT8BL = 32898,
+        PixarFilm = 32908,
+        PixarLog = 32909,
+        Deflate = 32946,
+        DCS = 32947,
+        [Description("Aperio JPEG 2000 YCbCr")]
+        AperioJPEG2000YCbCr = 33003,
+        [Description("Aperio JPEG 2000 RGB")]
+        AperioJPEG2000RGB = 33005,
+        JBIG = 34661,
+        SGILog = 34676,
+        SGILog24 = 34677,
+        [Description("JPEG 2000")]
+        JPEG2000 = 34712,
+        [Description("Nikon NEF Compressed")]
+        NikonNEFCompressed = 34713,
+        [Description("JBIG2 TIFF FX")]
+        JBIG2TIFFFX = 34715,
+        [Description("Microsoft Document Imaging (MDI) Binary Level Codec")]
+        MicrosoftDocumentImagingMDIBinaryLevelCodec = 34718,
+        [Description("Microsoft Document Imaging (MDI) Progressive Transform Codec")]
+        MicrosoftDocumentImagingMDIProgressiveTransformCodec = 34719,
+        [Description("Microsoft Document Imaging (MDI) Vector")]
+        MicrosoftDocumentImagingMDIVector = 34720,
+        [Description("ESRI Lerc")]
+        ESRILerc = 34887,
+        [Description("Lossy JPEG")]
+        LossyJPEG = 34892,
+        LZMA2 = 34925,
+        Zstd = 34926,
+        WebP = 34927,
+        PNG = 34933,
+        JPEGXR = 34934,
+        [Description("Kodak DCR Compressed")]
+        KodakDCRCompressed = 65000,
+        [Description("Pentax PEF Compressed")]
+        PentaxPEFCompressed = 65535,
+
+    }
+}

--- a/src/UglyToad.PdfPig/Images/Jpg/Parts/Exif/ExifTypes/Contrast.cs
+++ b/src/UglyToad.PdfPig/Images/Jpg/Parts/Exif/ExifTypes/Contrast.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Text;
+
+namespace UglyToad.PdfPig.Images.Jpg.Parts.ExifTypes
+{
+    internal enum Contrast
+    {
+        Normal = 0,
+        Low = 1,
+        High = 2
+    }
+}

--- a/src/UglyToad.PdfPig/Images/Jpg/Parts/Exif/ExifTypes/ExposureMode.cs
+++ b/src/UglyToad.PdfPig/Images/Jpg/Parts/Exif/ExifTypes/ExposureMode.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Text;
+
+namespace UglyToad.PdfPig.Images.Jpg.Parts.ExifTypes
+{
+    internal enum ExposureMode
+    {
+        Auto = 0,
+        Manual = 1,
+        AutoBracket = 2
+    }
+}

--- a/src/UglyToad.PdfPig/Images/Jpg/Parts/Exif/ExifTypes/ExposureProgram.cs
+++ b/src/UglyToad.PdfPig/Images/Jpg/Parts/Exif/ExifTypes/ExposureProgram.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Text;
+
+namespace UglyToad.PdfPig.Images.Jpg.Parts.ExifTypes
+{
+    internal enum ExposureProgram
+    {
+        [Description("Not Defined")]
+        NotDefined = 0,
+        Manual = 1,
+        ProgramAE = 2,
+        [Description("Aperture-priority AE")]
+        AperturePriorityAE = 3,
+        [Description("Shutter speed priority AE")]
+        ShutterSpeedPriorityAE = 4,
+        [Description("Creative (Slow speed)")]
+        CreativeSlowSpeed = 5,
+        [Description("Action (High speed)")]
+        ActionHighSpeed = 6,
+        Portrait = 7,
+        Landscape = 8,
+        Bulb = 9
+    }
+}

--- a/src/UglyToad.PdfPig/Images/Jpg/Parts/Exif/ExifTypes/FileSource.cs
+++ b/src/UglyToad.PdfPig/Images/Jpg/Parts/Exif/ExifTypes/FileSource.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Text;
+
+namespace UglyToad.PdfPig.Images.Jpg.Parts.ExifTypes
+{
+    internal enum FileSource : byte
+    {
+        [Description("Film Scanner")]
+        FilmScanner = 1,
+        [Description("Reflection Print Scanner")]
+        ReflectionPrintScanner = 2,
+        [Description("Digital Camera")]
+        DigitalCamera = 3
+    }
+}

--- a/src/UglyToad.PdfPig/Images/Jpg/Parts/Exif/ExifTypes/Flash.cs
+++ b/src/UglyToad.PdfPig/Images/Jpg/Parts/Exif/ExifTypes/Flash.cs
@@ -1,0 +1,65 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Text;
+
+namespace UglyToad.PdfPig.Images.Jpg.Parts.ExifTypes
+{
+    internal enum Flash
+    {
+        [Description("No Flash")]
+        NoFlash = 0x0,
+        [Description("Fired")]
+        Fired = 0x1,
+        [Description("Fired, Return not detected")]
+        FiredReturnNotDetected = 0x5,
+        [Description("Fired, Return detected")]
+        FiredReturnDetected = 0x7,
+        [Description("On, Did not fire")]
+        OnDidNotFire = 0x8,
+        [Description("On, Fired")]
+        OnFired = 0x9,
+        [Description("On, Return not detected")]
+        OnReturnNotDetected = 0xd,
+        [Description("On, Return detected")]
+        OnReturnDetected = 0xf,
+        [Description("Off, Did not fire")]
+        OffDidNotFire = 0x10,
+        [Description("Off, Did not fire, Return not detected")]
+        OffDidNotFireReturnNotDetected = 0x14,
+        [Description("Auto, Did not fire")]
+        AutoDidNotFire = 0x18,
+        [Description("Auto, Fired")]
+        AutoFired = 0x19,
+        [Description("Auto, Fired, Return not detected")]
+        AutoFiredReturnNotDetected = 0x1d,
+        [Description("Auto, Fired, Return detected")]
+        AutoFiredReturnDetected = 0x1f,
+        [Description("No flash function")]
+        NoFlashFunction = 0x20,
+        [Description("Off, No flash function")]
+        OffNoFlashFunction = 0x30,
+        [Description("Fired, Red-eye reduction")]
+        FiredRedEyeReduction = 0x41,
+        [Description("Fired, Red-eye reduction, Return not detected")]
+        FiredRedEyeReductionReturnNotDetected = 0x45,
+        [Description("Fired, Red-eye reduction, Return detected")]
+        FiredRedEyeReductionReturnDetected = 0x47,
+        [Description("On, Red-eye reduction")]
+        OnRedEyeReduction = 0x49,
+        [Description("On, Red-eye reduction, Return not detected")]
+        OnRedEyeRductionReturnNotDetected = 0x4d,
+        [Description("On, Red-eye reduction, Return detected")]
+        OnRedEyeReductionReturnDetected = 0x4f,
+        [Description("Off, Red-eye reduction")]
+        OffRedEyeReduction = 0x50,
+        [Description("Auto, Did not fire, Red-eye reduction")]
+        AutoDidNotFireRedEyeReduction = 0x58,
+        [Description("Auto, Fired, Red-eye reduction")]
+        AutoFiredRedEyeReduction = 0x59,
+        [Description("Auto, Fired, Red-eye reduction, Return not detected")]
+        AutoFiredRedEyeReductionReturnNotDetected = 0x5d,
+        [Description("Auto, Fired, Red-eye reduction, Return detected")]
+        AutoFiredRedEyeReductionReturnDetected = 0x5f
+    }
+}

--- a/src/UglyToad.PdfPig/Images/Jpg/Parts/Exif/ExifTypes/FocalPlaneResolutionUnit.cs
+++ b/src/UglyToad.PdfPig/Images/Jpg/Parts/Exif/ExifTypes/FocalPlaneResolutionUnit.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Text;
+
+namespace UglyToad.PdfPig.Images.Jpg.Parts.ExifTypes
+{
+    internal enum FocalPlaneResolutionUnit
+    {
+        None = 1,
+        inches = 2,
+        Cm = 3,
+        Mm = 4,
+        Um = 5
+    }
+}

--- a/src/UglyToad.PdfPig/Images/Jpg/Parts/Exif/ExifTypes/GPSInfo.cs
+++ b/src/UglyToad.PdfPig/Images/Jpg/Parts/Exif/ExifTypes/GPSInfo.cs
@@ -1,0 +1,143 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using PropertyItem = UglyToad.PdfPig.Images.Jpg.Parts.Drawing.PropertyItem;
+ 
+
+namespace UglyToad.PdfPig.Images.Jpg.Parts.ExifTypes
+{
+    internal class GPSInfo
+    {
+        internal short VersionID { get; set; }
+        internal LatitudeRef LatitudeRef { get; set; }
+        internal double Latitude { get; set; }
+        internal LongitudeRef LongitudeRef { get; set; }
+        internal double Longitude { get; set; }
+        internal AltitudeRef AltitudeRef { get; set; }
+        internal float Altitude { get; set; }
+        internal DateTime TimeStamp { get; set; }
+        internal string Satellites { get; set; }
+        internal Status Status { get; set; }
+        internal string MeasureMode { get; set; }
+        internal long DOP { get; set; }
+        internal string SpeedRef { get; set; }
+        internal long Speed { get; set; }
+        internal TrackRef TrackRef { get; set; }
+        internal long Track { get; set; }
+        internal ImgDirectionRef ImgDirectionRef { get; set; }
+        internal long ImgDirection { get; set; }
+        internal string MapDatum { get; set; }
+        internal string DestLatitudeRef { get; set; }
+        internal double DestLatitude { get; set; }
+        internal DestLongitudeRef DestLongitudeRef { get; set; }
+        internal int DestLongitude { get; set; }
+        internal DestBearingRef DestBearingRef { get; set; }
+        internal double DestBearing { get; set; }
+        internal DestDistanceRef DestDistanceRef { get; set; }
+        internal double DestDistance { get; set; }
+        internal string ProcessingMethod { get; set; }
+        internal string AreaInformation { get; set; }
+        internal DateTime DateStamp { get; set; }
+        internal Differential Differential { get; set; }
+        internal double HPositioningError { get; set; }
+
+        internal static double ExifGpsToFloat(string gpsRef, PropertyItem propItem)
+        {
+            uint degreesNumerator = BitConverter.ToUInt32(propItem.Value, 0);
+            uint degreesDenominator = BitConverter.ToUInt32(propItem.Value, 4);
+            float degrees = degreesNumerator / (float)degreesDenominator;
+
+            uint minutesNumerator = BitConverter.ToUInt32(propItem.Value, 8);
+            uint minutesDenominator = BitConverter.ToUInt32(propItem.Value, 12);
+            float minutes = minutesNumerator / (float)minutesDenominator;
+
+            uint secondsNumerator = BitConverter.ToUInt32(propItem.Value, 16);
+            uint secondsDenominator = BitConverter.ToUInt32(propItem.Value, 20);
+            float seconds = secondsNumerator / (float)secondsDenominator;
+
+            float coorditate = degrees + (minutes / 60f) + (seconds / 3600f);
+
+            if (gpsRef == "South" || gpsRef == "West")
+                coorditate = 0 - coorditate;
+            return coorditate;
+        }
+
+        internal static DateTime GetDateTime(PropertyItem propItem, string formatacao)
+        {
+            var data = new DateTime();
+
+            DateTime.ParseExact(BitConverter.ToInt16(propItem.Value, 0).ToString(), formatacao, System.Globalization.CultureInfo.InvariantCulture);
+
+            return data;
+        }
+    }
+
+    internal enum LatitudeRef
+    {
+        North = 'N',
+        South = 'S'
+    }
+
+    internal enum LongitudeRef
+    {
+        East = 'E',
+        West = 'W'
+    }
+
+    internal enum AltitudeRef
+    {
+        [Description("Above Sea Level")]
+        AboveSeaLevel = 0,
+        [Description("Below Sea Level")]
+        BelowSeaLevel = 1
+    }
+
+    internal enum Status
+    {
+        [Description("Measurement Active")]
+        MeasurementActive = 'A',
+        [Description("Measurement Void")]
+        MeasurementVoid = 'V'
+    }
+    internal enum TrackRef
+    {
+        [Description("Magnetic North")]
+        MagneticNorth = 'M',
+        [Description("True North")]
+        TrueNorth = 'T'
+    }
+    internal enum ImgDirectionRef
+    {
+        [Description("Magnetic North")]
+        MagneticNorth = 'M',
+        [Description("True North")]
+        TrueNorth = 'T'
+    }
+
+    internal enum DestLongitudeRef
+    {
+        East = 'E',
+        West = 'W'
+    }
+    internal enum DestBearingRef
+    {
+        [Description("Magnetic North")]
+        MagneticNorth = 'M',
+        [Description("True North")]
+        TrueNorth = 'T'
+    }
+    internal enum DestDistanceRef
+    {
+        Kilometers = 'K',
+        Miles = 'M',
+        [Description("Nautical Miles")]
+        NauticalMiles = 'N'
+    }
+    internal enum Differential
+    {
+        [Description("No Correction")]
+        NoCorrection = 0,
+        [Description(" Differential Corrected")]
+        DifferentialCorrected = 1
+    }
+}

--- a/src/UglyToad.PdfPig/Images/Jpg/Parts/Exif/ExifTypes/GainControl.cs
+++ b/src/UglyToad.PdfPig/Images/Jpg/Parts/Exif/ExifTypes/GainControl.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Text;
+
+namespace UglyToad.PdfPig.Images.Jpg.Parts.ExifTypes
+{
+    internal enum GainControl
+    {
+        None = 0,
+        /// <summary>
+        /// Low Gain Up
+        /// </summary>
+        LowGainUp = 1,
+        /// <summary>
+        /// High Gain Up
+        /// </summary>
+        HighGainUp = 2,
+        /// <summary>
+        /// Low Gain Down
+        /// </summary>
+        LowGainDown = 3,
+        /// <summary>
+        /// High Gain Down
+        /// </summary>
+        HighGainDown = 4
+    }
+}

--- a/src/UglyToad.PdfPig/Images/Jpg/Parts/Exif/ExifTypes/InteropIndex.cs
+++ b/src/UglyToad.PdfPig/Images/Jpg/Parts/Exif/ExifTypes/InteropIndex.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Text;
+
+namespace UglyToad.PdfPig.Images.Jpg.Parts.ExifTypes
+{
+    internal enum InteropIndex
+    {
+        [Description("R03 - DCF option file (Adobe RGB)")]
+        R03,
+        [Description("R98 - DCF basic file (sRGB)")]
+        R98,
+        [Description("THM - DCF thumbnail file")]
+        THM
+    }
+}

--- a/src/UglyToad.PdfPig/Images/Jpg/Parts/Exif/ExifTypes/LightSource.cs
+++ b/src/UglyToad.PdfPig/Images/Jpg/Parts/Exif/ExifTypes/LightSource.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Text;
+
+namespace UglyToad.PdfPig.Images.Jpg.Parts.ExifTypes
+{
+    internal enum LightSource
+    {
+        Unknown = 0,
+        Fluorescent = 2,
+        Daylight = 1,
+        Flash = 4,
+        [Description("Tungsten (Incandescent)")]
+        TungstenIncandescent = 3,
+        [Description("Fine Weather")]
+        FineWeather = 9,
+        Cloudy = 10,
+        Shade = 11,
+        [Description("Daylight Fluorescent")]
+        DaylightFluorescent = 12,
+        [Description("Day White Fluorescent")]
+        DayWhiteFluorescent = 13,
+        [Description("Cool White Fluorescent")]
+        CoolWhiteFluorescent = 14,
+        [Description("White Fluorescent")]
+        WhiteFluorescent = 15,
+        [Description("Warm White Fluorescent")]
+        WarmWhiteFluorescent = 16,
+        [Description("Standard Light A")]
+        StandardLightA = 17,
+        [Description("Standard Light B")]
+        StandardLightB = 18,
+        [Description("Standard Light C")]
+        StandardLightC = 19,
+        D55 = 20,
+        D65 = 21,
+        D75 = 22,
+        D50 = 23,
+        [Description("ISO Studio Tungsten")]
+        ISOStudioTungsten = 24,
+        Other = 255
+    }
+}

--- a/src/UglyToad.PdfPig/Images/Jpg/Parts/Exif/ExifTypes/MeteringMode.cs
+++ b/src/UglyToad.PdfPig/Images/Jpg/Parts/Exif/ExifTypes/MeteringMode.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Text;
+
+namespace UglyToad.PdfPig.Images.Jpg.Parts.ExifTypes
+{
+    internal enum MeteringMode
+    {
+        Unknown = 0,
+        Average = 1,
+        [Description("Center-weighted average")]
+        CenterWeightedAverage = 2,
+        Spot = 3,
+        [Description("Multi-spot")]
+        MultiSpot = 4,
+        [Description("Multi-segment")]
+        MultiSegment = 5,
+        Partial = 6,
+        Other = 255
+    }
+}

--- a/src/UglyToad.PdfPig/Images/Jpg/Parts/Exif/ExifTypes/Orientation.cs
+++ b/src/UglyToad.PdfPig/Images/Jpg/Parts/Exif/ExifTypes/Orientation.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace UglyToad.PdfPig.Images.Jpg.Parts.ExifTypes
+{
+    internal enum Orientation
+    {
+        Horizontal = 1,
+        [Description("Mirror horizontal")]
+        MirrorHorizontal = 2,
+        [Description("Rotate 180º")]
+        Rotate180 = 3,
+        [Description("Mirror vertical")]
+        MirrorVertical = 4,
+        [Description("Mirror horizontal and rotate 270º CW")]
+        MirrorHorizontalRotate270 = 5,
+        [Description("Rotate 90º CW")]
+        Rotate90 = 6,
+        [Description("Mirror horizontal and rotate 90º CW")]
+        MirrorHorizontalRotate90 = 7,
+        [Description("Rotate 270º CW")]
+        Rotate270 = 8
+    }
+}

--- a/src/UglyToad.PdfPig/Images/Jpg/Parts/Exif/ExifTypes/PhotometricInterpretation.cs
+++ b/src/UglyToad.PdfPig/Images/Jpg/Parts/Exif/ExifTypes/PhotometricInterpretation.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Text;
+
+namespace UglyToad.PdfPig.Images.Jpg.Parts.ExifTypes
+{
+    internal enum PhotometricInterpretation
+    {
+        [Description("White Is Zero")]
+        WhiteIsZero = 0,
+        [Description("Black Is Zero")]
+        BlackIsZero = 1,
+        RGB = 2,
+        [Description("RGB Palette")]
+        RGBPalette = 3,
+        [Description("Transparency Mask")]
+        TransparencyMask = 4,
+        CMYK = 5,
+        YCbCr = 6,
+        CIELab = 8,
+        ICCLab = 9,
+        ITULab = 10,
+        [Description("Color Filter Array")]
+        ColorFilterArray = 32803,
+        [Description("Pixar LogL")]
+        PixarLogL = 32844,
+        [Description("Pixar LogLuv")]
+        PixarLogLuv = 32845,
+        [Description("Sequential Color Filter")]
+        SequentialColorFilter = 32892,
+        [Description("Linear Raw")]
+        LinearRaw = 34892,
+        [Description("Depth Map")]
+        DepthMap = 51177
+    }
+}

--- a/src/UglyToad.PdfPig/Images/Jpg/Parts/Exif/ExifTypes/PlanarConfiguration.cs
+++ b/src/UglyToad.PdfPig/Images/Jpg/Parts/Exif/ExifTypes/PlanarConfiguration.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Text;
+
+namespace UglyToad.PdfPig.Images.Jpg.Parts.ExifTypes
+{
+    internal enum PlanarConfiguration
+    {
+        Chunky = 1,
+        Planar = 2,
+    }
+}

--- a/src/UglyToad.PdfPig/Images/Jpg/Parts/Exif/ExifTypes/Predictor.cs
+++ b/src/UglyToad.PdfPig/Images/Jpg/Parts/Exif/ExifTypes/Predictor.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Text;
+
+namespace UglyToad.PdfPig.Images.Jpg.Parts.ExifTypes
+{
+    internal enum Predictor
+    {
+        None = 1,
+        [Description("Horizontal differencing")]
+        HorizontalDifferencing = 2,
+        [Description("Floating point")]
+        FloatingPoint = 3,
+        [Description("Horizontal difference X2")]
+        HorizontalDifferenceX2 = 34892,
+        [Description("Horizontal difference X4")]
+        HorizontalDifferenceX4 = 34893,
+        [Description("Floating point X2")]
+        FloatingPointX2 = 34894,
+        [Description("Floating point X4")]
+        FloatingPointX4 = 34895
+    }
+}

--- a/src/UglyToad.PdfPig/Images/Jpg/Parts/Exif/ExifTypes/ResolutionUnit.cs
+++ b/src/UglyToad.PdfPig/Images/Jpg/Parts/Exif/ExifTypes/ResolutionUnit.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Text;
+
+namespace UglyToad.PdfPig.Images.Jpg.Parts.ExifTypes
+{
+    internal enum ResolutionUnit
+    {
+        None = 1,
+        Inch = 2,
+        CM = 3
+    }
+}

--- a/src/UglyToad.PdfPig/Images/Jpg/Parts/Exif/ExifTypes/Saturation.cs
+++ b/src/UglyToad.PdfPig/Images/Jpg/Parts/Exif/ExifTypes/Saturation.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Text;
+
+namespace UglyToad.PdfPig.Images.Jpg.Parts.ExifTypes
+{
+    internal enum Saturation
+    {
+        Normal = 0,
+        Low = 1,
+        High = 2
+    }
+}

--- a/src/UglyToad.PdfPig/Images/Jpg/Parts/Exif/ExifTypes/SceneCaptureType.cs
+++ b/src/UglyToad.PdfPig/Images/Jpg/Parts/Exif/ExifTypes/SceneCaptureType.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Text;
+
+namespace UglyToad.PdfPig.Images.Jpg.Parts.ExifTypes
+{
+    internal enum SceneCaptureType
+    {
+        Standard = 0,
+        Landscape = 1,
+        Portrait = 2,
+        Night = 3,
+        Other = 4
+    }
+}

--- a/src/UglyToad.PdfPig/Images/Jpg/Parts/Exif/ExifTypes/SceneType.cs
+++ b/src/UglyToad.PdfPig/Images/Jpg/Parts/Exif/ExifTypes/SceneType.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Text;
+
+namespace UglyToad.PdfPig.Images.Jpg.Parts.ExifTypes
+{
+    internal enum SceneType
+    {
+        [Description("Directly Photographed")]
+        DirectlyPhotographed = '1'
+    }
+}

--- a/src/UglyToad.PdfPig/Images/Jpg/Parts/Exif/ExifTypes/SecurityClassification.cs
+++ b/src/UglyToad.PdfPig/Images/Jpg/Parts/Exif/ExifTypes/SecurityClassification.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Text;
+
+namespace UglyToad.PdfPig.Images.Jpg.Parts.ExifTypes
+{
+    internal enum SecurityClassification
+    {
+        Confidential = 'C',
+        Restricted = 'R',
+        Secret = 'S',
+        [Description("Top Secret")]
+        TopSecret = 'T',
+        Unclassified = 'U'
+    }
+}

--- a/src/UglyToad.PdfPig/Images/Jpg/Parts/Exif/ExifTypes/SensingMethod.cs
+++ b/src/UglyToad.PdfPig/Images/Jpg/Parts/Exif/ExifTypes/SensingMethod.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Text;
+
+namespace UglyToad.PdfPig.Images.Jpg.Parts.ExifTypes
+{
+    internal enum SensingMethod
+    {
+        [Description("Monochrome area")]
+        MonochromeArea = 1,
+        [Description("One-chip color area")]
+        OneChipColorArea = 2,
+        [Description("Two-chip color area")]
+        TwoChipColorArea = 3,
+        [Description("Three-chip color area")]
+        ThreeChipColorArea = 4,
+        [Description("Color sequential area")]
+        ColorSequentialArea = 5,
+        [Description("Monochrome linear")]
+        MonochromeLinear = 6,
+        Trilinear = 7,
+        [Description("Color sequential linear")]
+        ColorSequentialLinear = 8,
+
+    }
+}

--- a/src/UglyToad.PdfPig/Images/Jpg/Parts/Exif/ExifTypes/Sharpness.cs
+++ b/src/UglyToad.PdfPig/Images/Jpg/Parts/Exif/ExifTypes/Sharpness.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Text;
+
+namespace UglyToad.PdfPig.Images.Jpg.Parts.ExifTypes
+{
+    internal enum Sharpness
+    {
+        Normal = 0,
+        Soft = 1,
+        Hard = 2
+    }
+}

--- a/src/UglyToad.PdfPig/Images/Jpg/Parts/Exif/ExifTypes/SubjectDistanceRange.cs
+++ b/src/UglyToad.PdfPig/Images/Jpg/Parts/Exif/ExifTypes/SubjectDistanceRange.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Text;
+
+namespace UglyToad.PdfPig.Images.Jpg.Parts.ExifTypes
+{
+    internal enum SubjectDistanceRange
+    {
+        Unknown = 0,
+        Macro = 1,
+        Close = 2,
+        Distant = 3
+    }
+}

--- a/src/UglyToad.PdfPig/Images/Jpg/Parts/Exif/ExifTypes/WhiteBalance.cs
+++ b/src/UglyToad.PdfPig/Images/Jpg/Parts/Exif/ExifTypes/WhiteBalance.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Text;
+
+namespace UglyToad.PdfPig.Images.Jpg.Parts.ExifTypes
+{
+    internal enum WhiteBalance
+    {
+        Auto = 0,
+        Manual = 1
+    }
+}

--- a/src/UglyToad.PdfPig/Images/Jpg/Parts/Exif/ExifTypes/YCbCrPositioning.cs
+++ b/src/UglyToad.PdfPig/Images/Jpg/Parts/Exif/ExifTypes/YCbCrPositioning.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Text;
+
+namespace UglyToad.PdfPig.Images.Jpg.Parts.ExifTypes
+{
+    internal enum YCbCrPositioning
+    {
+        Centered = 1,
+        Cosited = 2
+    }
+}

--- a/src/UglyToad.PdfPig/Images/Jpg/Parts/Exif/ExifUtils/Utils.cs
+++ b/src/UglyToad.PdfPig/Images/Jpg/Parts/Exif/ExifUtils/Utils.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using PropertyItem = UglyToad.PdfPig.Images.Jpg.Parts.Drawing.PropertyItem;
+namespace UglyToad.PdfPig.Images.Jpg.Parts.ExifUtils
+{
+    class Utils
+    {
+        public static float calcFnumber(PropertyItem property)
+        {
+            return (float)BitConverter.ToInt32(property.Value, 0) / (float)BitConverter.ToInt32(property.Value, 4);
+        }
+        
+        public static float calcShutterSpeedValue(PropertyItem property)
+        {
+            return (float)Math.Pow(2, Math.Abs(((float)BitConverter.ToInt32(property.Value, 0)) / (float)BitConverter.ToInt32(property.Value, 4)));
+        }
+
+        public static DateTime convertDateTime(PropertyItem property, string format)
+        {
+            return DateTime.ParseExact(new ASCIIEncoding().GetString(property.Value), format, System.Globalization.CultureInfo.InvariantCulture);
+        }
+
+        public static int getNumberValueInt32(PropertyItem property, int position = 0)
+        {
+            return BitConverter.ToInt32(property.Value, position);
+        }
+
+        public static short getNumberValueInt16(PropertyItem property, int position = 0)
+        {
+            return BitConverter.ToInt16(property.Value, position);
+        }
+
+        public static long getNumberValueInt64(PropertyItem property, int position = 0)
+        {
+            return BitConverter.ToInt64(property.Value, position);
+        }
+
+        public static float getNumberValueFloat(PropertyItem property, int position = 0)
+        {
+            return BitConverter.ToInt32(property.Value, position);
+        }
+
+        public static string getStringValue(PropertyItem property)
+        {
+            return new ASCIIEncoding().GetString(property.Value);
+        }
+    }
+}

--- a/src/UglyToad.PdfPig/Images/Jpg/Parts/HuffmanTree.cs
+++ b/src/UglyToad.PdfPig/Images/Jpg/Parts/HuffmanTree.cs
@@ -1,0 +1,17 @@
+﻿namespace UglyToad.PdfPig.Images.Jpg.Parts
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Text;
+
+    internal class HuffmanTree
+    {
+        byte[] qtab;
+        private HuffmanTreeNode[] nodes;
+        internal HuffmanTree()
+        {
+            nodes = new HuffmanTreeNode[65536];
+            qtab = new byte[64];                           
+        }
+    }
+}

--- a/src/UglyToad.PdfPig/Images/Jpg/Parts/HuffmanTreeNode.cs
+++ b/src/UglyToad.PdfPig/Images/Jpg/Parts/HuffmanTreeNode.cs
@@ -1,0 +1,12 @@
+﻿namespace UglyToad.PdfPig.Images.Jpg.Parts
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Text;
+
+    internal struct HuffmanTreeNode
+    {
+        public byte bits;
+        public byte code;
+    };
+}

--- a/src/UglyToad.PdfPig/Images/Jpg/Parts/JpegMarker.cs
+++ b/src/UglyToad.PdfPig/Images/Jpg/Parts/JpegMarker.cs
@@ -1,0 +1,403 @@
+﻿namespace UglyToad.PdfPig.Images.Jpg.Parts
+{
+
+    //JPEG ISO/IEC 10918-1 : 1993(E)  Table B.1 Page 36 https://www.w3.org/Graphics/JPEG/itu-t81.pdf
+    // https://github.com/corkami/formats/blob/master/image/jpeg.md
+    // https://github.com/BitMiracle/libjpeg.net/blob/f4b1a86d3ddb8bd45ef47ac993746c85d79401a2/LibJpeg/Classic/JPEG_MARKER.cs
+    // https://github.com/BitMiracle/libjpeg.net
+    internal enum JpegMarker : byte
+    {
+        /// <summary>
+        /// Internal use - marker is not yet known.
+        /// </summary>
+        Unknown = 0x00,
+
+        /// <summary>
+        /// (TEM) For temporary private use in arithmetic coding    
+        /// </summary>
+        TemporaryPrivateUseInArithmeticCoding = 0x01,
+
+        
+
+        #region JPEG 2000
+        /// <summary>
+        /// (SOC) Start of codestream        
+        /// </summary>
+        StartOfCodeStream = 0x4F,
+        /// <summary>
+        /// (SOT) Start of tile
+        /// </summary>
+        StartOfTile = 0x90,
+        /// <summary>
+        /// (SOD) Start of d....(?)
+        /// </summary>
+        StartOfD = 0x93,
+
+        /// (EOC) End of codestream (overlaps EOI) 0xD9
+         
+        /// <summary>
+        /// (SIZ) Image and tile size
+        /// </summary>
+        SizeofTile = 0x51,
+
+        #region Functional Segments
+        /// <summary>
+        /// (COD) Coding Style Default
+        /// </summary>
+        CodingStyleDefault = 0x52,
+        /// <summary>
+        /// (COC) Coding Style Component
+        /// </summary>
+        CodingStyleComponent = 0x53,
+        /// <summary>
+        /// (QCD) Quantization Default
+        /// </summary>
+        QuantizationDefault = 0x5C,
+        /// <summary>
+        /// (QCC) Quantization Component
+        /// </summary>
+        QuantizationComponent = 0x5D,
+        /// <summary>
+        /// (RGN) Region of interest
+        /// </summary>
+        RegionOfInterest = 0x5E,
+        /// <summary>
+        /// (POC) Progression Order Change
+        /// </summary>
+        ProgressionOrderChange = 0x5F,
+        #endregion
+
+        #region pointer segments
+        /// <summary>
+        /// (TLM) Tile-part Lengths
+        /// </summary>
+        TilePartLenths = 0x55,
+        /// <summary>
+        /// (PLM) Packet Length (main header)
+        /// </summary>
+        PacketLengthMainHeader = 0x57,
+        /// <summary>
+        /// (PLT) Packet Length (tile-part header)
+        /// </summary>
+        PacketLengthTilePartHeader = 0x58,
+        /// <summary>
+        /// (PPM) packed packet headers (main header)
+        /// </summary>
+        PacketedPacketHeadersMainHeader = 0x60,
+        /// <summary>
+        /// (PPT) packed packet headers (tile-part header)
+        /// </summary>
+        PacketedPacketHeadersTilePartHeader = 0x61,
+        #endregion
+        #region bitstream internal markers and segments
+        /// <summary>
+        /// (SOP) start of packet
+        /// </summary>
+        StartOfPacket = 0x91,
+        /// <summary>
+        /// (EOP) end of packet header
+        /// </summary>
+        EndOfPacketHeader = 0x92,
+        #endregion
+        #region informational segments
+        /// <summary>
+        /// (CRG) component registration
+        /// </summary>
+        ComponentRegistration = 0x63,
+        /// <summary>
+        /// (COM) comment
+        /// </summary>
+        CommentJpeg2000 = 0x64,
+        /// <summary>
+        /// (CBD) Component bit depth definition
+        /// </summary>
+        ComponentBitDepthDefinition = 0x78,
+        /// <summary>
+        /// (MCT) Multiple Component Transform
+        /// </summary>
+        MultipleComponentTransform = 0x74,
+        /// <summary>
+        /// (MCC) Multiple Component Collection
+        /// </summary>
+        MultipleComponentCollection = 0x75,
+        /// <summary>
+        /// (MCO) Multiple component transformation ordering
+        /// </summary>
+        MultipleComponentTransformationOrdering = 0x77,
+        #endregion
+        #region Part 8: Secure JPEG 2000
+        /// <summary>
+        /// (SEC) SEcured Codestream
+        /// </summary>
+        SecuredCodestream = 0x65,
+        /// <summary>
+        ///  (INSEC) INSEcured Codestream
+        /// </summary>
+        InsecuredCodestream = 0x94,
+        #endregion
+        #region Part 11: JPEG 2000 for Wireless
+        /// <summary>
+        ///  (EPC) Error Protection Capability
+        /// </summary>
+        ErrorProtectionCapability = 0x68,
+        /// <summary>
+        ///  (EPB) Error Protection Block
+        /// </summary>
+        ErrorProtectionBlock = 0x66,
+        /// <summary>
+        ///  (ESD) Error Sensitivity Descriptor
+        /// </summary>
+        ErrorSensitivityDescriptor = 0x67,
+        /// <summary>
+        ///  (RED) Residual Error Descriptor
+        /// </summary>
+        ResidualErrorDescriptor = 0x69,
+        #endregion
+        #endregion
+
+
+        #region Start Of Frame (SOF)      
+        #region Non-differential Huffman
+        /// <summary>
+        /// (SOF0) Start Of Frame markers, non-differential, Huffman coding : Baseline DCT
+        /// Indicates that this is a baseline DCT-based JPEG, and specifies the width, height, number of components, and component subsampling.
+        /// </summary>
+        StartOfFrame0BaselineDctFrame = 0xC0,
+        /// <summary>
+        /// (SOF1) Start Of Frame markers, non-differential, Huffman coding : Extended sequential DCT
+        /// </summary>
+        StartOfFame1BaselineDctExtendedSequentialFrame = 0xC1,
+        /// <summary>
+        /// (SOF2) Start Of Frame markers, non-differential, Huffman coding : Progressive DCT
+        /// </summary>
+        StartOfFrame2ProgressiveDctFrame = 0xC2,
+        /// <summary>
+        /// (SOF3) Start Of Frame markers, non-differential, Huffman coding : Lossless (sequential)
+        /// </summary>
+        StartOfFrame3LosslessSequential = 0xC3,
+        #endregion
+
+        // Note there is no SOF4 - for C4 see DefineHuffmanTable
+
+        #region Differential Huffman coding
+        /// <summary>
+        /// (SOF5) Start Of Frame markers, differential, Huffman coding : Differential sequential DCT        
+        /// </summary>
+        StartOfFrame5DifferentialSequentialDct = 0xC5,
+        /// <summary>
+        /// (SOF6) Start Of Frame markers, differential, Huffman coding : Differential progressive DCT
+        /// </summary>
+        StartOfFrame6DifferentialProgressiveDct = 0xC6,
+        /// <summary>
+        /// (SOF7) Start Of Frame markers, differential, Huffman coding : Differential lossless (sequential)
+        /// </summary>
+        StartOfFrame7DifferentialLosslessSequential = 0xC7,
+        #endregion
+
+        #region Non-differential, arithmetic coding
+        /// <summary>
+        /// (JPG) Start Of Frame markers, non-differential, arithmetic coding: Reserved for JPEG extensions
+        /// </summary>
+        StartOfFrameJpgArithmeticLosslessSequential = 0xC8,
+      
+        /// <summary>
+        /// (SOF9) Start Of Frame markers, non-differential, arithmetic coding: Extended sequential DCT
+        /// </summary>
+        StartOfFrame9ArithmeticDctExtendedSequentialFrame = 0xC9,
+      
+        /// <summary>
+        /// (SOF10) Start Of Frame markers, non-differential, arithmetic coding: Progressive DCT
+        /// </summary>
+        StartOfFrame10ArithmeticProgressiveDctFrame = 0xCA,
+        /// <summary>
+        /// (SOF11) Start Of Frame markers, non-differential, arithmetic coding: Progressive DCT
+        /// </summary>
+        StartOfFrame11ArithmeticLosslessSequential = 0xCB,
+        #endregion
+
+        /// <summary>
+        /// (DHT) Huffman table specification :  Define Huffman table(s)
+        /// Specifies one or more Huffman tables.
+        /// </summary>
+        DefineHuffmanTable = 0xC4,
+        #endregion
+
+        /// <summary>
+        /// (DAC) Arithmetic coding conditioning specification : Define arithmetic coding conditioning(s)
+        /// </summary>
+        ArithmeticCodingConditioningSpecificationrithmeticCodingConditionings = 0xCC,
+
+        #region Reset internval termination
+        /// <summary>
+        /// (RST0) Restart with modulo 8 count “m”
+        /// Inserted every r macroblocks.
+        /// </summary> 
+        Restart0 = 0xD0,
+        /// <summary>
+        /// (RST1) Restart with modulo 8 count “m”
+        /// Inserted every r macroblocks.
+        /// </summary>        
+        Restart1 = 0xD1,
+        /// <summary>
+        /// (RST2) Restart with modulo 8 count “m”
+        /// Inserted every r macroblocks.
+        /// </summary>
+        Restart2 = 0xD2,
+        /// <summary>
+        /// (RST3) Restart with modulo 8 count “m”
+        /// Inserted every r macroblocks.
+        /// </summary>
+        Restart3 = 0xD3,
+        /// <summary>
+        /// (RST4) Restart with modulo 8 count “m”
+        /// Inserted every r macroblocks.
+        /// </summary>
+        Restart4 = 0xD4,
+        /// <summary>
+        /// (RST5) Restart with modulo 8 count “m”
+        /// Inserted every r macroblocks.
+        /// </summary>
+        Restart5 = 0xD5,
+        /// <summary>
+        /// (RST6) Restart with modulo 8 count “m”
+        /// Inserted every r macroblocks.
+        /// </summary>
+        Restart6 = 0xD6,
+        /// <summary>
+        /// (RST7) Restart with modulo 8 count “m”
+        /// Inserted every r macroblocks.
+        /// </summary>
+        Restart7 = 0xD7,
+        #endregion
+
+        #region Other markers
+        /// <summary>
+        /// (SOI) Marks the start of a JPEG image file.
+        /// </summary>
+        StartOfImage = 0xD8,
+        /// <summary>
+        /// (EOI) Marks the end of a JPEG image file.
+        /// </summary>
+        EndOfImage = 0xD9,
+        /// <summary>
+        /// (SOS) Start of scan
+        /// Begins a top-to-bottom scan of the image. In baseline images, there is generally a single scan.
+        /// Progressive images usually contain multiple scans. 
+        /// </summary>
+        StartOfScan = 0xDA,
+        /// <summary> 
+        /// (DQT) Define quantization table(s)
+        /// Specifies one or more quantization tables. 
+        /// </summary>
+        DefineQuantizationTable = 0xDB,
+        /// <summary>
+        /// (DNL) Define number of lines                
+        /// </summary>
+        DefineNumberOfLines = 0xDC,
+        /// <summary>
+        /// (DRI) Define restart interval
+        /// Specifies the interval between RSTn markers, in Minimum Coded Units (MCUs).
+        /// This marker is followed by two bytes indicating the fixed size so it can be treated like any other variable size segment.
+        /// </summary>
+        DefineRestartInterval = 0xDD,
+        /// <summary>
+        /// (DHP) Define hierarchical progression        
+        /// </summary>
+        DefineHierarchicalProgression = 0xDE,
+        /// <summary>
+        /// (EXP) Expand reference component(s)      
+        /// </summary>
+        ExpandReferenceComponents = 0xDF,
+
+        #region Application Specific
+        /// <summary>
+        /// (App0) JFIF (len >=14) / JFXX (len >= 6) / AVI MJPEG
+        /// </summary>
+        ApplicationSpecific0 = 0xE0,
+        /// <summary>
+        /// (App1) EXIF/XMP/XAP
+        /// </summary>
+        ApplicationSpecific1 = 0xE1,
+        /// <summary>
+        /// (App2) FlashPix 
+        /// </summary>
+        ApplicationSpecific2 = 0xE2,
+        /// <summary>
+        /// (App4) Kodak
+        /// </summary>
+        ApplicationSpecific3 = 0xE3,
+        /// <summary>
+        /// (App4) FlashPix
+        /// </summary>
+        ApplicationSpecific4 = 0xE4,
+        /// <summary>
+        /// (App5) Ricoh
+        /// </summary>
+        ApplicationSpecific5 = 0xE5,
+        /// <summary>
+        /// (App6) GoPro
+        /// </summary>
+        ApplicationSpecific6 = 0xE6,
+        /// <summary>
+        /// (App7) Pentax/Qualcomm
+        /// </summary>
+        ApplicationSpecific7 = 0xE7,
+        /// <summary>
+        /// (App8) Spiff
+        /// </summary>
+        ApplicationSpecific8 = 0xE8,
+        /// <summary>
+        /// (App9) MediaJukebox
+        /// </summary>
+        ApplicationSpecific9 = 0xE9,
+        /// <summary>
+        /// (App10) PhotoStudio
+        /// </summary>
+        ApplicationSpecific10 = 0xEA,
+        /// <summary>
+        /// (App11) HDR
+        /// </summary>
+        ApplicationSpecific11 = 0xEB,
+        /// <summary>
+        /// (App12) (photoshoP ducky / savE foR web
+        /// </summary>
+        ApplicationSpecific12 = 0xEC,
+        /// <summary>
+        /// (App13) photoshoP savE As
+        /// </summary>
+        ApplicationSpecific13 = 0xED,
+        /// <summary>
+        /// (App14) Application segment 14 ("adobe" (length = 12))
+        /// </summary>
+        ApplicationSpecific14 = 0xEE,
+        ApplicationSpecific15 = 0xEF,
+        #endregion
+        #region Reserved for JPEG extensions
+        JpgExtensions0 = 0xF0,
+        JpgExtensions1 = 0xF1,
+        JpgExtensions2 = 0xF2,
+        JpgExtensions3 = 0xF3,
+        JpgExtensions4 = 0xF4,
+        JpgExtensions5 = 0xF5,
+        JpgExtensions6 = 0xF6,
+        JpgExtensions7 = 0xF7, // JPEG-LS  SOF48
+        JpgExtensions8 = 0xF8, // JPEG-LS  LSE
+        JpgExtensions9 = 0xF9,
+        JpgExtensions10 = 0xFA,
+        JpgExtensions11 = 0xFB,
+        JpgExtensions12 = 0xFC,
+        JpgExtensions13 = 0xFD,
+        JpgExtensions14 = 0xFE,
+        JpgExtensions15 = 0xFF,
+        #endregion
+
+        /// <summary>
+        /// Marks a text comment.
+        /// </summary>
+        Comment = 0xFE
+        #endregion
+
+    }
+
+  
+}

--- a/src/UglyToad.PdfPig/Images/Jpg/Parts/StartOfFrame0BaselineDCT.cs
+++ b/src/UglyToad.PdfPig/Images/Jpg/Parts/StartOfFrame0BaselineDCT.cs
@@ -1,0 +1,193 @@
+﻿namespace UglyToad.PdfPig.Images.Jpg.Parts
+{
+    using System;
+    using System.Diagnostics;
+    using System.IO;
+    using ContextForSOF0 = Helpers.Context.ContextForSOF0;
+ 
+    internal static class StartOfFrame0BaselineDCT
+    {
+        internal static void ParseSof0(JpgBinaryStreamReader reader, ContextForSOF0 context)
+        {
+            int Width;
+            int Height;
+            int NumberOfComponents;
+            Component[] Components;
+
+            // Lf: Frame header length (16 bits)   Possible Values: 8 + 3 × Nf
+            // Specifies the length of the frame header
+            var frameHeader = reader.DecodeFrameHeader(); // Get Length
+
+            if (frameHeader.remaining < 9) { throw new Exception(); }
+
+
+            // P: Sample precision  (8 bits) Possible Values: 8 (DCT Baseline) 8 or 12 (DCT Ext) 8 or 12 (Progressive DCT) 2-16 (Lossless)
+            // Specifies the precision in bits for the samples of the components in the frame.
+            var p = frameHeader.ReadByte();
+#if DEBUG
+            UglyToad.PdfPig.Images.Jpg.Jpg.precision = p;
+#endif
+            if (p != 8) { throw new NotImplementedException("Only 8 bit precision is supported."); }
+
+
+            // Y : Number of lines (16 bits)  Possible Values: 0-65 535
+            // Specifies the maximum number of lines in the source image. This shall be equal to the
+            // number of lines in the component with the maximum number of vertical samples. Value 0 indicates
+            // that the number of lines shall be defined by the DNL marker and parameters at the end of the first scan
+            Height = frameHeader.ReadInt16BE();
+            if (Height > 5000) { Debug.WriteLine($"Warning: Jpg Height > 5000."); }
+            if (Height <= 0 ) { throw new InvalidDataException($"Jpg Height: {Height}. Expected: >0"); }
+
+            // X: Number of samples per line (16 bits) Possible Values:  1-65 535
+            // Specifies the maximum number of samples per line in the source image. This
+            // shall be equal to the number of samples per line in the component with the maximum number of horizontal
+            // samples
+            Width = frameHeader.ReadInt16BE();
+            if (Width > 5000) { Debug.WriteLine($"Warning: Jpg Width > 5000."); }
+            if (Width <= 0) { throw new InvalidDataException($"Jpg Width: {Width}. Expected: >0"); }
+
+            // Nf : Number of image components in frame (8 bits) Possible values (as per spec): 1-255 (Baseline DCT)
+            // Specifies the number of source image components in the frame.
+            // The value of Nf shall be equal to the number of sets of frame component specification parameters(Ci, Hi, Vi,
+            // and Tqi) present in the frame header.
+            NumberOfComponents = frameHeader.ReadByte();
+            switch (NumberOfComponents)
+            {
+                case 1:
+                case 3: break;
+                case 4: throw new NotImplementedException("Warning: Support for 4 component Jpg decode not yet implemented.");
+                default:
+                    throw new NotImplementedException($"Error: Jpg Number of Components is {NumberOfComponents}. Expected: 1, 3 or 4.");
+            }
+
+            if (frameHeader.remaining < 3 * NumberOfComponents) { throw new NotImplementedException(); }
+
+            Components = new Component[3] { new Component(), new Component(), new Component() };
+
+            int MaxHSF = 0;
+            int MaxVSF = 0;
+            int qtused = 0;
+            for (int i = 0; i < NumberOfComponents; i++)
+            {
+                var component = Components[i];
+
+                // Ci: Component identifier (8 bit) Possible Values: 0-255
+                // Assigns a unique label to the ith component in the sequence of frame component
+                // specification parameters. These values shall be used in the scan headers to identify the components in the scan.
+                // The value of Ci shall be different from the values of C1 through Ci − 1.
+                component.cid = frameHeader.ReadByte();
+
+                // Hi: Horizontal sampling factor (HSF)  (4 bits) Possible Values: 1-4
+                // Specifies the relationship between the component horizontal dimension
+                // and maximum image dimension X; also specifies the number of horizontal data units of component
+                // Ci in each MCU, when more than one component is encoded in a scan.
+
+                // Vi: Vertical sampling factor (VSF)    (4 bits) Possible Values: 1-4
+                // Specifies the relationship between the component vertical dimension and
+                // maximum image dimension Y; also specifies the number of vertical data units of component Ci in
+                // each MCU, when more than one component is encoded in a scan.
+                {
+                    var value = frameHeader.ReadByte();
+                    component.HSF = value >> 4;
+                    if (component.HSF == 0) { throw new Exception(); }
+                    if ((component.HSF & (component.HSF - 1)) != 0) { throw new Exception(); } // not a power of two
+                    component.VSF = value & 15;
+                    if ((component.VSF & (component.VSF - 1)) != 0) { throw new Exception(); }  // not a power of two
+                }
+
+                // Tqi: Quantization table destination selector (8 bits) Possible Values: 0-3
+                // Specifies one of four possible quantization table destinations
+                // from which the quantization table to use for dequantization of DCT coefficients of component Ci is retrieved.If
+                // the decoding process uses the dequantization procedure, this table shall have been installed in this destination
+                // by the time the decoder is ready to decode the scan(s) containing component Ci.The destination shall not be respecified, or its contents changed, until all scans containing Ci have been completed.
+                {
+                    var value = frameHeader.ReadByte();
+                    if ((value & 0xFC) != 0) { throw new Exception(); } // Value is not 0, 1, 2 or 3
+                    component.qtsel = value;
+                }
+
+                qtused |= 1 << component.qtsel;
+                if (component.HSF > MaxHSF) { MaxHSF = component.HSF; }
+                if (component.VSF > MaxVSF) { MaxVSF = component.VSF; }
+            }
+            if (NumberOfComponents == 1)
+            {
+                var component = Components[0];
+                component.HSF = 1;
+                component.VSF = 1;
+                MaxHSF = 1;
+                MaxVSF = 1;
+            }
+
+
+            int mbwidth, mbheight;
+            int mbsizex, mbsizey;
+
+            mbsizex = MaxHSF << 3;
+            mbsizey = MaxVSF << 3;
+            mbwidth = (Width + mbsizex - 1) / mbsizex;
+            mbheight = (Height + mbsizey - 1) / mbsizey;
+
+            for (int i = 0; i < NumberOfComponents; i++)
+            {
+                var component = Components[i];
+                component.width = (Width * component.HSF + MaxHSF - 1) / MaxHSF;
+                var StrideCalc1 = (component.width + 7) & 0x7FFFFFF8;
+                component.height = (Height * component.VSF + MaxVSF - 1) / MaxVSF;
+                var StrideCalc2 = mbwidth * mbsizex * component.HSF / MaxHSF;
+                var StrideCalc3 = mbwidth * component.HSF << 3;
+                 
+                if (StrideCalc1 != StrideCalc2) { Debug.WriteLine($"Alt stride calc: {StrideCalc1} vs {StrideCalc2} vs {StrideCalc3}. Going with #3"); }
+                component.stride = StrideCalc3;
+                if (((component.width < 3) && (component.HSF != MaxHSF)) ||
+                    ((component.height < 3) && (component.VSF != MaxVSF)))
+                {
+                    Debug.WriteLine($"component.width: {component.width} component.height: {component.height} component.HSF: {component.HSF} component.VSF: {component.VSF} MaxHSF: {MaxHSF} MaxVSF: {MaxVSF}");
+
+                    var output = string.Empty;
+                    if (component.width < 3)
+                    {
+                        if (component.HSF != MaxHSF) { output += $"component.HSF ({component.HSF}) != MaxHSF ({MaxHSF})"; }
+                    }
+                    if (component.height < 3)
+                    {
+                        if (component.VSF != MaxVSF) { output += $"component.VSF ({component.VSF}) != MaxVSF ({MaxVSF})"; }
+                    }
+                    Debug.WriteLine(output);
+                    throw new Exception(output);
+                }
+
+                component.pixels = new byte[component.stride * (mbheight * mbsizey * component.VSF / MaxVSF)];
+                if (component.pixels is null)
+                {
+                    throw new OutOfMemoryException();
+                }
+            }
+            byte[] rgb = null;
+            if (NumberOfComponents == 3)
+            {
+                rgb = new byte[Width * Height * NumberOfComponents];
+                if (rgb is null)
+                {
+                    throw new OutOfMemoryException();
+                }
+            }
+
+            context.width = Width;
+            context.height = Height;
+            context.comp = Components;
+            context.ncomp = NumberOfComponents;
+
+            context.rgb = rgb;
+            
+            context.mbwidth = mbwidth;
+            context.mbheight = mbheight;
+
+            context.mbsizex = mbsizex;
+            context.mbsizey = mbsizey;
+
+            context.qtused = qtused;
+        }
+
+    }
+}

--- a/src/UglyToad.PdfPig/Images/Jpg/Parts/StartOfFrame2ProgressDctFrame.cs
+++ b/src/UglyToad.PdfPig/Images/Jpg/Parts/StartOfFrame2ProgressDctFrame.cs
@@ -1,0 +1,178 @@
+﻿namespace UglyToad.PdfPig.Images.Jpg.Parts
+{
+    using System;
+    using System.Diagnostics;
+    using System.IO;
+    using ContextForSOF0 = Helpers.Context.ContextForSOF0;
+ 
+    internal static class StartOfFrame2ProgressDctFrame
+    {
+        internal static void ParseSof2(JpgBinaryStreamReader reader, ContextForSOF0 context)
+        {
+            throw new NotImplementedException("ProgressDct not yet implemented.");
+#if WIP_2023_03_23_COPY_OF_SOF1_ONLY_TO_BE_UPDATED
+            int Width;
+            int Height;
+            int NumberOfComponents;
+            Component[] Components;
+
+            // Lf: Frame header length (16 bits)   Possible Values: 8 + 3 × Nf
+            // Specifies the length of the frame header
+            var frameHeader = reader.DecodeFrameHeader(); // Get Length
+
+            if (frameHeader.remaining < 9) { throw new Exception(); }
+
+
+            // P: Sample precision  (8 bits) Possible Values: 8 (DCT Baseline) 8 or 12 (DCT Ext) 8 or 12 (Progressive DCT) 2-16 (Lossless)
+            // Specifies the precision in bits for the samples of the components in the frame.
+            var p = frameHeader.ReadByte();
+            if (p != 8) { throw new NotImplementedException(); }
+
+            // Y : Number of lines (16 bits)  Possible Values: 0-65 535
+            // Specifies the maximum number of lines in the source image. This shall be equal to the
+            // number of lines in the component with the maximum number of vertical samples. Value 0 indicates
+            // that the number of lines shall be defined by the DNL marker and parameters at the end of the first scan
+            Height = frameHeader.ReadInt16BE();
+            if (Height>5000) { Debug.WriteLine($"Warning: Jpg Height > 5000."); }
+            if (Height <= 0 ) { throw new InvalidDataException($"Jpg Height: {Height}. Expected: >0"); }
+
+            // X: Number of samples per line (16 bits) Possible Values:  1-65 535
+            // Specifies the maximum number of samples per line in the source image. This
+            // shall be equal to the number of samples per line in the component with the maximum number of horizontal
+            // samples
+            Width = frameHeader.ReadInt16BE();
+            if (Width > 5000) { Debug.WriteLine($"Warning: Jpg Width > 5000."); }
+            if (Width <= 0) { throw new InvalidDataException($"Jpg Width: {Width}. Expected: >0"); }
+
+            // Nf : Number of image components in frame (8 bits) Possible values (as per spec): 1-255 (Baseline DCT)
+            // Specifies the number of source image components in the frame.
+            // The value of Nf shall be equal to the number of sets of frame component specification parameters(Ci, Hi, Vi,
+            // and Tqi) present in the frame header.
+            NumberOfComponents = frameHeader.ReadByte();
+            switch (NumberOfComponents)
+            {
+                case 1:
+                case 3: break;
+                case 4: throw new NotImplementedException("Warning: Support for 4 component Jpg decode not yet implemented.");
+                default:
+                    throw new NotImplementedException($"Error: Jpg Number of Components is {NumberOfComponents}. Expected: 1, 3 or 4.");
+            }
+
+            if (frameHeader.remaining < 3 * NumberOfComponents) { throw new NotImplementedException(); }
+
+            Components = new Component[3] { new Component(), new Component(), new Component() };
+
+            int MaxHSF = 0;
+            int MaxVSF = 0;
+            int qtused = 0;
+            for (int i = 0; i < NumberOfComponents; i++)
+            {
+                var component = Components[i];
+
+                // Ci: Component identifier (8 bit) Possible Values: 0-255
+                // Assigns a unique label to the ith component in the sequence of frame component
+                // specification parameters. These values shall be used in the scan headers to identify the components in the scan.
+                // The value of Ci shall be different from the values of C1 through Ci − 1.
+                component.cid = frameHeader.ReadByte();
+
+                // Hi: Horizontal sampling factor (HSF)  (4 bits) Possible Values: 1-4
+                // Specifies the relationship between the component horizontal dimension
+                // and maximum image dimension X; also specifies the number of horizontal data units of component
+                // Ci in each MCU, when more than one component is encoded in a scan.
+
+                // Vi: Vertical sampling factor (VSF)    (4 bits) Possible Values: 1-4
+                // Specifies the relationship between the component vertical dimension and
+                // maximum image dimension Y; also specifies the number of vertical data units of component Ci in
+                // each MCU, when more than one component is encoded in a scan.
+                {
+                    var value = frameHeader.ReadByte();
+                    component.HSF = value >> 4;
+                    if (component.HSF == 0) { throw new Exception(); }
+                    if ((component.HSF & (component.HSF - 1)) != 0) { throw new Exception(); } // not a power of two
+                    component.VSF = value & 15;
+                    if ((component.VSF & (component.VSF - 1)) != 0) { throw new Exception(); }  // not a power of two
+                }
+
+                // Tqi: Quantization table destination selector (8 bits) Possible Values: 0-3
+                // Specifies one of four possible quantization table destinations
+                // from which the quantization table to use for dequantization of DCT coefficients of component Ci is retrieved.If
+                // the decoding process uses the dequantization procedure, this table shall have been installed in this destination
+                // by the time the decoder is ready to decode the scan(s) containing component Ci.The destination shall not be respecified, or its contents changed, until all scans containing Ci have been completed.
+                {
+                    var value = frameHeader.ReadByte();
+                    if ((value & 0xFC) != 0) { throw new Exception(); } // Value is not 0, 1, 2 or 3
+                    component.qtsel = value;
+                }
+
+                qtused |= 1 << component.qtsel;
+                if (component.HSF > MaxHSF) { MaxHSF = component.HSF; }
+                if (component.VSF > MaxVSF) { MaxVSF = component.VSF; }
+            }
+            if (NumberOfComponents == 1)
+            {
+                var component = Components[0];
+                component.HSF = 1;
+                component.VSF = 1;
+                MaxHSF = 1;
+                MaxVSF = 1;
+            }
+
+
+            int mbwidth, mbheight;
+            int mbsizex, mbsizey;
+
+            mbsizex = MaxHSF << 3;
+            mbsizey = MaxVSF << 3;
+            mbwidth = (Width + mbsizex - 1) / mbsizex;
+            mbheight = (Height + mbsizey - 1) / mbsizey;
+
+            for (int i = 0; i < NumberOfComponents; i++)
+            {
+                var component = Components[i];
+                component.width = (Width * component.HSF + MaxHSF - 1) / MaxHSF;
+                var strideByWidth = (component.width + 7) & 0x7FFFFFF8;
+                component.height = (Height * component.VSF + MaxVSF - 1) / MaxVSF;
+                var altStrideCalc = mbwidth * mbsizex * component.HSF / MaxHSF;
+                if (strideByWidth != altStrideCalc) { throw new Exception(); }
+                component.stride = strideByWidth;
+                if (((component.width < 3) && (component.HSF != MaxHSF)) ||
+                    ((component.height < 3) && (component.VSF != MaxVSF)))
+                {
+                    throw new Exception();
+                }
+
+                component.pixels = new byte[component.stride * (mbheight * mbsizey * component.VSF / MaxVSF)];
+                if (component.pixels is null)
+                {
+                    throw new OutOfMemoryException();
+                }
+            }
+            byte[] rgb = null;
+            if (NumberOfComponents == 3)
+            {
+                rgb = new byte[Width * Height * NumberOfComponents];
+                if (rgb is null)
+                {
+                    throw new OutOfMemoryException();
+                }
+            }
+
+            context.width = Width;
+            context.height = Height;
+            context.comp = Components;
+            context.ncomp = NumberOfComponents;
+
+            context.rgb = rgb;
+            
+            context.mbwidth = mbwidth;
+            context.mbheight = mbheight;
+
+            context.mbsizex = mbsizex;
+            context.mbsizey = mbsizey;
+
+            context.qtused = qtused;
+#endif
+        }
+
+    }
+}

--- a/src/UglyToad.PdfPig/Images/Jpg/Parts/StartOfFrame2ProgressDctFrame.cs
+++ b/src/UglyToad.PdfPig/Images/Jpg/Parts/StartOfFrame2ProgressDctFrame.cs
@@ -10,7 +10,7 @@
         internal static void ParseSof2(JpgBinaryStreamReader reader, ContextForSOF0 context)
         {
             throw new NotImplementedException("ProgressDct not yet implemented.");
-#if WIP_2023_03_23_COPY_OF_SOF1_ONLY_TO_BE_UPDATED
+#if WIP_2023_03_23_COPY_OF_SOF0_ONLY_TO_BE_UPDATED
             int Width;
             int Height;
             int NumberOfComponents;

--- a/src/UglyToad.PdfPig/Images/Jpg/Parts/StartOfScan.cs
+++ b/src/UglyToad.PdfPig/Images/Jpg/Parts/StartOfScan.cs
@@ -1,0 +1,340 @@
+﻿namespace UglyToad.PdfPig.Images.Jpg.Parts
+{
+    using System;
+    using ContextForStartOfScan = Helpers.Context.ContextForStartOfScan;
+    using BitReader = Helpers.BitReader;
+    using System.Diagnostics;
+    using System.Drawing;
+
+    internal static class StartOfScan
+    {
+         
+        internal static void ParseSos(JpgBinaryStreamReader reader, ContextForStartOfScan contextForStartOfScan) 
+        {
+            var components = contextForStartOfScan.comp;
+            var vlctab = contextForStartOfScan.vlctab;
+            var rstinterval = contextForStartOfScan.rstinterval;
+            var qtab = contextForStartOfScan.qtab;
+
+#if DEBUG
+            var isOnDebug = UglyToad.PdfPig.Images.Jpg.Jpg.isOnDebug;
+            if (isOnDebug) { Debug.WriteLine($"StartOfScan {reader.BaseStream.Position}"); }
+#endif
+
+            var frameHeader = reader.DecodeFrameHeader();
+                 
+            // Ns: Number of image components in scan
+            // Specifies the number of source image components in the scan. The
+            // value of Ns shall be equal to the number of sets of scan component specification parameters(Csj, Tdj, and Taj)
+            // present in the scan header.
+            var Ns = frameHeader.ReadByte();
+            var NumberOfComponents = contextForStartOfScan.ncomp;
+            if (frameHeader.length < (4 + 2 * NumberOfComponents)) { throw new Exception(); } // Syntax
+            if (Ns != NumberOfComponents) { throw new Exception(); } // Unsupported
+
+
+            for (int i = 0; i < NumberOfComponents; i++)
+            {
+                var component = components[i];
+
+                // Csj: Scan component selector (8 bits) Possible Values: Ci values in frame headers
+                // Selects which of the Nf image components specified in the frame parameters
+                // shall be the jth component in the scan. 
+                var Csj = frameHeader.ReadByte();
+                if (Csj != component.cid) { throw new Exception(); } // Syntax
+
+                // Entropy Coding Table Destination Select (ECTD) (8 bits - 2 x 4 bit values : Tdj and Taj)
+
+                // Tdj: DC entropy coding table destination selector (4 bits) Possible Values: 0 or 1 (Baseline DCT)
+                // Specifies one of four possible DC entropy coding table
+                // destinations from which the entropy table needed for decoding of the DC coefficients of component Csj is
+                // retrieved.The DC entropy table shall have been installed in this destination(see B.2.4.2 and B.2.4.3) by the
+                // time the decoder is ready to decode the current scan.
+                // This parameter specifies the entropy coding table destination for the lossless processes.
+
+                // Taj: AC entropy coding table destination selector Possible Values: 0 or 1 (Baseline DCT)
+                // Specifies one of four possible AC entropy coding table
+                // destinations from which the entropy table needed for decoding of the AC coefficients of component Csj is
+                // retrieved.The AC entropy table selected shall have been installed in this destination(see B.2.4.2 and B.2.4.3)
+                // by the time the decoder is ready to decode the current scan.
+                // This parameter is zero for the lossless processes.
+                var ECTD = frameHeader.ReadByte();
+                if ((ECTD & 0xEE) != 0) { throw new Exception(); } // Syntax
+                component.dctabsel = ECTD >> 4;
+                component.actabsel = (ECTD & 1) | 2;
+            }
+
+            // Ss: Start of spectral or predictor selection (8 bits) Possible Values: 0 (Baseline DCT)
+            // In the DCT modes of operation, this parameter specifies the first
+            // DCT coefficient in each block in zig - zag order which shall be coded in the scan. This parameter shall be set to
+            // zero for the sequential DCT processes. In the lossless mode of operations this parameter is used to select the
+            //predictor.
+            var Ss = frameHeader.ReadByte();
+            if (Ss != 0) { throw new Exception(); } // Syntax
+
+            // Se: End of spectral selection (8 bits) Possible Values: 63  (Baseline DCT)
+            // Specifies the last DCT coefficient in each block in zig-zag order which shall be
+            // coded in the scan. This parameter shall be set to 63 for the sequential DCT processes. In the lossless mode of
+            // operations this parameter has no meaning.It shall be set to zero.
+            var Se = frameHeader.ReadByte();
+            if (Se != 63) { throw new Exception(); } // Syntax
+
+            // Approximation bit position  (ABP) (8 bits - 2 x 4 bit values : Ah and Al) Possible Values: 0 (Baseline DCT)
+
+            // Ah: Successive approximation bit position high
+            // This parameter specifies the point transform used in the
+            // preceding scan(i.e.successive approximation bit position low in the preceding scan) for the band of coefficients
+            // specified by Ss and Se.This parameter shall be set to zero for the first scan of each band of coefficients. In the
+            // lossless mode of operations this parameter has no meaning.It shall be set to zero.
+
+            // Al: Successive approximation bit position low or point transform
+            // In the DCT modes of operation this
+            // parameter specifies the point transform, i.e.bit position low, used before coding the band of coefficients
+            // specified by Ss and Se. This parameter shall be set to zero for the seq
+            var ABP = frameHeader.ReadByte();
+            if (ABP != 0) { throw new Exception(); } // Syntax
+
+            frameHeader.Skip(frameHeader.remaining); // pos: 323  length: 3
+            // pos: 326 length: 0
+            int mbx = 0;
+            int mby = 0;
+            var rstcount = rstinterval;
+            int nextrst = 0;
+            int[] block = new int[64];
+            var bitreader = new BitReader(reader.BaseStream);
+            while (true)
+            {
+                for (var i = 0; i < NumberOfComponents; ++i)  
+                {
+                    var component = components[i];
+                    for (var sby = 0; sby < component.VSF; ++sby)  
+                    {
+                        for (var sbx = 0; sbx < component.HSF; ++sbx) 
+                        {                             
+                            var value = ((mby * component.VSF + sby) * component.stride + mbx * component.HSF + sbx) << 3;
+                            var isSuccess = DecodeBlock(bitreader, component, value, vlctab, qtab,ref block);
+                            if (isSuccess == false) { throw new Exception(); }
+                        }
+                    }
+                }
+                if (++mbx >= contextForStartOfScan.mbwidth)
+                {
+                    mbx = 0;
+                    if (++mby >= contextForStartOfScan.mbheight)
+                    {
+                        break;
+                    }
+                }
+                
+                if (rstinterval != 0 && (--rstcount) == 0)
+                {
+#if DEBUG
+                    UglyToad.PdfPig.Images.Jpg.Jpg.hasRestart = true;
+                    //Debug.WriteLine($"RestartInterval position: {reader.BaseStream.Position}");
+#endif
+
+                    bitreader.Align();
+                    var i = bitreader.Read(16);
+                    //Debug.WriteLine($"RestartInterval i: {i}");
+                    if (((i & 0xFFF8) != 0xFFD0) || ((i & 7) != nextrst)) { throw new Exception(); } // SYNTAX
+                    nextrst = (nextrst + 1) & 7;
+                    rstcount = contextForStartOfScan.rstinterval;
+                    //Debug.WriteLine($"RestartInterval {rstcount}");
+                    for (i = 0; i < components.Length; ++i)
+                    {
+                        components[i].dcpred = 0;
+                    }
+                }
+                 
+            }
+
+
+        }
+
+        public static readonly byte[] ZZSeq = Helpers.JpgNaturalOrder.ZigZagSequenceOfQuantizedDCTCoefficients;
+         
+
+        private static bool DecodeBlock(BitReader reader, Component component, int outv, HuffmanTreeNode[][] vlctab, byte[][]qtab, ref int[]block)
+        { 
+
+            byte discard = 0;
+            byte code = 0;
+            int value, coef = 0;
+            block = new int[64];
+            var details = GetVariableLengthCode(reader, vlctab[component.dctabsel], ref discard);
+            component.dcpred += details.value;
+            block[0] = (component.dcpred) * qtab[component.qtsel][0];
+  
+            do
+            {
+                (value, var isSuccess) = GetVariableLengthCode(reader,vlctab[component.actabsel], ref code);
+
+                if (code == 0) { break; }  // EOB
+                if ((code & 0x0F) == 0 && (code != 0xF0)) { throw new Exception(); } //SYNTAX
+                coef += (code >> 4) + 1;
+
+                if (coef > 63) { throw new Exception($"Jpg DecodeBlock expected coef <= 63. Got: {coef}."); } //SYNTAX
+                block[(int)ZZSeq[coef]] = value * qtab[component.qtsel][coef];
+                 
+            } while (coef < 63);
+            for (coef = 0; coef < 64; coef += 8)
+            {
+                GetRowIDCT(block, coef);
+            }
+            for (coef = 0; coef < 8; ++coef)
+            {
+                GetColIDCT(block, coef, component.pixels, outv + coef, component.stride);
+            }
+            return true;
+        }
+         
+
+        public static readonly int W1 = 2841;
+        public static readonly int W2 = 2676;
+        public static readonly int W3 = 2408;
+        public static readonly int W5 = 1609;
+        public static readonly int W6 = 1108;
+        public static readonly int W7 = 565;
+        public static void GetRowIDCT(int[] blk, int coef)
+        {            
+            int x0, x1, x2, x3, x4, x5, x6, x7, x8;
+            if (((x1 = blk[coef + 4] << 11)
+                | (x2 = blk[coef + 6])
+                | (x3 = blk[coef + 2])
+                | (x4 = blk[coef + 1])
+                | (x5 = blk[coef + 7])
+                | (x6 = blk[coef + 5])
+                | (x7 = blk[coef + 3])) == 0)
+            {
+                
+                blk[coef] = blk[coef + 1] = blk[coef + 2] = blk[coef + 3] = blk[coef + 4] = blk[coef + 5] = blk[coef + 6] = blk[coef + 7] = blk[coef] << 3;
+                 
+                return;
+            }
+            x0 = (blk[coef] << 11) + 128;
+            x8 = W7 * (x4 + x5);
+            x4 = x8 + (W1 - W7) * x4;
+            x5 = x8 - (W1 + W7) * x5;
+            x8 = W3 * (x6 + x7);
+            x6 = x8 - (W3 - W5) * x6;
+            x7 = x8 - (W3 + W5) * x7;
+            x8 = x0 + x1;
+            x0 -= x1;
+            x1 = W6 * (x3 + x2);
+            x2 = x1 - (W2 + W6) * x2;
+            x3 = x1 + (W2 - W6) * x3;
+            x1 = x4 + x6;
+            x4 -= x6;
+            x6 = x5 + x7;
+            x5 -= x7;
+            x7 = x8 + x3;
+            x8 -= x3;
+            x3 = x0 + x2;
+            x0 -= x2;
+            x2 = (181 * (x4 + x5) + 128) >> 8;
+            x4 = (181 * (x4 - x5) + 128) >> 8;
+            blk[coef] = (x7 + x1) >> 8;
+            blk[coef + 1] = (x3 + x2) >> 8;
+            blk[coef + 2] = (x0 + x4) >> 8;
+            blk[coef + 3] = (x8 + x6) >> 8;
+            blk[coef + 4] = (x8 - x6) >> 8;
+            blk[coef + 5] = (x0 - x4) >> 8;
+            blk[coef + 6] = (x3 - x2) >> 8;
+            blk[coef + 7] = (x7 - x1) >> 8;             
+        }
+
+
+        public static void GetColIDCT(int[] blk, int coef, byte[] pixels, int outv, int stride)
+        {
+            int x0, x1, x2, x3, x4, x5, x6, x7, x8;
+            if (((x1 = blk[coef + 8 * 4] << 8)
+                | (x2 = blk[coef + 8 * 6])
+                | (x3 = blk[coef + 8 * 2])
+                | (x4 = blk[coef + 8 * 1])
+                | (x5 = blk[coef + 8 * 7])
+                | (x6 = blk[coef + 8 * 5])
+                | (x7 = blk[coef + 8 * 3])) == 0)
+            {
+                x1 = Clip(((blk[coef] + 32) >> 6) + 128);
+                for (x0 = 8; x0 != 0; --x0)
+                {
+                    pixels[outv] = (byte)x1;
+                    outv += stride;
+                }
+                return;
+            }
+            x0 = (blk[coef] << 8) + 8192;
+            x8 = W7 * (x4 + x5) + 4;
+            x4 = (x8 + (W1 - W7) * x4) >> 3;
+            x5 = (x8 - (W1 + W7) * x5) >> 3;
+            x8 = W3 * (x6 + x7) + 4;
+            x6 = (x8 - (W3 - W5) * x6) >> 3;
+            x7 = (x8 - (W3 + W5) * x7) >> 3;
+            x8 = x0 + x1;
+            x0 -= x1;
+            x1 = W6 * (x3 + x2) + 4;
+            x2 = (x1 - (W2 + W6) * x2) >> 3;
+            x3 = (x1 + (W2 - W6) * x3) >> 3;
+            x1 = x4 + x6;
+            x4 -= x6;
+            x6 = x5 + x7;
+            x5 -= x7;
+            x7 = x8 + x3;
+            x8 -= x3;
+            x3 = x0 + x2;
+            x0 -= x2;
+            x2 = (181 * (x4 + x5) + 128) >> 8;
+            x4 = (181 * (x4 - x5) + 128) >> 8;
+            pixels[outv] = Clip(((x7 + x1) >> 14) + 128); outv += stride;
+            pixels[outv] = Clip(((x3 + x2) >> 14) + 128); outv += stride;
+            pixels[outv] = Clip(((x0 + x4) >> 14) + 128); outv += stride;
+            pixels[outv] = Clip(((x8 + x6) >> 14) + 128); outv += stride;
+            pixels[outv] = Clip(((x8 - x6) >> 14) + 128); outv += stride;
+            pixels[outv] = Clip(((x0 - x4) >> 14) + 128); outv += stride;
+            pixels[outv] = Clip(((x3 - x2) >> 14) + 128); outv += stride;
+            pixels[outv] = Clip(((x7 - x1) >> 14) + 128);
+        }
+
+        public static byte Clip(int x)
+        {
+            return (byte)((x < 0) ? 0 : ((x > 0xFF) ? 0xFF : (byte)x));
+        }
+
+
+        private static (int value, bool isSuccess) GetVariableLengthCode(BitReader reader, HuffmanTreeNode[] vlc, ref byte code)
+        {
+            int value = reader.EnsureData(16); 
+            int bits = vlc[value].bits;
+            if (bits == 0) { 
+                return (0, false); 
+            }
+            reader.Skip(bits); 
+            value = vlc[value].code;
+            code = (byte)value;
+            bits = value & 15;
+            if (bits == 0)
+            {
+                return (0, true);
+            }
+            value = reader.Read(bits);
+            if (value < (1 << (bits - 1)))
+            {
+                value += ((-1) << bits) + 1;
+            }
+
+            return (value, true);
+
+        }
+
+        private static int ShowBits(JpgBinaryStreamReader reader, int bits)
+        {
+            return GetNumberOfBitsFromStream(reader, bits);
+        }
+
+        private static int GetNumberOfBitsFromStream(JpgBinaryStreamReader reader, int bits)
+        {
+            
+            return 0;
+        }         
+    }    
+}

--- a/src/UglyToad.PdfPig/Images/Jpg/Parts/XMP/Xmp.cs
+++ b/src/UglyToad.PdfPig/Images/Jpg/Parts/XMP/Xmp.cs
@@ -1,0 +1,24 @@
+﻿namespace UglyToad.PdfPig.Images.Jpg.Parts.XMP
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Text;
+    using static UglyToad.PdfPig.Images.Jpg.Helpers.Context;
+
+    internal class Xmp
+    {
+        internal static void GetXmp(ContextForApp1Segment context, int segmentLength, byte[] segmentData)
+        {
+            const string sig = "http://ns.adobe.com/xap/1.0/\0";
+            byte[]rdp = new byte[segmentLength - sig.Length];
+
+            Buffer.BlockCopy(segmentData,sig.Length,rdp,0, rdp.Length-2);
+            var rdpString = new ASCIIEncoding().GetString(rdp);
+
+            var doc = new System.Xml.XmlDocument();
+            doc.LoadXml(rdpString);
+
+            context.XMP = doc;
+        }
+    }
+}


### PR DESCRIPTION
Addresses issue #532.

DCT (Discrete Cosine Transform) based on ITU-T81 4.5 has four distinct modes of operation with various coding processes:
1. sequential DCT-based,
2. progressive DCT-based,
3. lossless, and
4. hierarchical.
Currently only mode 1 is implemented.
 PDF spec calls for mode 2 support (but not implemented).
Supports 8-bit grayscale and YCbCr images.
Translation to RGB colorspace. Other colorspaces require work.
Supports restart markers.
Reads Adobe Segment
Draft/WIP of reading JIFF/EXIF segment

Untested.