### PR TITLE
Fix: copyfrom resources collisions

### DIFF
--- a/src/UglyToad.PdfPig.Tests/Functions/Type4/Type4Tester.cs
+++ b/src/UglyToad.PdfPig.Tests/Functions/Type4/Type4Tester.cs
@@ -1,6 +1,7 @@
 ﻿namespace UglyToad.PdfPig.Tests.Functions.Type4
 {
     using System;
+    using System.Globalization;
     using UglyToad.PdfPig.Functions.Type4;
     using Xunit;
 
@@ -60,7 +61,7 @@
         /// <returns>this instance</returns>
         public Type4Tester PopReal(double expected, double delta)
         {
-            double value = Convert.ToDouble(context.Stack.Pop());
+            double value = Convert.ToDouble(context.Stack.Pop(), CultureInfo.InvariantCulture);
             DoubleComparer doubleComparer = new DoubleComparer(delta);
             Assert.True(doubleComparer.Equals(expected, value));//expected, value, delta);
             return this;
@@ -98,7 +99,7 @@
         {
             object value = context.PopNumber();
             DoubleComparer doubleComparer = new DoubleComparer(delta);
-            Assert.True(doubleComparer.Equals(expected, Convert.ToDouble(value)));
+            Assert.True(doubleComparer.Equals(expected, Convert.ToDouble(value, CultureInfo.InvariantCulture)));
             return this;
         }
 

--- a/src/UglyToad.PdfPig/Functions/Type4/InstructionSequenceBuilder.cs
+++ b/src/UglyToad.PdfPig/Functions/Type4/InstructionSequenceBuilder.cs
@@ -1,6 +1,7 @@
 ﻿namespace UglyToad.PdfPig.Functions.Type4
 {
     using System.Collections.Generic;
+    using System.Globalization;
 
     /// <summary>
     /// Basic parser for Type 4 functions which is used to build up instruction sequences.
@@ -62,13 +63,13 @@
             }
             else
             {
-                if (int.TryParse(token, out int tokenInt))
+                if (int.TryParse(token, NumberStyles.Integer, CultureInfo.InvariantCulture, out int tokenInt))
                 {
                     GetCurrentSequence().AddInteger(tokenInt);
                     return;
                 }
 
-                if (double.TryParse(token, out double tokenFloat))
+                if (double.TryParse(token, NumberStyles.Float, CultureInfo.InvariantCulture, out double tokenFloat))
                 {
                     GetCurrentSequence().AddReal(tokenFloat);
                     return;


### PR DESCRIPTION
When copying multiple pages from a source document to a single destination page, there is a conflict not only with resources prefixed by I (images), but also Fm (containing drawing instructions) and ExtGfxState (used for opacity etc).

This change resolves conflict during page copyFrom.

I introduced a new class to manage name collision (using a default prefix, but that can also fix existing names by extracting the prefix)

The ExtGfxState has to be handled separately since it is referenced in a different operation and is located in a different dictionary.

There are probably other names/resources/instructions that need to be handled in the same way, like ColorSpaces etc...