### PR TITLE
make Bookmarks constructor public

### DIFF
--- a/src/UglyToad.PdfPig/Outline/Bookmarks.cs
+++ b/src/UglyToad.PdfPig/Outline/Bookmarks.cs
@@ -12,7 +12,10 @@ namespace UglyToad.PdfPig.Outline
         /// </summary>
         public IReadOnlyList<BookmarkNode> Roots { get; }
 
-        internal Bookmarks(IReadOnlyList<BookmarkNode> roots)
+        /// <summary>
+        /// Create a new <see cref="Bookmarks" />.
+        /// </summary>
+        public Bookmarks(IReadOnlyList<BookmarkNode> roots)
         {
             Roots = roots;
         }


### PR DESCRIPTION
Fix #552 not exposing `Bookmarks` as a public API for `PdfDocumentBuilder.Bookmarks`.