### PR TITLE
Revert "Update run_integration_tests.yml"

### DIFF
--- a/.github/workflows/run_integration_tests.yml
+++ b/.github/workflows/run_integration_tests.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Set up dotnet core
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: "3.1.x"
+          dotnet-version: "2.1.x"
 
       - name: Restore cached part 1
         id: restore-cache-p1


### PR DESCRIPTION
This reverts commit 92f47df9f6c6ff6d01df9dc8815a17e63ca3409d.

@EliotJones should we trigger the run_integration_tests on PR to master too? like the other tests. Would avoid discovering issues after PR has been merged