### PR TITLE
Pdf merger support copy links

### DIFF
--- a/src/UglyToad.PdfPig.Tests/Writer/PdfMergerTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Writer/PdfMergerTests.cs
@@ -5,6 +5,7 @@
     using System;
     using System.Collections.Generic;
     using System.IO;
+    using System.Linq;
     using Xunit;
 
     public class PdfMergerTests
@@ -184,6 +185,36 @@
                 {
                     Assert.NotNull(page.Text);
                 }
+            }
+        }
+
+        [Fact]
+        public void CanMergeWithLinks()
+        {
+            var test = IntegrationHelpers.GetDocumentPath("outline.pdf");
+            var result = PdfMerger.Merge(new[] { File.ReadAllBytes(test), File.ReadAllBytes(test) });
+
+            WriteFile(nameof(CanMergeWithLinks), result);
+
+            using (var document = PdfDocument.Open(result, ParsingOptions.LenientParsingOff))
+            {
+                Assert.Equal(2, document.GetPages().Sum(
+                    page => page.ExperimentalAccess.GetAnnotations().Count(x => x.Type == Annotations.AnnotationType.Link)));
+            }
+        }
+
+        [Fact]
+        public void CanMergeWithLinksWithSelection()
+        {
+            var test = IntegrationHelpers.GetDocumentPath("outline.pdf");
+            var result = PdfMerger.Merge(new[] { File.ReadAllBytes(test), File.ReadAllBytes(test) }, new[] { new[] { 2, 1 }, new[] { 3, 1 } });
+
+            WriteFile(nameof(CanMergeWithLinksWithSelection), result);
+
+            using (var document = PdfDocument.Open(result, ParsingOptions.LenientParsingOff))
+            {
+                Assert.Equal(1, document.GetPages().Sum(
+                    page => page.ExperimentalAccess.GetAnnotations().Count(x => x.Type == Annotations.AnnotationType.Link)));
             }
         }
 

--- a/src/UglyToad.PdfPig/Annotations/AnnotationProvider.cs
+++ b/src/UglyToad.PdfPig/Annotations/AnnotationProvider.cs
@@ -142,7 +142,7 @@
             }
         }
 
-        private PdfAction GetAction(DictionaryToken annotationDictionary)
+        internal PdfAction GetAction(DictionaryToken annotationDictionary)
         {
             // If this annotation returns a direct destination, turn it into a GoTo action.
             if (DestinationProvider.TryGetDestination(annotationDictionary,

--- a/src/UglyToad.PdfPig/Content/Page.cs
+++ b/src/UglyToad.PdfPig/Content/Page.cs
@@ -18,7 +18,7 @@
     /// </summary>
     public class Page
     {
-        private readonly AnnotationProvider annotationProvider;
+        internal readonly AnnotationProvider annotationProvider;
         internal readonly IPdfTokenScanner pdfScanner;
         private readonly Lazy<string> textLazy;
 

--- a/src/UglyToad.PdfPig/Writer/PdfPageBuilder.cs
+++ b/src/UglyToad.PdfPig/Writer/PdfPageBuilder.cs
@@ -21,6 +21,7 @@
     using Tokens;
     using Graphics.Operations.PathPainting;
     using Images.Png;
+    using UglyToad.PdfPig.Actions;
 
     /// <summary>
     /// A builder used to add construct a page in a PDF document.
@@ -36,6 +37,9 @@
         // streams
         internal readonly List<IPageContentStream> contentStreams;
         private IPageContentStream currentStream;
+
+        // links to be resolved when all page references are available
+        internal readonly List<(DictionaryToken token, PdfAction action)> links;
         
         // maps fonts added using PdfDocumentBuilder to page font names
         private readonly Dictionary<Guid, NameToken> documentFonts = new Dictionary<Guid, NameToken>();
@@ -80,16 +84,17 @@
         }
 
         internal PdfPageBuilder(int number, PdfDocumentBuilder documentBuilder, IEnumerable<CopiedContentStream> copied,
-            Dictionary<NameToken, IToken> pageDict)
+            Dictionary<NameToken, IToken> pageDict, List<(DictionaryToken token, PdfAction action)> links)
         {
             this.documentBuilder = documentBuilder ?? throw new ArgumentNullException(nameof(documentBuilder));
+            this.links = links;
             PageNumber = number;
             pageDictionary = pageDict;
             contentStreams = new List<IPageContentStream>();
             contentStreams.AddRange(copied);
             currentStream = new DefaultContentStream();
             contentStreams.Add(currentStream);
-        }	        
+        }
 
         /// <summary>
         /// Allow to append a new content stream before the current one and select it


### PR DESCRIPTION
Implements link copy for PDF merger. 

- Introduces a new `AddPage` overload that takes a `Func<PdfAction, PdfAction> copyLink` parameter to define how links should be copied.
   - When `copyLink` is `null` or when `copyLink` returns `null`, links are not copied
   - When `copyLink` returns the same instance as input, links are copied as is
   - When `copyLink` returns a new instance, links are copied based on the returned instance.
- Update `PdfMerger` to copy links:
   - Without page selection, copy all links
   - With page selection, copy only links whose target page has been selected.
  
> NOTE: Named dest links `/Dest` will be turned into goto explicit destination action `/A` after merge


fixes #485 

related: https://github.com/dotnet/docfx/issues/4250