### PR TITLE
Fix integration tests for #595

### DIFF
--- a/src/UglyToad.PdfPig/Graphics/ColorSpaceContext.cs
+++ b/src/UglyToad.PdfPig/Graphics/ColorSpaceContext.cs
@@ -14,7 +14,7 @@
 
         public ColorSpaceDetails CurrentStrokingColorSpace { get; private set; } = DeviceGrayColorSpaceDetails.Instance;
 
-        public ColorSpaceDetails CurrentNonStrokingColorSpace { get; set; } = DeviceGrayColorSpaceDetails.Instance;
+        public ColorSpaceDetails CurrentNonStrokingColorSpace { get; private set; } = DeviceGrayColorSpaceDetails.Instance;
 
         public ColorSpaceContext(Func<CurrentGraphicsState> currentStateFunc, IResourceStore resourceStore)
         {
@@ -22,9 +22,9 @@
             this.resourceStore = resourceStore ?? throw new ArgumentNullException(nameof(resourceStore));
         }
 
-        public void SetStrokingColorspace(NameToken colorspace)
+        public void SetStrokingColorspace(NameToken colorspace, DictionaryToken dictionary = null)
         {
-            CurrentStrokingColorSpace = resourceStore.GetColorSpaceDetails(colorspace, null);
+            CurrentStrokingColorSpace = resourceStore.GetColorSpaceDetails(colorspace, dictionary);
             if (CurrentStrokingColorSpace is UnsupportedColorSpaceDetails)
             {
                 return;
@@ -61,9 +61,9 @@
             currentStateFunc().CurrentStrokingColor = CurrentStrokingColorSpace.GetColor((double)c, (double)m, (double)y, (double)k);
         }
 
-        public void SetNonStrokingColorspace(NameToken colorspace)
+        public void SetNonStrokingColorspace(NameToken colorspace, DictionaryToken dictionary = null)
         {
-            CurrentNonStrokingColorSpace = resourceStore.GetColorSpaceDetails(colorspace, null);
+            CurrentNonStrokingColorSpace = resourceStore.GetColorSpaceDetails(colorspace, dictionary);
             if (CurrentNonStrokingColorSpace is UnsupportedColorSpaceDetails)
             {
                 return;

--- a/src/UglyToad.PdfPig/Graphics/ContentStreamProcessor.cs
+++ b/src/UglyToad.PdfPig/Graphics/ContentStreamProcessor.cs
@@ -513,8 +513,7 @@
                 {
                     if (csArrayToken.Data[0] is NameToken firstColorSpaceName)
                     {
-                        startState.ColorSpaceContext.CurrentNonStrokingColorSpace = resourceStore.GetColorSpaceDetails(firstColorSpaceName, formGroupToken);
-                        startState.CurrentNonStrokingColor = startState.ColorSpaceContext.CurrentNonStrokingColorSpace.GetInitializeColor();
+                        startState.ColorSpaceContext.SetNonStrokingColorspace(csNameToken, formGroupToken);
                     }
                     else
                     {

--- a/src/UglyToad.PdfPig/Graphics/IColorSpaceContext.cs
+++ b/src/UglyToad.PdfPig/Graphics/IColorSpaceContext.cs
@@ -18,17 +18,21 @@
         /// <summary>
         /// The <see cref="ColorSpaceDetails"/> used for non-stroking operations.
         /// </summary>
-        ColorSpaceDetails CurrentNonStrokingColorSpace { get; internal set; }
+        ColorSpaceDetails CurrentNonStrokingColorSpace { get; }
 
         /// <summary>
-        /// Set the current color space to use for stroking operations.
+        /// Set the current color space to use for stroking operations and initialize the stroking color.
         /// </summary>
-        void SetStrokingColorspace(NameToken colorspace);
+        /// <param name="colorspace">The color space name.</param>
+        /// <param name="dictionary">The color space dictionary. Default value is null.</param>
+        void SetStrokingColorspace(NameToken colorspace, DictionaryToken dictionary = null);
 
         /// <summary>
-        /// Set the current color space to use for nonstroking operations.
+        /// Set the current color space to use for nonstroking operations and initialize the nonstroking color.
         /// </summary>
-        void SetNonStrokingColorspace(NameToken colorspace);
+        /// <param name="colorspace">The color space name.</param>
+        /// <param name="dictionary">The color space dictionary. Default value is null.</param>
+        void SetNonStrokingColorspace(NameToken colorspace, DictionaryToken dictionary = null);
 
         /// <summary>
         /// Set the color to use for stroking operations using the current color space.


### PR DESCRIPTION
Fix failing integration tests following #595 

https://github.com/UglyToad/PdfPig/actions/runs/4692608923

> 'ColorSpaceContext' does not implement interface member 'IColorSpaceContext.CurrentNonStrokingColorSpace.set'. 'ColorSpaceContext.CurrentNonStrokingColorSpace.set' cannot implicitly implement a non-public member.
