### PR TITLE
Move IColorSpaceContext to CurrentGraphicsState

### DIFF
--- a/src/UglyToad.PdfPig.Tests/Graphics/TestOperationContext.cs
+++ b/src/UglyToad.PdfPig.Tests/Graphics/TestOperationContext.cs
@@ -26,15 +26,13 @@
 
         public PdfPath CurrentPath { get; set; }
 
-        public IColorSpaceContext ColorSpaceContext { get; }
-
         public PdfPoint CurrentPosition { get; set; }
 
         public TestOperationContext()
         {
             StateStack.Push(new CurrentGraphicsState());
             CurrentSubpath = new PdfSubpath();
-            ColorSpaceContext = new ColorSpaceContext(GetCurrentState, new ResourceStore(new TestPdfTokenScanner(), new TestFontFactory()));
+            GetCurrentState().ColorSpaceContext = new ColorSpaceContext(GetCurrentState, new ResourceStore(new TestPdfTokenScanner(), new TestFontFactory()));
         }
 
         public CurrentGraphicsState GetCurrentState()

--- a/src/UglyToad.PdfPig/Graphics/ColorSpaceContext.cs
+++ b/src/UglyToad.PdfPig/Graphics/ColorSpaceContext.cs
@@ -221,5 +221,16 @@
             CurrentNonStrokingColorSpace = ColorSpace.DeviceCMYK;
             currentStateFunc().CurrentNonStrokingColor = new CMYKColor(c, m, y, k);
         }
+
+        public IColorSpaceContext DeepClone()
+        {
+            return new ColorSpaceContext(currentStateFunc, resourceStore)
+            {
+                CurrentStrokingColorSpace = CurrentStrokingColorSpace,
+                CurrentNonStrokingColorSpace = CurrentNonStrokingColorSpace,
+                AdvancedStrokingColorSpace = AdvancedStrokingColorSpace,
+                AdvancedNonStrokingColorSpace = AdvancedNonStrokingColorSpace
+            };
+        }
     }
 }

--- a/src/UglyToad.PdfPig/Graphics/ContentStreamProcessor.cs
+++ b/src/UglyToad.PdfPig/Graphics/ContentStreamProcessor.cs
@@ -7,6 +7,7 @@
     using Geometry;
     using Logging;
     using Operations;
+    using Operations.TextPositioning;
     using Parser;
     using PdfFonts;
     using PdfPig.Core;
@@ -16,7 +17,6 @@
     using System.Linq;
     using Tokenization.Scanner;
     using Tokens;
-    using Operations.TextPositioning;
     using Util;
     using XObjects;
     using static PdfPig.Core.PdfSubpath;
@@ -72,8 +72,6 @@
 
         public PdfPath CurrentPath { get; private set; }
 
-        public IColorSpaceContext ColorSpaceContext { get; }
-
         public PdfPoint CurrentPosition { get; set; }
 
         public int StackSize => graphicsStack.Count;
@@ -84,10 +82,10 @@
             {XObjectType.PostScript, new List<XObjectContentRecord>()}
         };
 
-        public ContentStreamProcessor(IResourceStore resourceStore, 
-            UserSpaceUnit userSpaceUnit, 
-            MediaBox mediaBox, 
-            CropBox cropBox, 
+        public ContentStreamProcessor(IResourceStore resourceStore,
+            UserSpaceUnit userSpaceUnit,
+            MediaBox mediaBox,
+            CropBox cropBox,
             PageRotationDegrees rotation,
             IPdfTokenScanner pdfScanner,
             IPageContentParser pageContentParser,
@@ -114,13 +112,13 @@
                 CurrentClippingPath = clippingPath
             });
 
-            ColorSpaceContext = new ColorSpaceContext(GetCurrentState, resourceStore);
+            GetCurrentState().ColorSpaceContext = new ColorSpaceContext(GetCurrentState, resourceStore);
         }
 
         [System.Diagnostics.Contracts.Pure]
-        internal static TransformationMatrix GetInitialMatrix(UserSpaceUnit userSpaceUnit, 
+        internal static TransformationMatrix GetInitialMatrix(UserSpaceUnit userSpaceUnit,
             MediaBox mediaBox,
-            CropBox cropBox, 
+            CropBox cropBox,
             PageRotationDegrees rotation,
             ILog log)
         {
@@ -129,7 +127,7 @@
             var viewBox = mediaBox.Bounds.Intersect(cropBox.Bounds) ?? cropBox.Bounds;
 
             if (rotation.Value == 0
-                && viewBox.Left == 0 
+                && viewBox.Left == 0
                 && viewBox.Bottom == 0
                 && userSpaceUnit.PointMultiples == 1)
             {
@@ -300,7 +298,7 @@
                 var transformedPdfBounds = PerformantRectangleTransformer
                     .Transform(renderingMatrix, textMatrix, transformationMatrix, new PdfRectangle(0, 0, boundingBox.Width, 0));
 
-                      
+
                 Letter letter = null;
                 if (Diacritics.IsInCombiningDiacriticRange(unicode) && bytes.CurrentOffset > 0 && letters.Count > 0)
                 {

--- a/src/UglyToad.PdfPig/Graphics/CurrentGraphicsState.cs
+++ b/src/UglyToad.PdfPig/Graphics/CurrentGraphicsState.cs
@@ -14,6 +14,11 @@ namespace UglyToad.PdfPig.Graphics
     public class CurrentGraphicsState : IDeepCloneable<CurrentGraphicsState>
     {
         /// <summary>
+        /// The active colorspaces for this content stream.
+        /// </summary>
+        public IColorSpaceContext ColorSpaceContext { get; set; }
+
+        /// <summary>
         /// The current clipping path.
         /// </summary>
         public PdfPath CurrentClippingPath { get; set; }
@@ -143,7 +148,8 @@ namespace UglyToad.PdfPig.Graphics
                 StrokeAdjustment = StrokeAdjustment,
                 CurrentStrokingColor = CurrentStrokingColor,
                 CurrentNonStrokingColor = CurrentNonStrokingColor,
-                CurrentClippingPath = CurrentClippingPath
+                CurrentClippingPath = CurrentClippingPath,
+                ColorSpaceContext = ColorSpaceContext?.DeepClone()
             };
         }
     }

--- a/src/UglyToad.PdfPig/Graphics/IColorSpaceContext.cs
+++ b/src/UglyToad.PdfPig/Graphics/IColorSpaceContext.cs
@@ -2,11 +2,12 @@
 {
     using Colors;
     using Tokens;
+    using UglyToad.PdfPig.Core;
 
     /// <summary>
     /// Methods for manipulating and retrieving the current color state for a PDF content stream.
     /// </summary>
-    public interface IColorSpaceContext
+    public interface IColorSpaceContext : IDeepCloneable<IColorSpaceContext>
     {
         /// <summary>
         /// The <see cref="ColorSpace"/> used for stroking operations.
@@ -27,7 +28,7 @@
         /// The name of the advanced ColorSpace active for non-stroking operations, if any.
         /// </summary>
         NameToken AdvancedNonStrokingColorSpace { get; }
-        
+
         /// <summary>
         ///  Set the current color space to use for stroking operations.
         /// </summary>

--- a/src/UglyToad.PdfPig/Graphics/IOperationContext.cs
+++ b/src/UglyToad.PdfPig/Graphics/IOperationContext.cs
@@ -11,11 +11,6 @@
     public interface IOperationContext
     {
         /// <summary>
-        /// The active colorspaces for this content stream.
-        /// </summary>
-        IColorSpaceContext ColorSpaceContext { get; }
-
-        /// <summary>
         /// The current position.
         /// </summary>
         PdfPoint CurrentPosition { get; set; }
@@ -29,6 +24,11 @@
         /// The number of graphics states on the stack.
         /// </summary>
         int StackSize { get; }
+
+        /// <summary>
+        /// Gets the current graphic state.
+        /// </summary>
+        CurrentGraphicsState GetCurrentState();
 
         /// <summary>
         /// Sets the current graphics state to the state from the top of the stack.

--- a/src/UglyToad.PdfPig/Graphics/Operations/SetNonStrokeColor.cs
+++ b/src/UglyToad.PdfPig/Graphics/Operations/SetNonStrokeColor.cs
@@ -38,13 +38,13 @@
             switch (Operands.Count)
             {
                 case 1:
-                    operationContext.ColorSpaceContext.SetNonStrokingColorGray(Operands[0]);
+                    operationContext.GetCurrentState().ColorSpaceContext.SetNonStrokingColorGray(Operands[0]);
                     break;
                 case 3:
-                    operationContext.ColorSpaceContext.SetNonStrokingColorRgb(Operands[0], Operands[1], Operands[2]);
+                    operationContext.GetCurrentState().ColorSpaceContext.SetNonStrokingColorRgb(Operands[0], Operands[1], Operands[2]);
                     break;
                 case 4:
-                    operationContext.ColorSpaceContext.SetNonStrokingColorCmyk(Operands[0], Operands[1], Operands[2], Operands[3]);
+                    operationContext.GetCurrentState().ColorSpaceContext.SetNonStrokingColorCmyk(Operands[0], Operands[1], Operands[2], Operands[3]);
                     break;
                 default:
                     return;

--- a/src/UglyToad.PdfPig/Graphics/Operations/SetNonStrokeColorAdvanced.cs
+++ b/src/UglyToad.PdfPig/Graphics/Operations/SetNonStrokeColorAdvanced.cs
@@ -56,8 +56,10 @@
         /// <inheritdoc />
         public void Run(IOperationContext operationContext)
         {
-            if (operationContext.ColorSpaceContext.CurrentNonStrokingColorSpace.GetFamily() != ColorSpaceFamily.Device
-                || operationContext.ColorSpaceContext.AdvancedNonStrokingColorSpace != null)
+            var colorSpaceContext = operationContext.GetCurrentState().ColorSpaceContext;
+
+            if (colorSpaceContext.CurrentNonStrokingColorSpace.GetFamily() != ColorSpaceFamily.Device
+                || colorSpaceContext.AdvancedNonStrokingColorSpace != null)
             {
                 return;
             }
@@ -65,13 +67,13 @@
             switch (Operands.Count)
             {
                 case 1:
-                    operationContext.ColorSpaceContext.SetNonStrokingColorGray(Operands[0]);
+                    colorSpaceContext.SetNonStrokingColorGray(Operands[0]);
                     break;
                 case 3:
-                    operationContext.ColorSpaceContext.SetNonStrokingColorRgb(Operands[0], Operands[1], Operands[2]);
+                    colorSpaceContext.SetNonStrokingColorRgb(Operands[0], Operands[1], Operands[2]);
                     break;
                 case 4:
-                    operationContext.ColorSpaceContext.SetNonStrokingColorCmyk(Operands[0], Operands[1], Operands[2], Operands[3]);
+                    colorSpaceContext.SetNonStrokingColorCmyk(Operands[0], Operands[1], Operands[2], Operands[3]);
                     break;
                 default:
                     return;

--- a/src/UglyToad.PdfPig/Graphics/Operations/SetNonStrokeColorDeviceCmyk.cs
+++ b/src/UglyToad.PdfPig/Graphics/Operations/SetNonStrokeColorDeviceCmyk.cs
@@ -54,7 +54,7 @@
         /// <inheritdoc />
         public void Run(IOperationContext operationContext)
         {
-            operationContext.ColorSpaceContext.SetNonStrokingColorCmyk(C, M, Y, K);
+            operationContext.GetCurrentState().ColorSpaceContext.SetNonStrokingColorCmyk(C, M, Y, K);
         }
 
         /// <inheritdoc />

--- a/src/UglyToad.PdfPig/Graphics/Operations/SetNonStrokeColorDeviceGray.cs
+++ b/src/UglyToad.PdfPig/Graphics/Operations/SetNonStrokeColorDeviceGray.cs
@@ -33,7 +33,7 @@
         /// <inheritdoc />
         public void Run(IOperationContext operationContext)
         {
-            operationContext.ColorSpaceContext.SetNonStrokingColorGray(Gray);
+            operationContext.GetCurrentState().ColorSpaceContext.SetNonStrokingColorGray(Gray);
         }
 
         /// <inheritdoc />

--- a/src/UglyToad.PdfPig/Graphics/Operations/SetNonStrokeColorDeviceRgb.cs
+++ b/src/UglyToad.PdfPig/Graphics/Operations/SetNonStrokeColorDeviceRgb.cs
@@ -47,7 +47,7 @@
         /// <inheritdoc />
         public void Run(IOperationContext operationContext)
         {
-            operationContext.ColorSpaceContext.SetNonStrokingColorRgb(R, G, B);
+            operationContext.GetCurrentState().ColorSpaceContext.SetNonStrokingColorRgb(R, G, B);
         }
 
         /// <inheritdoc />

--- a/src/UglyToad.PdfPig/Graphics/Operations/SetNonStrokeColorSpace.cs
+++ b/src/UglyToad.PdfPig/Graphics/Operations/SetNonStrokeColorSpace.cs
@@ -38,7 +38,7 @@
         /// <inheritdoc />
         public void Run(IOperationContext operationContext)
         {
-            operationContext.ColorSpaceContext.SetNonStrokingColorspace(Name);
+            operationContext.GetCurrentState().ColorSpaceContext.SetNonStrokingColorspace(Name);
         }
 
         /// <inheritdoc />

--- a/src/UglyToad.PdfPig/Graphics/Operations/SetStrokeColor.cs
+++ b/src/UglyToad.PdfPig/Graphics/Operations/SetStrokeColor.cs
@@ -38,13 +38,13 @@
             switch (Operands.Count)
             {
                 case 1:
-                    operationContext.ColorSpaceContext.SetStrokingColorGray(Operands[0]);
+                    operationContext.GetCurrentState().ColorSpaceContext.SetStrokingColorGray(Operands[0]);
                     break;
                 case 3:
-                    operationContext.ColorSpaceContext.SetStrokingColorRgb(Operands[0], Operands[1], Operands[2]);
+                    operationContext.GetCurrentState().ColorSpaceContext.SetStrokingColorRgb(Operands[0], Operands[1], Operands[2]);
                     break;
                 case 4:
-                    operationContext.ColorSpaceContext.SetStrokingColorCmyk(Operands[0], Operands[1], Operands[2], Operands[3]);
+                    operationContext.GetCurrentState().ColorSpaceContext.SetStrokingColorCmyk(Operands[0], Operands[1], Operands[2], Operands[3]);
                     break;
                 default:
                     return;

--- a/src/UglyToad.PdfPig/Graphics/Operations/SetStrokeColorAdvanced.cs
+++ b/src/UglyToad.PdfPig/Graphics/Operations/SetStrokeColorAdvanced.cs
@@ -56,8 +56,10 @@
         /// <inheritdoc />
         public void Run(IOperationContext operationContext)
         {
-            if (operationContext.ColorSpaceContext.CurrentStrokingColorSpace.GetFamily() != ColorSpaceFamily.Device
-                || operationContext.ColorSpaceContext.AdvancedStrokingColorSpace != null)
+            var colorSpaceContext = operationContext.GetCurrentState().ColorSpaceContext;
+
+            if (colorSpaceContext.CurrentStrokingColorSpace.GetFamily() != ColorSpaceFamily.Device
+                || colorSpaceContext.AdvancedStrokingColorSpace != null)
             {
                 return;
             }
@@ -65,13 +67,13 @@
             switch (Operands.Count)
             {
                 case 1:
-                    operationContext.ColorSpaceContext.SetStrokingColorGray(Operands[0]);
+                    colorSpaceContext.SetStrokingColorGray(Operands[0]);
                     break;
                 case 3:
-                    operationContext.ColorSpaceContext.SetStrokingColorRgb(Operands[0], Operands[1], Operands[2]);
+                    colorSpaceContext.SetStrokingColorRgb(Operands[0], Operands[1], Operands[2]);
                     break;
                 case 4:
-                    operationContext.ColorSpaceContext.SetStrokingColorCmyk(Operands[0], Operands[1], Operands[2], Operands[3]);
+                    colorSpaceContext.SetStrokingColorCmyk(Operands[0], Operands[1], Operands[2], Operands[3]);
                     break;
                 default:
                     return;

--- a/src/UglyToad.PdfPig/Graphics/Operations/SetStrokeColorDeviceCmyk.cs
+++ b/src/UglyToad.PdfPig/Graphics/Operations/SetStrokeColorDeviceCmyk.cs
@@ -54,7 +54,7 @@
         /// <inheritdoc />
         public void Run(IOperationContext operationContext)
         {
-            operationContext.ColorSpaceContext.SetStrokingColorCmyk(C, M, Y, K);
+            operationContext.GetCurrentState().ColorSpaceContext.SetStrokingColorCmyk(C, M, Y, K);
         }
 
         /// <inheritdoc />

--- a/src/UglyToad.PdfPig/Graphics/Operations/SetStrokeColorDeviceGray.cs
+++ b/src/UglyToad.PdfPig/Graphics/Operations/SetStrokeColorDeviceGray.cs
@@ -33,7 +33,7 @@
         /// <inheritdoc />
         public void Run(IOperationContext operationContext)
         {
-            operationContext.ColorSpaceContext.SetStrokingColorGray(Gray);
+            operationContext.GetCurrentState().ColorSpaceContext.SetStrokingColorGray(Gray);
         }
         
         /// <inheritdoc />

--- a/src/UglyToad.PdfPig/Graphics/Operations/SetStrokeColorDeviceRgb.cs
+++ b/src/UglyToad.PdfPig/Graphics/Operations/SetStrokeColorDeviceRgb.cs
@@ -47,7 +47,7 @@
         /// <inheritdoc />
         public void Run(IOperationContext operationContext)
         {
-            operationContext.ColorSpaceContext.SetStrokingColorRgb(R, G, B);
+            operationContext.GetCurrentState().ColorSpaceContext.SetStrokingColorRgb(R, G, B);
         }
 
         /// <inheritdoc />

--- a/src/UglyToad.PdfPig/Graphics/Operations/SetStrokeColorSpace.cs
+++ b/src/UglyToad.PdfPig/Graphics/Operations/SetStrokeColorSpace.cs
@@ -38,7 +38,7 @@
         /// <inheritdoc />
         public void Run(IOperationContext operationContext)
         {
-            operationContext.ColorSpaceContext.SetStrokingColorspace(Name);
+            operationContext.GetCurrentState().ColorSpaceContext.SetStrokingColorspace(Name);
         }
 
         /// <inheritdoc />


### PR DESCRIPTION
As per "Pdf Reference 1.7", section 8.4 Graphics State, Table 52, the color space should be part of the graphics state (together with the CTM, etc.)
![image](https://user-images.githubusercontent.com/38405645/227736531-1acb8359-9071-495d-b645-a0871bbdd937.png)
