### PR TITLE
Use double everywhere instead of decimal

### DIFF
--- a/src/UglyToad.PdfPig.Core/PdfPoint.cs
+++ b/src/UglyToad.PdfPig.Core/PdfPoint.cs
@@ -4,7 +4,7 @@
     using System.Globalization;
 
     /// <summary>
-    /// A point in a PDF file. 
+    /// A point in a PDF file.
     /// </summary>
     /// <remarks>
     /// PDF coordinates are defined with the origin at the lower left (0, 0).
@@ -16,7 +16,7 @@
         /// <summary>
         /// The origin of the coordinates system.
         /// </summary>
-        public static PdfPoint Origin { get; } = new PdfPoint(0m, 0m);
+        public static PdfPoint Origin { get; } = new PdfPoint(0, 0);
 
         /// <summary>
         /// The X coordinate for this point. (Horizontal axis).
@@ -27,16 +27,6 @@
         /// The Y coordinate of this point. (Vertical axis).
         /// </summary>
         public double Y { get; }
-
-        /// <summary>
-        /// Create a new <see cref="PdfPoint"/> at this position.
-        /// </summary>
-        [DebuggerStepThrough]
-        public PdfPoint(decimal x, decimal y)
-        {
-            X = (double)x;
-            Y = (double)y;
-        }
 
         /// <summary>
         /// Create a new <see cref="PdfPoint"/> at this position.

--- a/src/UglyToad.PdfPig.Core/PdfRange.cs
+++ b/src/UglyToad.PdfPig.Core/PdfRange.cs
@@ -11,27 +11,6 @@
         private readonly IReadOnlyList<double> rangeArray;
         private readonly int startingIndex;
 
-        /// <summary>
-        /// Constructor assumes a starting index of 0.
-        /// </summary>
-        /// <param name="range">The array that describes the range.</param>
-        public PdfRange(IEnumerable<decimal> range)
-            : this(range.Select(v => (double)v), 0)
-        {
-        }
-
-        /// <summary>
-        /// Constructor with an index into an array. Because some arrays specify
-        /// multiple ranges ie [0, 1, 0, 2, 2, 3]. It is convenient for this
-        /// class to take an index into an array. So if you want this range to
-        /// represent 0, 2 in the above example then you would say <c>new PDRange(array, 1)</c>.
-        /// </summary>
-        /// <param name="range">The array that describes the index</param>
-        /// <param name="index">The range index into the array for the start of the range.</param>
-        public PdfRange(IEnumerable<decimal> range, int index)
-            : this(range.Select(v => (double)v), index)
-        {
-        }
 
         /// <summary>
         /// Constructor assumes a starting index of 0.

--- a/src/UglyToad.PdfPig.Core/TransformationMatrix.cs
+++ b/src/UglyToad.PdfPig.Core/TransformationMatrix.cs
@@ -352,14 +352,6 @@
         /// </summary>
         /// <param name="values">Either all 9 values of the matrix, 6 values in the default PDF order or the 4 values of the top left square.</param>
         /// <returns></returns>
-        public static TransformationMatrix FromArray(decimal[] values)
-            => FromArray(values.Select(x => (double) x).ToArray());
-
-        /// <summary>
-        /// Create a new <see cref="TransformationMatrix"/> from the values.
-        /// </summary>
-        /// <param name="values">Either all 9 values of the matrix, 6 values in the default PDF order or the 4 values of the top left square.</param>
-        /// <returns></returns>
         public static TransformationMatrix FromArray(double[] values)
         {
             if (values.Length == 9)

--- a/src/UglyToad.PdfPig.DocumentLayoutAnalysis/Export/HOcrTextExporter.cs
+++ b/src/UglyToad.PdfPig.DocumentLayoutAnalysis/Export/HOcrTextExporter.cs
@@ -289,8 +289,8 @@
 
             // http://kba.cloud/hocr-spec/1.2/#propdef-baseline
             // below will be 0 as long as the word's bounding box bottom is the BaseLine and not 'Bottom'
-            double baseLine = (double)line.Words[0].Letters[0].StartBaseLine.Y;
-            baseLine = (double)line.BoundingBox.Bottom - baseLine;
+            double baseLine = line.Words[0].Letters[0].StartBaseLine.Y;
+            baseLine = line.BoundingBox.Bottom - baseLine;
 
             string hocr = GetIndent(level) + "<span class='ocr_line' id='line_" + pageCount + "_" + lineCount + "' title='" +
                 GetCode(line.BoundingBox, pageHeight) + "; baseline " + angle + " 0'>"; //"; x_size 42; x_descenders 5; x_ascenders 12' >";

--- a/src/UglyToad.PdfPig.Fonts/AdobeFontMetrics/AdobeFontMetrics.cs
+++ b/src/UglyToad.PdfPig.Fonts/AdobeFontMetrics/AdobeFontMetrics.cs
@@ -11,7 +11,7 @@
         /// <summary>
         /// Version of the Adobe Font Metrics specification used to generate this file.
         /// </summary>
-        public decimal AfmVersion { get; }
+        public double AfmVersion { get; }
 
         /// <summary>
         /// Any comments in the file.
@@ -103,38 +103,38 @@
         /// <summary>
         /// Usually the y-value of the top of capital 'H'.
         /// </summary>
-        public decimal CapHeight { get; }
+        public double CapHeight { get; }
 
         /// <summary>
         /// Usually the y-value of the top of lowercase 'x'.
         /// </summary>
-        public decimal XHeight { get; }
+        public double XHeight { get; }
 
         /// <summary>
         /// Usually the y-value of the top of lowercase 'd'.
         /// </summary>
-        public decimal Ascender { get; }
+        public double Ascender { get; }
 
         /// <summary>
         /// Usually the y-value of the bottom of lowercase 'p'.
         /// </summary>
-        public decimal Descender { get; }
+        public double Descender { get; }
 
         /// <summary>
         /// Distance from the baseline for underlining.
         /// </summary>
-        public decimal UnderlinePosition { get; }
+        public double UnderlinePosition { get; }
 
         /// <summary>
         /// Width of the line for underlining.
         /// </summary>
-        public decimal UnderlineThickness { get; }
+        public double UnderlineThickness { get; }
 
         /// <summary>
         /// Angle in degrees counter-clockwise from the vertical of the vertical linea.
         /// Zero for non-italic fonts.
         /// </summary>
-        public decimal ItalicAngle { get; }
+        public double ItalicAngle { get; }
 
         /// <summary>
         /// If present all characters have this width and height.
@@ -144,12 +144,12 @@
         /// <summary>
         /// Horizontal stem width.
         /// </summary>
-        public decimal HorizontalStemWidth { get; }
+        public double HorizontalStemWidth { get; }
 
         /// <summary>
         /// Vertical stem width.
         /// </summary>
-        public decimal VerticalStemWidth { get; }
+        public double VerticalStemWidth { get; }
 
         /// <summary>
         /// Metrics for the individual characters.
@@ -159,7 +159,7 @@
         /// <summary>
         /// Create a new <see cref="AdobeFontMetrics"/>.
         /// </summary>
-        public AdobeFontMetrics(decimal afmVersion, IReadOnlyList<string> comments, int metricSets, string fontName,
+        public AdobeFontMetrics(double afmVersion, IReadOnlyList<string> comments, int metricSets, string fontName,
             string fullName,
             string familyName,
             string weight,
@@ -174,16 +174,16 @@
             bool isBaseFont,
             AdobeFontMetricsVector vVector,
             bool isFixedV,
-            decimal capHeight,
-            decimal xHeight,
-            decimal ascender,
-            decimal descender,
-            decimal underlinePosition,
-            decimal underlineThickness,
-            decimal italicAngle,
+            double capHeight,
+            double xHeight,
+            double ascender,
+            double descender,
+            double underlinePosition,
+            double underlineThickness,
+            double italicAngle,
             AdobeFontMetricsCharacterSize characterWidth,
-            decimal horizontalStemWidth,
-            decimal verticalStemWidth,
+            double horizontalStemWidth,
+            double verticalStemWidth,
             IReadOnlyDictionary<string, AdobeFontMetricsIndividualCharacterMetric> characterMetrics)
         {
             AfmVersion = afmVersion;

--- a/src/UglyToad.PdfPig.Fonts/AdobeFontMetrics/AdobeFontMetricsBuilder.cs
+++ b/src/UglyToad.PdfPig.Fonts/AdobeFontMetrics/AdobeFontMetricsBuilder.cs
@@ -7,7 +7,7 @@
 
     internal class AdobeFontMetricsBuilder
     {
-        public decimal AfmVersion { get; }
+        public double AfmVersion { get; }
 
         public List<string> Comments { get; }
 
@@ -37,7 +37,7 @@
         /// <summary>
         /// Angle in degrees counter-clockwise from vertical of vertical strokes of the font.
         /// </summary>
-        public decimal ItalicAngle { get; set; }
+        public double ItalicAngle { get; set; }
 
         /// <summary>
         /// Whether the font is monospaced or not.
@@ -52,12 +52,12 @@
         /// <summary>
         /// Distance from the baseline for underlining.
         /// </summary>
-        public decimal UnderlinePosition { get; set; }
+        public double UnderlinePosition { get; set; }
 
         /// <summary>
         /// The stroke width for underlining.
         /// </summary>
-        public decimal UnderlineThickness { get; set; }
+        public double UnderlineThickness { get; set; }
 
         /// <summary>
         /// Version identifier for the font program.
@@ -86,32 +86,32 @@
         /// <summary>
         /// The y-value of the top of a capital H.
         /// </summary>
-        public decimal CapHeight { get; set; }
+        public double CapHeight { get; set; }
 
         /// <summary>
         /// The y-value of the top of lowercase x.
         /// </summary>
-        public decimal XHeight { get; set; }
+        public double XHeight { get; set; }
 
         /// <summary>
         /// Generally the y-value of the top of lowercase d.
         /// </summary>
-        public decimal Ascender { get; set; }
+        public double Ascender { get; set; }
 
         /// <summary>
         /// The y-value of the bottom of lowercase p.
         /// </summary>
-        public decimal Descender { get; set; }
+        public double Descender { get; set; }
 
         /// <summary>
         /// Width of horizontal stems.
         /// </summary>
-        public decimal StdHw { get; set; }
+        public double StdHw { get; set; }
 
         /// <summary>
         /// Width of vertical stems.
         /// </summary>
-        public decimal StdVw { get; set; }
+        public double StdVw { get; set; }
 
         public int EscapeCharacter { get; set; }
 
@@ -123,7 +123,7 @@
 
         public bool IsFixedV { get; set; }
 
-        public AdobeFontMetricsBuilder(decimal afmVersion)
+        public AdobeFontMetricsBuilder(double afmVersion)
         {
             AfmVersion = afmVersion;
             Comments = new List<string>();

--- a/src/UglyToad.PdfPig.Fonts/AdobeFontMetrics/AdobeFontMetricsParser.cs
+++ b/src/UglyToad.PdfPig.Fonts/AdobeFontMetrics/AdobeFontMetricsParser.cs
@@ -326,10 +326,10 @@ namespace UglyToad.PdfPig.Fonts.AdobeFontMetrics
         /// </summary>
         public const string KernPairKpy = "KPY";
 
-        private static readonly char[] IndividualCharmetricsSplit = {';'};
+        private static readonly char[] IndividualCharmetricsSplit = { ';' };
 
-        private static readonly char[] CharmetricsKeySplit = {' '};
-        
+        private static readonly char[] CharmetricsKeySplit = { ' ' };
+
         /// <summary>
         /// Parse the font metrics from the input bytes.
         /// </summary>
@@ -344,7 +344,7 @@ namespace UglyToad.PdfPig.Fonts.AdobeFontMetrics
                 throw new InvalidFontFormatException($"The AFM file was not valid, it did not start with {StartFontMetrics}.");
             }
 
-            var version = ReadDecimal(bytes, stringBuilder);
+            var version = ReadDouble(bytes, stringBuilder);
 
             var builder = new AdobeFontMetricsBuilder(version);
 
@@ -368,7 +368,7 @@ namespace UglyToad.PdfPig.Fonts.AdobeFontMetrics
                         builder.Weight = ReadLine(bytes, stringBuilder);
                         break;
                     case ItalicAngle:
-                        builder.ItalicAngle = ReadDecimal(bytes, stringBuilder);
+                        builder.ItalicAngle = ReadDouble(bytes, stringBuilder);
                         break;
                     case IsFixedPitch:
                         builder.IsFixedPitch = ReadBool(bytes, stringBuilder);
@@ -378,10 +378,10 @@ namespace UglyToad.PdfPig.Fonts.AdobeFontMetrics
                             ReadDouble(bytes, stringBuilder), ReadDouble(bytes, stringBuilder));
                         break;
                     case UnderlinePosition:
-                        builder.UnderlinePosition = ReadDecimal(bytes, stringBuilder);
+                        builder.UnderlinePosition = ReadDouble(bytes, stringBuilder);
                         break;
                     case UnderlineThickness:
-                        builder.UnderlineThickness = ReadDecimal(bytes, stringBuilder);
+                        builder.UnderlineThickness = ReadDouble(bytes, stringBuilder);
                         break;
                     case Version:
                         builder.Version = ReadLine(bytes, stringBuilder);
@@ -393,37 +393,37 @@ namespace UglyToad.PdfPig.Fonts.AdobeFontMetrics
                         builder.EncodingScheme = ReadLine(bytes, stringBuilder);
                         break;
                     case MappingScheme:
-                        builder.MappingScheme = (int)ReadDecimal(bytes, stringBuilder);
+                        builder.MappingScheme = (int)ReadDouble(bytes, stringBuilder);
                         break;
                     case CharacterSet:
                         builder.CharacterSet = ReadLine(bytes, stringBuilder);
                         break;
                     case EscChar:
-                        builder.EscapeCharacter = (int) ReadDecimal(bytes, stringBuilder);
+                        builder.EscapeCharacter = (int)ReadDouble(bytes, stringBuilder);
                         break;
                     case Characters:
-                        builder.Characters = (int) ReadDecimal(bytes, stringBuilder);
+                        builder.Characters = (int)ReadDouble(bytes, stringBuilder);
                         break;
                     case IsBaseFont:
                         builder.IsBaseFont = ReadBool(bytes, stringBuilder);
                         break;
                     case CapHeight:
-                        builder.CapHeight = ReadDecimal(bytes, stringBuilder);
+                        builder.CapHeight = ReadDouble(bytes, stringBuilder);
                         break;
                     case XHeight:
-                        builder.XHeight = ReadDecimal(bytes, stringBuilder);
+                        builder.XHeight = ReadDouble(bytes, stringBuilder);
                         break;
                     case Ascender:
-                        builder.Ascender = ReadDecimal(bytes, stringBuilder);
+                        builder.Ascender = ReadDouble(bytes, stringBuilder);
                         break;
                     case Descender:
-                        builder.Descender = ReadDecimal(bytes, stringBuilder);
+                        builder.Descender = ReadDouble(bytes, stringBuilder);
                         break;
                     case StdHw:
-                        builder.StdHw = ReadDecimal(bytes, stringBuilder);
+                        builder.StdHw = ReadDouble(bytes, stringBuilder);
                         break;
                     case StdVw:
-                        builder.StdVw = ReadDecimal(bytes, stringBuilder);
+                        builder.StdVw = ReadDouble(bytes, stringBuilder);
                         break;
                     case CharWidth:
                         builder.SetCharacterWidth(ReadDouble(bytes, stringBuilder), ReadDouble(bytes, stringBuilder));
@@ -435,7 +435,7 @@ namespace UglyToad.PdfPig.Fonts.AdobeFontMetrics
                         builder.IsFixedV = ReadBool(bytes, stringBuilder);
                         break;
                     case StartCharMetrics:
-                        var count = (int)ReadDecimal(bytes, stringBuilder);
+                        var count = (int)ReadDouble(bytes, stringBuilder);
                         for (var i = 0; i < count; i++)
                         {
                             var metric = ReadCharacterMetric(bytes, stringBuilder);
@@ -457,17 +457,10 @@ namespace UglyToad.PdfPig.Fonts.AdobeFontMetrics
             return builder.Build();
         }
 
-        private static decimal ReadDecimal(IInputBytes input, StringBuilder stringBuilder)
-        {
-            var str = ReadString(input, stringBuilder);
-
-            return decimal.Parse(str, CultureInfo.InvariantCulture);
-        }
-
         private static double ReadDouble(IInputBytes input, StringBuilder stringBuilder)
         {
-            var dec = ReadDecimal(input, stringBuilder);
-            return (double) dec;
+            var str = ReadString(input, stringBuilder);
+            return double.Parse(str, CultureInfo.InvariantCulture);
         }
 
         private static bool ReadBool(IInputBytes input, StringBuilder stringBuilder)
@@ -484,7 +477,7 @@ namespace UglyToad.PdfPig.Fonts.AdobeFontMetrics
                     throw new InvalidFontFormatException($"The AFM should have contained a boolean but instead contained: {boolean}.");
             }
         }
-        
+
         private static string ReadString(IInputBytes input, StringBuilder stringBuilder)
         {
             stringBuilder.Clear();
@@ -602,7 +595,7 @@ namespace UglyToad.PdfPig.Fonts.AdobeFontMetrics
                         }
                     case CharmetricsVv:
                         {
-                            metric.VVector = new AdobeFontMetricsVector(double.Parse(parts[1], CultureInfo.InvariantCulture), 
+                            metric.VVector = new AdobeFontMetricsVector(double.Parse(parts[1], CultureInfo.InvariantCulture),
                                 double.Parse(parts[2], CultureInfo.InvariantCulture));
                             break;
                         }

--- a/src/UglyToad.PdfPig.Fonts/AdobeStylePrivateDictionary.cs
+++ b/src/UglyToad.PdfPig.Fonts/AdobeStylePrivateDictionary.cs
@@ -12,12 +12,12 @@
         /// <summary>
         /// Default value of <see cref="BlueScale"/>.
         /// </summary>
-        public static readonly decimal DefaultBlueScale = 0.039625m;
+        public static readonly double DefaultBlueScale = 0.039625;
 
         /// <summary>
         /// Default value of <see cref="ExpansionFactor"/>.
         /// </summary>
-        public static readonly decimal DefaultExpansionFactor = 0.06m;
+        public static readonly double DefaultExpansionFactor = 0.06;
 
         /// <summary>
         /// Default value of <see cref="BlueFuzz"/>.
@@ -33,7 +33,7 @@
         /// Default value of <see cref="LanguageGroup"/>.
         /// </summary>
         public const int DefaultLanguageGroup = 0;
-        
+
         /// <summary>
         /// Required. An array containing an even number of integers.
         /// The first pair is the baseline overshoot position and the baseline.
@@ -76,7 +76,7 @@
         /// points on a 300-dpi device, you should set BlueScale to
         /// (11 − 0.49) ÷ 240 or 0.04379
         /// </example>
-        public decimal BlueScale { get; }
+        public double BlueScale { get; }
 
         /// <summary>
         /// Optional: The character space distance beyond the flat position of alignment zones
@@ -97,22 +97,22 @@
         /// <summary>
         /// Optional: The dominant width of horizontal stems vertically in character space units.
         /// </summary>
-        public decimal? StandardHorizontalWidth { get; }
+        public double? StandardHorizontalWidth { get; }
 
         /// <summary>
         /// Optional: The dominant width of vertical stems horizontally in character space units.
         /// </summary>
-        public decimal? StandardVerticalWidth { get; }
+        public double? StandardVerticalWidth { get; }
 
         /// <summary>
         /// Optional: Up to 12 numbers with the most common widths for horizontal stems vertically in character space units.
         /// </summary>
-        public IReadOnlyList<decimal> StemSnapHorizontalWidths { get; }
+        public IReadOnlyList<double> StemSnapHorizontalWidths { get; }
 
         /// <summary>
         /// Optional: Up to 12 numbers with the most common widths for vertical stems horizontally in character space units.
         /// </summary>
-        public IReadOnlyList<decimal> StemSnapVerticalWidths { get; }
+        public IReadOnlyList<double> StemSnapVerticalWidths { get; }
 
         /// <summary>
         /// Optional: At small sizes at low resolutions this controls whether bold characters should appear thicker using
@@ -131,7 +131,7 @@
         /// Optional: The limit for changing the size of a character bounding box for
         /// <see cref="LanguageGroup"/> 1 counters during font processing.
         /// </summary>
-        public decimal ExpansionFactor { get; }
+        public double ExpansionFactor { get; }
         
         /// <summary>
         /// Creates a new <see cref="AdobeStylePrivateDictionary"/>.
@@ -153,8 +153,8 @@
             BlueShift = builder.BlueShift ?? DefaultBlueShift;
             StandardHorizontalWidth = builder.StandardHorizontalWidth;
             StandardVerticalWidth = builder.StandardVerticalWidth;
-            StemSnapHorizontalWidths = builder.StemSnapHorizontalWidths ?? EmptyArray<decimal>.Instance;
-            StemSnapVerticalWidths = builder.StemSnapVerticalWidths ?? EmptyArray<decimal>.Instance;
+            StemSnapHorizontalWidths = builder.StemSnapHorizontalWidths ?? EmptyArray<double>.Instance;
+            StemSnapVerticalWidths = builder.StemSnapVerticalWidths ?? EmptyArray<double>.Instance;
             ForceBold = builder.ForceBold ?? false;
             LanguageGroup = builder.LanguageGroup ?? DefaultLanguageGroup;
             ExpansionFactor = builder.ExpansionFactor ?? DefaultExpansionFactor;
@@ -188,7 +188,7 @@
             /// <summary>
             /// <see cref="AdobeStylePrivateDictionary.BlueScale"/>.
             /// </summary>
-            public decimal? BlueScale { get; set; }
+            public double? BlueScale { get; set; }
 
             /// <summary>
             /// <see cref="AdobeStylePrivateDictionary.BlueShift"/>.
@@ -203,22 +203,22 @@
             /// <summary>
             /// <see cref="AdobeStylePrivateDictionary.StandardVerticalWidth"/>.
             /// </summary>
-            public decimal? StandardHorizontalWidth { get; set; }
+            public double? StandardHorizontalWidth { get; set; }
 
             /// <summary>
             /// <see cref="AdobeStylePrivateDictionary.StandardVerticalWidth"/>.
             /// </summary>
-            public decimal? StandardVerticalWidth { get; set; }
+            public double? StandardVerticalWidth { get; set; }
 
             /// <summary>
             /// <see cref="AdobeStylePrivateDictionary.StemSnapHorizontalWidths"/>.
             /// </summary>
-            public IReadOnlyList<decimal> StemSnapHorizontalWidths { get; set; }
+            public IReadOnlyList<double> StemSnapHorizontalWidths { get; set; }
 
             /// <summary>
             /// <see cref="AdobeStylePrivateDictionary.StemSnapVerticalWidths"/>.
             /// </summary>
-            public IReadOnlyList<decimal> StemSnapVerticalWidths { get; set; }
+            public IReadOnlyList<double> StemSnapVerticalWidths { get; set; }
 
             /// <summary>
             /// <see cref="AdobeStylePrivateDictionary.ForceBold"/>.
@@ -229,11 +229,11 @@
             /// <see cref="AdobeStylePrivateDictionary.LanguageGroup"/>.
             /// </summary>
             public int? LanguageGroup { get; set; }
-            
+
             /// <summary>
             /// <see cref="AdobeStylePrivateDictionary.ExpansionFactor"/>.
             /// </summary>
-            public decimal? ExpansionFactor { get; set; }
+            public double? ExpansionFactor { get; set; }
         }
     }
 }

--- a/src/UglyToad.PdfPig.Fonts/CompactFontFormat/CompactFontFormatFont.cs
+++ b/src/UglyToad.PdfPig.Fonts/CompactFontFormat/CompactFontFormatFont.cs
@@ -37,7 +37,7 @@
         /// <summary>
         /// The value of Italic Angle from the top dictionary or 0.
         /// </summary>
-        public decimal ItalicAngle => TopDictionary?.ItalicAngle ?? 0;
+        public double ItalicAngle => TopDictionary?.ItalicAngle ?? 0;
 
         internal CompactFontFormatFont(CompactFontFormatTopLevelDictionary topDictionary, CompactFontFormatPrivateDictionary privateDictionary,
             ICompactFontFormatCharset charset,
@@ -68,7 +68,7 @@
                 return null;
             }
 
-            var glyph = type2CharStrings.Generate(characterName, (double)defaultWidthX, (double)nominalWidthX);
+            var glyph = type2CharStrings.Generate(characterName, defaultWidthX, nominalWidthX);
             var rectangle = PdfSubpath.GetBoundingRectangle(glyph.Path);
             if (rectangle.HasValue)
             {
@@ -84,7 +84,6 @@
         /// </summary>
         /// <param name="characterName"></param>
         /// <param name="path"></param>
-        /// <returns></returns>
         public bool TryGetPath(string characterName, out IReadOnlyList<PdfSubpath> path)
         {
             var defaultWidthX = GetDefaultWidthX(characterName);
@@ -101,7 +100,7 @@
                 return false;
             }
 
-            path = type2CharStrings.Generate(characterName, (double)defaultWidthX, (double)nominalWidthX).Path;
+            path = type2CharStrings.Generate(characterName, defaultWidthX, nominalWidthX).Path;
             return true;
         }
 
@@ -125,13 +124,13 @@
                 return null;
             }
 
-            return type2CharStrings.Generate(characterName, (double)defaultWidthX, (double)nominalWidthX).Path;
+            return type2CharStrings.Generate(characterName, defaultWidthX, nominalWidthX).Path;
         }
 
         /// <summary>
         /// Get the default width of x for the character.
         /// </summary>
-        protected virtual decimal GetDefaultWidthX(string characterName)
+        protected virtual double GetDefaultWidthX(string characterName)
         {
             return PrivateDictionary.DefaultWidthX;
         }
@@ -139,7 +138,7 @@
         /// <summary>
         /// Get the nominal width of x for the character.
         /// </summary>
-        protected virtual decimal GetNominalWidthX(string characterName)
+        protected virtual double GetNominalWidthX(string characterName)
         {
             return PrivateDictionary.NominalWidthX;
         }
@@ -163,7 +162,7 @@
             FdSelect = fdSelect;
         }
 
-        protected override decimal GetDefaultWidthX(string characterName)
+        protected override double GetDefaultWidthX(string characterName)
         {
             if (!TryGetPrivateDictionaryForCharacter(characterName, out var dictionary))
             {
@@ -173,7 +172,7 @@
             return dictionary.DefaultWidthX;
         }
 
-        protected override decimal GetNominalWidthX(string characterName)
+        protected override double GetNominalWidthX(string characterName)
         {
             if (!TryGetPrivateDictionaryForCharacter(characterName, out var dictionary))
             {

--- a/src/UglyToad.PdfPig.Fonts/CompactFontFormat/Dictionaries/CompactFontFormatDictionaryReader.cs
+++ b/src/UglyToad.PdfPig.Fonts/CompactFontFormat/Dictionaries/CompactFontFormatDictionaryReader.cs
@@ -91,7 +91,7 @@
             return builder;
         }
 
-        private static decimal ReadRealNumber(CompactFontFormatData data)
+        private static double ReadRealNumber(CompactFontFormatData data)
         {
             var sb = new StringBuilder();
             var done = false;
@@ -170,10 +170,10 @@
 
             if (sb.Length == 0)
             {
-                return 0m;
+                return 0.0;
             }
 
-            return hasExponent ? decimal.Parse(sb.ToString(), NumberStyles.Float, CultureInfo.InvariantCulture) : decimal.Parse(sb.ToString(), CultureInfo.InvariantCulture);
+            return hasExponent ? double.Parse(sb.ToString(), NumberStyles.Float, CultureInfo.InvariantCulture) : double.Parse(sb.ToString(), CultureInfo.InvariantCulture);
         }
 
         protected abstract void ApplyOperation(TBuilder builder, List<Operand> operands, OperandKey operandKey, IReadOnlyList<string> stringIndex);
@@ -187,7 +187,7 @@
 
             if (!operands[0].Int.HasValue)
             {
-                throw new InvalidOperationException($"The first operand for reading a string was not an integer. Got: {operands[0].Decimal}");
+                throw new InvalidOperationException($"The first operand for reading a string was not an integer. Got: {operands[0].Double}");
             }
 
             var index = operands[0].Int.Value;
@@ -213,17 +213,17 @@
                 return new PdfRectangle();
             }
 
-            return new PdfRectangle((double)operands[0].Decimal, (double)operands[1].Decimal,
-                (double)operands[2].Decimal, (double)operands[3].Decimal);
+            return new PdfRectangle(operands[0].Double, operands[1].Double,
+                operands[2].Double, operands[3].Double);
         }
 
-        protected static decimal[] ToArray(List<Operand> operands)
+        protected static double[] ToArray(List<Operand> operands)
         {
-            var result = new decimal[operands.Count];
+            var result = new double[operands.Count];
 
             for (int i = 0; i < result.Length; i++)
             {
-                result[i] = operands[i].Decimal;
+                result[i] = operands[i].Double;
             }
 
             return result;
@@ -255,12 +255,12 @@
                 return results;
             }
 
-            results[0] = (int)operands[0].Decimal;
+            results[0] = (int)operands[0].Double;
 
             for (var i = 1; i < operands.Count; i++)
             {
                 var previous = results[i - 1];
-                var current = operands[i].Decimal;
+                var current = operands[i].Double;
 
                 results[i] = (int)(previous + current);
             }
@@ -268,21 +268,21 @@
             return results;
         }
 
-        protected static decimal[] ReadDeltaToArray(List<Operand> operands)
+        protected static double[] ReadDeltaToArray(List<Operand> operands)
         {
-            var results = new decimal[operands.Count];
+            var results = new double[operands.Count];
 
             if (operands.Count == 0)
             {
                 return results;
             }
 
-            results[0] = operands[0].Decimal;
+            results[0] = operands[0].Double;
 
             for (var i = 1; i < operands.Count; i++)
             {
                 var previous = results[i - 1];
-                var current = operands[i].Decimal;
+                var current = operands[i].Double;
 
                 results[i] = previous + current;
             }
@@ -294,18 +294,18 @@
         {
             public int? Int { get; }
 
-            public decimal Decimal { get; }
+            public double Double { get; }
 
             public Operand(int integer)
             {
                 Int = integer;
-                Decimal = integer;
+                Double = integer;
             }
 
-            public Operand(decimal d)
+            public Operand(double d)
             {
                 Int = null;
-                Decimal = d;
+                Double = d;
             }
         }
 

--- a/src/UglyToad.PdfPig.Fonts/CompactFontFormat/Dictionaries/CompactFontFormatPrivateDictionary.cs
+++ b/src/UglyToad.PdfPig.Fonts/CompactFontFormat/Dictionaries/CompactFontFormatPrivateDictionary.cs
@@ -7,7 +7,7 @@
         /// <summary>
         /// Compatibility entry.
         /// </summary>
-        public decimal InitialRandomSeed { get; }
+        public double InitialRandomSeed { get; }
 
         /// <summary>
         /// The offset in bytes for the local subroutine index in this font. The value is relative to this private dictionary.
@@ -17,12 +17,12 @@
         /// <summary>
         /// If a glyph's width equals the default width X it can be omitted from the charstring.
         /// </summary>
-        public decimal DefaultWidthX { get; }
+        public double DefaultWidthX { get; }
 
         /// <summary>
         /// If not equal to <see cref="DefaultWidthX"/>, Glyph width is computed by adding the charstring width to the nominal width X value.
         /// </summary>
-        public decimal NominalWidthX { get; }
+        public double NominalWidthX { get; }
 
         /// <inheritdoc />
         /// <summary>
@@ -44,19 +44,19 @@
 
         public class Builder : BaseBuilder
         {
-            public decimal InitialRandomSeed { get; set; }
+            public double InitialRandomSeed { get; set; }
 
             public int? LocalSubroutineOffset { get; set; }
 
             /// <summary>
             /// If a glyph's width equals the default width X it can be omitted from the charstring.
             /// </summary>
-            public decimal DefaultWidthX { get; set; }
+            public double DefaultWidthX { get; set; }
 
             /// <summary>
             /// If not equal to <see cref="DefaultWidthX"/>, Glyph width is computed by adding the charstring width to the nominal width X value.
             /// </summary>
-            public decimal NominalWidthX { get; set; }
+            public double NominalWidthX { get; set; }
 
             public CompactFontFormatPrivateDictionary Build()
             {

--- a/src/UglyToad.PdfPig.Fonts/CompactFontFormat/Dictionaries/CompactFontFormatPrivateDictionaryReader.cs
+++ b/src/UglyToad.PdfPig.Fonts/CompactFontFormat/Dictionaries/CompactFontFormatPrivateDictionaryReader.cs
@@ -31,10 +31,10 @@
                     dictionary.FamilyOtherBlues = ReadDeltaToIntArray(operands);
                     break;
                 case 10:
-                    dictionary.StandardHorizontalWidth = operands[0].Decimal;
+                    dictionary.StandardHorizontalWidth = operands[0].Double;
                     break;
                 case 11:
-                    dictionary.StandardVerticalWidth = operands[0].Decimal;
+                    dictionary.StandardVerticalWidth = operands[0].Double;
                     break;
                 case 12:
                 {
@@ -46,7 +46,7 @@
                     switch (operandKey.Byte1.Value)
                     {
                         case 9:
-                            dictionary.BlueScale = operands[0].Decimal;
+                            dictionary.BlueScale = operands[0].Double;
                             break;
                         case 10:
                             dictionary.BlueShift = operands[0].Int;
@@ -61,16 +61,16 @@
                             dictionary.StemSnapVerticalWidths = ReadDeltaToArray(operands);
                             break;
                         case 14:
-                            dictionary.ForceBold = operands[0].Decimal == 1;
+                            dictionary.ForceBold = operands[0].Double == 1;
                             break;
                         case 17:
                             dictionary.LanguageGroup = operands[0].Int;
                             break;
                         case 18:
-                            dictionary.ExpansionFactor = operands[0].Decimal;
+                            dictionary.ExpansionFactor = operands[0].Double;
                             break;
                         case 19:
-                            dictionary.InitialRandomSeed = operands[0].Decimal;
+                            dictionary.InitialRandomSeed = operands[0].Double;
                             break;
                     }
                 }
@@ -79,10 +79,10 @@
                     dictionary.LocalSubroutineOffset = GetIntOrDefault(operands, -1);
                     break;
                 case 20:
-                    dictionary.DefaultWidthX = operands[0].Decimal;
+                    dictionary.DefaultWidthX = operands[0].Double;
                     break;
                 case 21:
-                    dictionary.NominalWidthX = operands[0].Decimal;
+                    dictionary.NominalWidthX = operands[0].Double;
                     break;
             }
         }

--- a/src/UglyToad.PdfPig.Fonts/CompactFontFormat/Dictionaries/CompactFontFormatTopLevelDictionary.cs
+++ b/src/UglyToad.PdfPig.Fonts/CompactFontFormat/Dictionaries/CompactFontFormatTopLevelDictionary.cs
@@ -20,25 +20,25 @@
 
         public bool IsFixedPitch { get; set; }
 
-        public decimal ItalicAngle { get; set; }
+        public double ItalicAngle { get; set; }
 
-        public decimal UnderlinePosition { get; set; } = -100;
+        public double UnderlinePosition { get; set; } = -100;
 
-        public decimal UnderlineThickness { get; set; } = 50;
+        public double UnderlineThickness { get; set; } = 50;
 
-        public decimal PaintType { get; set; }
+        public double PaintType { get; set; }
 
         public CompactFontFormatCharStringType CharStringType { get; set; } = CompactFontFormatCharStringType.Type2;
 
         public TransformationMatrix FontMatrix { get; set; } = TransformationMatrix.FromValues(0.001, 0, 0, 0.001, 0, 0);
 
-        public decimal StrokeWidth { get; set; }
+        public double StrokeWidth { get; set; }
 
-        public decimal UniqueId { get; set; }
+        public double UniqueId { get; set; }
 
         public PdfRectangle FontBoundingBox { get; set; } = new PdfRectangle(0, 0, 0, 0);
 
-        public decimal[] Xuid { get; set; }
+        public double[] Xuid { get; set; }
 
         public int CharSetOffset { get; set; } = UnsetOffset;
 
@@ -54,7 +54,7 @@
 
         public string BaseFontName { get; set; }
 
-        public decimal[] BaseFontBlend { get; set; }
+        public double[] BaseFontBlend { get; set; }
 
         public bool IsCidFont { get; set; }
 
@@ -91,7 +91,7 @@
 
         public int Count { get; set; } = 8720;
 
-        public decimal UidBase { get; set; }
+        public double UidBase { get; set; }
 
         public int FontDictionaryArray { get; set; }
 
@@ -106,7 +106,7 @@
 
         public string Ordering { get; set; }
 
-        public decimal Supplement { get; set; }
+        public double Supplement { get; set; }
     }
 
     /// <summary>

--- a/src/UglyToad.PdfPig.Fonts/CompactFontFormat/Dictionaries/CompactFontFormatTopLevelDictionaryReader.cs
+++ b/src/UglyToad.PdfPig.Fonts/CompactFontFormat/Dictionaries/CompactFontFormatTopLevelDictionaryReader.cs
@@ -50,19 +50,19 @@
                                 dictionary.Copyright = GetString(operands, stringIndex);
                                 break;
                             case 1:
-                                dictionary.IsFixedPitch = operands[0].Decimal == 1;
+                                dictionary.IsFixedPitch = operands[0].Double == 1;
                                 break;
                             case 2:
-                                dictionary.ItalicAngle = operands[0].Decimal;
+                                dictionary.ItalicAngle = operands[0].Double;
                                 break;
                             case 3:
-                                dictionary.UnderlinePosition = operands[0].Decimal;
+                                dictionary.UnderlinePosition = operands[0].Double;
                                 break;
                             case 4:
-                                dictionary.UnderlineThickness = operands[0].Decimal;
+                                dictionary.UnderlineThickness = operands[0].Double;
                                 break;
                             case 5:
-                                dictionary.PaintType = operands[0].Decimal;
+                                dictionary.PaintType = operands[0].Double;
                                 break;
                             case 6:
                                 dictionary.CharStringType = (CompactFontFormatCharStringType)GetIntOrDefault(operands, 2);
@@ -86,7 +86,7 @@
                                 }
                                 break;
                             case 8:
-                                dictionary.StrokeWidth = operands[0].Decimal;
+                                dictionary.StrokeWidth = operands[0].Double;
                                 break;
                             case 20:
                                 dictionary.SyntheticBaseFontIndex = GetIntOrDefault(operands);
@@ -143,7 +143,7 @@
                     }
                     break;
                 case 13:
-                    dictionary.UniqueId = operands.Count > 0 ? operands[0].Decimal : 0;
+                    dictionary.UniqueId = operands.Count > 0 ? operands[0].Double : 0;
                     break;
                 case 14:
                     dictionary.Xuid = ToArray(operands);

--- a/src/UglyToad.PdfPig.Fonts/TrueType/Tables/MaximumProfileTable.cs
+++ b/src/UglyToad.PdfPig.Fonts/TrueType/Tables/MaximumProfileTable.cs
@@ -11,12 +11,12 @@
 
         public TrueTypeHeaderTable DirectoryTable { get; }
 
-        public bool IsCompressedFontFormat => Version == 0.5m;
+        public bool IsCompressedFontFormat => Version == 0.5;
 
         /// <summary>
         /// The table version number. CFF fonts must use version 0.5 and only set number of glyphs. TrueType must use version 1.
         /// </summary>
-        public decimal Version { get; }
+        public double Version { get; }
 
         /// <summary>
         /// The number of glyphs in the font.
@@ -26,7 +26,7 @@
         public BasicMaximumProfileTable(TrueTypeHeaderTable directoryTable, float version, int numberOfGlyphs)
         {
             DirectoryTable = directoryTable;
-            Version = (decimal)version;
+            Version = (double)version;
             NumberOfGlyphs = numberOfGlyphs;
         }
 
@@ -45,7 +45,7 @@
             var maxContours = data.ReadUnsignedShort();
             var maxCompositePoints = data.ReadUnsignedShort();
             var maxCompositeContours = data.ReadUnsignedShort();
-            
+
             var maxZones = data.ReadUnsignedShort();
             var maxTwilightPoints = data.ReadUnsignedShort();
             var maxStorage = data.ReadUnsignedShort();

--- a/src/UglyToad.PdfPig.Fonts/Type1/Parser/Type1ArrayTokenizer.cs
+++ b/src/UglyToad.PdfPig.Fonts/Type1/Parser/Type1ArrayTokenizer.cs
@@ -44,7 +44,7 @@
             {
                 if (char.IsNumber(part[0]) || part[0] == '-')
                 {
-                    if (decimal.TryParse(part, NumberStyles.AllowLeadingSign, CultureInfo.InvariantCulture, out var value))
+                    if (double.TryParse(part, NumberStyles.AllowLeadingSign, CultureInfo.InvariantCulture, out var value))
                     {
                         tokens.Add(new NumericToken(value));
                     }

--- a/src/UglyToad.PdfPig.Fonts/Type1/Parser/Type1EncryptedPortionParser.cs
+++ b/src/UglyToad.PdfPig.Fonts/Type1/Parser/Type1EncryptedPortionParser.cs
@@ -123,27 +123,27 @@
                         }
                     case Type1Symbols.StdHorizontalStemWidth:
                         {
-                            var widths = ReadArrayValues(tokenizer, x => x.AsDecimal());
+                            var widths = ReadArrayValues(tokenizer, x => x.AsDouble());
                             var width = widths[0];
                             builder.StandardHorizontalWidth = width;
                             break;
                         }
                     case Type1Symbols.StdVerticalStemWidth:
                         {
-                            var widths = ReadArrayValues(tokenizer, x => x.AsDecimal());
+                            var widths = ReadArrayValues(tokenizer, x => x.AsDouble());
                             var width = widths[0];
                             builder.StandardVerticalWidth = width;
                             break;
                         }
                     case Type1Symbols.StemSnapHorizontalWidths:
                         {
-                            var widths = ReadArrayValues(tokenizer, x => x.AsDecimal());
+                            var widths = ReadArrayValues(tokenizer, x => x.AsDouble());
                             builder.StemSnapHorizontalWidths = widths;
                             break;
                         }
                     case Type1Symbols.StemSnapVerticalWidths:
                         {
-                            var widths = ReadArrayValues(tokenizer, x => x.AsDecimal());
+                            var widths = ReadArrayValues(tokenizer, x => x.AsDouble());
                             builder.StemSnapVerticalWidths = widths;
                             break;
                         }
@@ -603,7 +603,7 @@
             return results;
         }
 
-        private static decimal ReadNumeric(Type1Tokenizer tokenizer)
+        private static double ReadNumeric(Type1Tokenizer tokenizer)
         {
             var token = tokenizer.GetNext();
 
@@ -612,7 +612,7 @@
                 throw new InvalidOperationException($"Expected to read a numeric token, instead got: {token}.");
             }
 
-            return token.AsDecimal();
+            return token.AsDouble();
         }
 
         private static bool ReadBoolean(Type1Tokenizer tokenizer)

--- a/src/UglyToad.PdfPig.Fonts/Type1/Parser/Type1Token.cs
+++ b/src/UglyToad.PdfPig.Fonts/Type1/Parser/Type1Token.cs
@@ -42,12 +42,12 @@
 
         public int AsInt()
         {
-            return (int)AsDecimal();
+            return (int)AsDouble();
         }
 
-        public decimal AsDecimal()
+        public double AsDouble()
         {
-            return decimal.Parse(Text, CultureInfo.InvariantCulture);
+            return double.Parse(Text, CultureInfo.InvariantCulture);
         }
 
         public bool AsBool()
@@ -69,11 +69,11 @@
             Real,
             Integer,
             /// <summary>
-            /// An array must begin with either '[' or '{'. 
+            /// An array must begin with either '[' or '{'.
             /// </summary>
             StartArray,
             /// <summary>
-            /// An array must end with either ']' or '}'. 
+            /// An array must end with either ']' or '}'.
             /// </summary>
             EndArray,
             StartProc,

--- a/src/UglyToad.PdfPig.Tests/Core/TransformationMatrixTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Core/TransformationMatrixTests.cs
@@ -10,19 +10,19 @@
         {
             new object[]
             {
-                new decimal[]
+                new double[]
                 {
                     1, 0, 0,
                     0, 1, 0,
                     0, 0, 1
                 },
-                new decimal[]
+                new double[]
                 {
                     1, 0, 0,
                     0, 1, 0,
                     0, 0, 1
                 },
-                new decimal[]
+                new double[]
                 {
                     1, 0, 0,
                     0, 1, 0,
@@ -31,19 +31,19 @@
             },
             new object[]
             {
-                new decimal[]
+                new double[]
                 {
                     65, 9, 3,
                     5, 2, 7,
                     11, 1, 6
                 },
-                new decimal[]
+                new double[]
                 {
                     1, 2, 3,
                     4, 5, 6,
                     7, 8, 9
                 },
-                new decimal[]
+                new double[]
                 {
                     122, 199, 276,
                     62, 76, 90,
@@ -52,19 +52,19 @@
             },
             new object[]
             {
-                new decimal[]
+                new double[]
                 {
                     3, 5, 7,
                     11, 13, -3,
                     17, -6, -9
                 },
-                new decimal[]
+                new double[]
                 {
                     5, 4, 3,
                     3, 7, 12,
                     1, 0, 6
                 },
-                new decimal[]
+                new double[]
                 {
                     37, 47, 111,
                     91, 135, 171,
@@ -75,7 +75,7 @@
 
         [Theory]
         [MemberData(nameof(MultiplicationData))]
-        public void MultipliesCorrectly(decimal[] a, decimal[] b, decimal[] expected)
+        public void MultipliesCorrectly(double[] a, double[] b, double[] expected)
         {
             var matrixA = TransformationMatrix.FromArray(a);
             var matrixB = TransformationMatrix.FromArray(b);

--- a/src/UglyToad.PdfPig.Tests/Functions/PdfFunctionType0Tests.cs
+++ b/src/UglyToad.PdfPig.Tests/Functions/PdfFunctionType0Tests.cs
@@ -16,7 +16,7 @@
 
         private static ArrayToken GetArrayToken(params double[] data)
         {
-            return new ArrayToken(data.Select(v => new NumericToken((decimal)v)).ToArray());
+            return new ArrayToken(data.Select(v => new NumericToken(v)).ToArray());
         }
 
         [Fact]

--- a/src/UglyToad.PdfPig.Tests/Functions/PdfFunctionType2Tests.cs
+++ b/src/UglyToad.PdfPig.Tests/Functions/PdfFunctionType2Tests.cs
@@ -15,12 +15,12 @@
             DictionaryToken dictionaryToken = new DictionaryToken(new Dictionary<NameToken, IToken>()
             {
                 { NameToken.FunctionType, new NumericToken(2) },
-                { NameToken.Domain, new ArrayToken(domain.Select(v => new NumericToken((decimal)v)).ToArray()) },
-                { NameToken.Range, new ArrayToken(range.Select(v => new NumericToken((decimal)v)).ToArray()) },
+                { NameToken.Domain, new ArrayToken(domain.Select(v => new NumericToken(v)).ToArray()) },
+                { NameToken.Range, new ArrayToken(range.Select(v => new NumericToken(v)).ToArray()) },
 
-                { NameToken.C0, new ArrayToken(c0.Select(v => new NumericToken((decimal)v)).ToArray()) },
-                { NameToken.C1, new ArrayToken(c1.Select(v => new NumericToken((decimal)v)).ToArray()) },
-                { NameToken.N, new NumericToken((decimal)n) },
+                { NameToken.C0, new ArrayToken(c0.Select(v => new NumericToken(v)).ToArray()) },
+                { NameToken.C1, new ArrayToken(c1.Select(v => new NumericToken(v)).ToArray()) },
+                { NameToken.N, new NumericToken(n) },
             });
 
             var func = PdfFunctionParser.Create(dictionaryToken, new TestPdfTokenScanner(), new TestFilterProvider());

--- a/src/UglyToad.PdfPig.Tests/Functions/PdfFunctionType4Tests.cs
+++ b/src/UglyToad.PdfPig.Tests/Functions/PdfFunctionType4Tests.cs
@@ -16,8 +16,8 @@
             DictionaryToken dictionaryToken = new DictionaryToken(new Dictionary<NameToken, IToken>()
             {
                 { NameToken.FunctionType, new NumericToken(4) },
-                { NameToken.Domain, new ArrayToken(domain.Select(v => new NumericToken((decimal)v)).ToArray()) },
-                { NameToken.Range, new ArrayToken(range.Select(v => new NumericToken((decimal)v)).ToArray()) },
+                { NameToken.Domain, new ArrayToken(domain.Select(v => new NumericToken(v)).ToArray()) },
+                { NameToken.Range, new ArrayToken(range.Select(v => new NumericToken(v)).ToArray()) },
             });
 
             var data = Encoding.ASCII.GetBytes(function); // OtherEncodings.Iso88591.GetBytes(function);

--- a/src/UglyToad.PdfPig.Tests/Graphics/Operations/GraphicsStateOperationTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Graphics/Operations/GraphicsStateOperationTests.cs
@@ -95,17 +95,17 @@
                 {
                     result[i] = NameToken.Create("Hog");
                 }
-                else if (type == typeof(decimal))
+                else if (type == typeof(double))
                 {
-                    result[i] = 0.5m;
+                    result[i] = 0.5;
                 }
                 else if (type == typeof(int))
                 {
                     result[i] = 1;
                 }
-                else if (type == typeof(decimal[]) || type == typeof(IReadOnlyList<decimal>))
+                else if (type == typeof(double[]) || type == typeof(IReadOnlyList<double>))
                 {
-                    result[i] = new decimal[]
+                    result[i] = new double[]
                     {
                         1, 0, 0, 1, 2, 5
                     };

--- a/src/UglyToad.PdfPig.Tests/Graphics/Operations/TextState/SetFontAndSizeTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Graphics/Operations/TextState/SetFontAndSizeTests.cs
@@ -20,10 +20,10 @@
         [Fact]
         public void SetsValues()
         {
-            var setFontAndSize = new SetFontAndSize(Font1Name, 12.75m);
+            var setFontAndSize = new SetFontAndSize(Font1Name, 12.75);
 
             Assert.Equal("Font1", setFontAndSize.Font.Data);
-            Assert.Equal(12.75m, setFontAndSize.Size);
+            Assert.Equal(12.75, setFontAndSize.Size);
         }
 
         [Fact]
@@ -46,7 +46,7 @@
         [Fact]
         public void StringRepresentationIsCorrect()
         {
-            var setFontAndSize = new SetFontAndSize(Font1Name, 12.76m);
+            var setFontAndSize = new SetFontAndSize(Font1Name, 12.76);
 
             Assert.Equal("/Font1 12.76 Tf", setFontAndSize.ToString());
         }
@@ -54,7 +54,7 @@
         [Fact]
         public void RunSetsFontAndFontSize()
         {
-            var setFontAndSize = new SetFontAndSize(Font1Name, 69.42m);
+            var setFontAndSize = new SetFontAndSize(Font1Name, 69.42);
 
             var context = new TestOperationContext();
 

--- a/src/UglyToad.PdfPig.Tests/Graphics/TestOperationContext.cs
+++ b/src/UglyToad.PdfPig.Tests/Graphics/TestOperationContext.cs
@@ -192,7 +192,7 @@
             TextMatrices.TextMatrix = matrix.Multiply(TextMatrices.TextMatrix);
         }
 
-        public void SetFlatnessTolerance(decimal tolerance)
+        public void SetFlatnessTolerance(double tolerance)
         {
             GetCurrentState().Flatness = tolerance;
         }
@@ -212,19 +212,19 @@
             GetCurrentState().JoinStyle = join;
         }
 
-        public void SetLineWidth(decimal width)
+        public void SetLineWidth(double width)
         {
             GetCurrentState().LineWidth = width;
         }
 
-        public void SetMiterLimit(decimal limit)
+        public void SetMiterLimit(double limit)
         {
             GetCurrentState().MiterLimit = limit;
         }
 
         public void MoveToNextLineWithOffset()
         {
-            var tdOperation = new MoveToNextLineWithOffset(0, -1 * (decimal)GetCurrentState().FontState.Leading);
+            var tdOperation = new MoveToNextLineWithOffset(0, -1 * GetCurrentState().FontState.Leading);
             tdOperation.Run(this);
         }
 

--- a/src/UglyToad.PdfPig.Tests/Integration/MultiplePageMortalityStatisticsTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Integration/MultiplePageMortalityStatisticsTests.cs
@@ -30,7 +30,7 @@
         {
             using (var document = PdfDocument.Open(GetFilename()))
             {
-                Assert.Equal(1.7m, document.Version);
+                Assert.Equal(1.7, document.Version);
             }
         }
 

--- a/src/UglyToad.PdfPig.Tests/Integration/SwedishTouringCarChampionshipTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Integration/SwedishTouringCarChampionshipTests.cs
@@ -25,7 +25,7 @@
         {
             using (var document = PdfDocument.Open(GetFilename()))
             {
-                Assert.Equal(1.4m, document.Version);
+                Assert.Equal(1.4, document.Version);
             }
         }
 

--- a/src/UglyToad.PdfPig.Tests/Parser/Parts/FileHeaderParserTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Parser/Parts/FileHeaderParserTests.cs
@@ -50,7 +50,7 @@
 
             var result = FileHeaderParser.Parse(scanner.scanner, scanner.bytes, false, log);
 
-            Assert.Equal(1.2m, result.Version);
+            Assert.Equal(1.2, result.Version);
             Assert.Equal(TestEnvironment.IsSingleByteNewLine(input) ? 7 : 9, result.OffsetInFile);
         }
 
@@ -58,7 +58,7 @@
         public void EmptyInputThrows()
         {
             var scanner = StringBytesTestConverter.Scanner(string.Empty);
-            
+
             Action action = () => FileHeaderParser.Parse(scanner.scanner, scanner.bytes, false, log);
 
             Assert.Throws<PdfDocumentFormatException>(action);
@@ -73,7 +73,7 @@
 
             var result = FileHeaderParser.Parse(scanner.scanner, scanner.bytes, false, log);
 
-            Assert.Equal(1.2m, result.Version);
+            Assert.Equal(1.2, result.Version);
             Assert.Equal(TestEnvironment.IsSingleByteNewLine(input) ? 12 : 13, result.OffsetInFile);
         }
 
@@ -86,7 +86,7 @@
 
             var result = FileHeaderParser.Parse(scanner.scanner, scanner.bytes, true, log);
 
-            Assert.Equal(1.7m, result.Version);
+            Assert.Equal(1.7, result.Version);
             Assert.Equal(TestEnvironment.IsSingleByteNewLine(input) ? 12 : 13, result.OffsetInFile);
         }
 
@@ -100,7 +100,7 @@ three %PDF-1.6";
 
             var result = FileHeaderParser.Parse(scanner.scanner, scanner.bytes, true, log);
 
-            Assert.Equal(1.6m, result.Version);
+            Assert.Equal(1.6, result.Version);
             Assert.Equal(TestEnvironment.IsSingleByteNewLine(s) ? 14 : 15, result.OffsetInFile);
         }
 
@@ -131,7 +131,7 @@ three %PDF-1.6";
 
             var result = FileHeaderParser.Parse(scanner.scanner, scanner.bytes, true, log);
 
-            Assert.Equal(1.4m, result.Version);
+            Assert.Equal(1.4, result.Version);
         }
 
         [Fact]
@@ -156,7 +156,7 @@ three %PDF-1.6";
 
             var result = FileHeaderParser.Parse(scanner, bytes, false, log);
 
-            Assert.Equal(1.7m, result.Version);
+            Assert.Equal(1.7, result.Version);
         }
 
         [Fact]
@@ -175,7 +175,7 @@ three %PDF-1.6";
 
             Assert.Equal(0, scanner.scanner.CurrentPosition);
             Assert.Equal(128, result.OffsetInFile);
-            Assert.Equal(1.1m, result.Version);
+            Assert.Equal(1.1, result.Version);
             Assert.Equal("PDF-1.1", result.VersionString);
         }
     }

--- a/src/UglyToad.PdfPig.Tests/TestPdfImage.cs
+++ b/src/UglyToad.PdfPig.Tests/TestPdfImage.cs
@@ -24,7 +24,7 @@
 
         public bool IsImageMask { get; set; }
 
-        public IReadOnlyList<decimal> Decode { get; set; }
+        public IReadOnlyList<double> Decode { get; set; }
 
         public bool Interpolate { get; set; }
 

--- a/src/UglyToad.PdfPig.Tests/Tokenization/ArrayTokenizerTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Tokenization/ArrayTokenizerTests.cs
@@ -27,12 +27,12 @@
 
         public static IEnumerable<object[]> SingleElementTestData => new[]
         {
-            new object[] {"[12]", 12m},
-            new object[] {"[ 12 ]", 12m},
+            new object[] {"[12]", 12.0},
+            new object[] {"[ 12 ]", 12.0},
             new object[] {@"[ 
-2948344 ]", 2948344m},
-            new object[] { "[(Bertrand)  \t]", "Bertrand" }, 
-            new object[] { "[ <AE>\r\n]", "®" }, 
+2948344 ]", 2948344.0},
+            new object[] { "[(Bertrand)  \t]", "Bertrand" },
+            new object[] { "[ <AE>\r\n]", "®" },
         };
 
         [Theory]
@@ -82,8 +82,8 @@
 
             var array = AssertArrayToken(token);
 
-            Assert.Equal(12m, AssertDataToken<NumericToken, decimal>(0, array).Data);
-            Assert.Equal(10.453m, AssertDataToken<NumericToken, decimal>(1, array).Data);
+            Assert.Equal(12, AssertDataToken<NumericToken, double>(0, array).Data);
+            Assert.Equal(10.453, AssertDataToken<NumericToken, double>(1, array).Data);
             Assert.Equal(NameToken.Create("Fonts"), AssertDataToken<NameToken, string>(2, array).Data);
 
             var inner = AssertArrayToken(array.Data[3]);
@@ -113,13 +113,13 @@
 
             var firstFirstInner = AssertArrayToken(firstInner.Data[0]);
 
-            Assert.Equal(19m, AssertDataToken<NumericToken, decimal>(0, firstFirstInner).Data);
-            Assert.Equal(-69m, AssertDataToken<NumericToken, decimal>(1, firstFirstInner).Data);
-            
+            Assert.Equal(19, AssertDataToken<NumericToken, double>(0, firstFirstInner).Data);
+            Assert.Equal(-69, AssertDataToken<NumericToken, double>(1, firstFirstInner).Data);
+
             var secondFirstInner = AssertArrayToken(firstInner.Data[1]);
 
-            Assert.Equal(7m, AssertDataToken<NumericToken, decimal>(0, secondFirstInner).Data);
-            Assert.Equal(64.625m, AssertDataToken<NumericToken, decimal>(1, secondFirstInner).Data);
+            Assert.Equal(7, AssertDataToken<NumericToken, double>(0, secondFirstInner).Data);
+            Assert.Equal(64.625, AssertDataToken<NumericToken, double>(1, secondFirstInner).Data);
 
             Assert.Equal("More", AssertDataToken<StringToken, string>(2, array).Data);
 
@@ -129,7 +129,7 @@
 
             var firstFirstSecondInner = AssertArrayToken(firstSecondInner.Data[0]);
 
-            Assert.Equal(15m, AssertDataToken<NumericToken, decimal>(0, firstFirstSecondInner).Data);
+            Assert.Equal(15, AssertDataToken<NumericToken, double>(0, firstFirstSecondInner).Data);
         }
 
         [Fact]
@@ -145,13 +145,13 @@
 
             var array = AssertArrayToken(token);
 
-            Assert.Equal(549m, AssertDataToken<NumericToken, decimal>(0, array).Data);
-            Assert.Equal(3.14m, AssertDataToken<NumericToken, decimal>(1, array).Data);
+            Assert.Equal(549, AssertDataToken<NumericToken, double>(0, array).Data);
+            Assert.Equal(3.14, AssertDataToken<NumericToken, double>(1, array).Data);
             Assert.False(AssertDataToken<BooleanToken, bool>(2, array).Data);
             Assert.Equal("Ralph", AssertDataToken<StringToken, string>(3, array).Data);
             Assert.Equal(NameToken.Create("SomeName"), AssertDataToken<NameToken, string>(4, array).Data);
         }
-        
+
         private static ArrayToken AssertArrayToken(IToken token)
         {
             Assert.NotNull(token);

--- a/src/UglyToad.PdfPig.Tests/Tokenization/DictionaryTokenizerTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Tokenization/DictionaryTokenizerTests.cs
@@ -67,8 +67,8 @@ namespace UglyToad.PdfPig.Tests.Tokenization
             var dictionary = AssertDictionaryToken(token);
 
             AssertDictionaryEntry<NameToken, string>(dictionary, NameToken.Filter, NameToken.FlateDecode.Data);
-            AssertDictionaryEntry<NumericToken, decimal>(dictionary, NameToken.S, 36);
-            AssertDictionaryEntry<NumericToken, decimal>(dictionary, NameToken.Length, 53);
+            AssertDictionaryEntry<NumericToken, double>(dictionary, NameToken.S, 36);
+            AssertDictionaryEntry<NumericToken, double>(dictionary, NameToken.Length, 53);
         }
 
         [Fact]
@@ -111,11 +111,11 @@ namespace UglyToad.PdfPig.Tests.Tokenization
             Assert.True(result);
 
             var dictionary = AssertDictionaryToken(token);
-            
+
             AssertDictionaryEntry<NameToken, string>(dictionary, NameToken.Type, "Example");
             AssertDictionaryEntry<NameToken, string>(dictionary, NameToken.Subtype, "DictionaryExample");
-            AssertDictionaryEntry<NumericToken, decimal>(dictionary, NameToken.Version, 0.01m);
-            AssertDictionaryEntry<NumericToken, decimal>(dictionary, NameToken.Create("IntegerItem"), 12m);
+            AssertDictionaryEntry<NumericToken, double>(dictionary, NameToken.Version, 0.01);
+            AssertDictionaryEntry<NumericToken, double>(dictionary, NameToken.Create("IntegerItem"), 12);
             AssertDictionaryEntry<StringToken, string>(dictionary, NameToken.Create("StringItem"), "a string");
 
             var subDictionary = GetIndex(5, dictionary);
@@ -123,13 +123,13 @@ namespace UglyToad.PdfPig.Tests.Tokenization
             Assert.Equal("Subdictionary", subDictionary.Key);
 
             var subDictionaryValue = Assert.IsType<DictionaryToken>(subDictionary.Value);
-            
-            AssertDictionaryEntry<NumericToken, decimal>(subDictionaryValue, NameToken.Create("Item1"), 0.4m);
+
+            AssertDictionaryEntry<NumericToken, double>(subDictionaryValue, NameToken.Create("Item1"), 0.4);
             AssertDictionaryEntry<BooleanToken, bool>(subDictionaryValue, NameToken.Create("Item2"), true);
             AssertDictionaryEntry<StringToken, string>(subDictionaryValue, NameToken.Create("LastItem"), "not!");
             AssertDictionaryEntry<StringToken, string>(subDictionaryValue, NameToken.Create("VeryLastItem"), "OK");
         }
-        
+
         [Fact]
         public void ExitsDictionaryParsingSingleLevel()
         {
@@ -162,7 +162,7 @@ endobj
 
             var dictionary = AssertDictionaryToken(token);
 
-            AssertDictionaryEntry<NumericToken, decimal>(dictionary, NameToken.Count, 12);
+            AssertDictionaryEntry<NumericToken, double>(dictionary, NameToken.Count, 12);
 
             var subDictionaryToken = GetIndex(1, dictionary);
 

--- a/src/UglyToad.PdfPig.Tests/Tokenization/NumericTokenizerTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Tokenization/NumericTokenizerTests.cs
@@ -30,39 +30,39 @@
 
         public static IEnumerable<object[]> ValidNumberTestData => new []
         {
-            new object[] {"0", 0m},
-            new object[] {"1", 1m},
-            new object[] {"2", 2m},
-            new object[] {"3", 3m},
-            new object[] {"4", 4m},
-            new object[] {"5", 5m},
-            new object[] {"6", 6m},
-            new object[] {"7", 7m},
-            new object[] {"8", 8m},
-            new object[] {"9", 9m},
-            new object[] {"10", 10m},
-            new object[] {"11", 11m},
-            new object[] {"29", 29m},
-            new object[] {"-0", 0m},
-            new object[] {"-0123", -123m},
-            new object[] {"-6.9000", -6.9m},
-            new object[] {"57473.3458382", 57473.3458382m},
-            new object[] { "123", 123m},
-            new object[] { "43445", 43445m},
-            new object[] { "+17", 17m},
-            new object[] { "-98", -98m},
-            new object[] { "34.5", 34.5m},
-            new object[] { "-3.62", -3.62m},
-            new object[] { "+123.6", 123.6m},
-            new object[] { "4.", 4m},
-            new object[] { "-.002", -0.002m},
-            new object[] { "0.0", 0m},
-            new object[] {"1.57e3", 1570m}
+            new object[] {"0", 0},
+            new object[] {"1", 1},
+            new object[] {"2", 2},
+            new object[] {"3", 3},
+            new object[] {"4", 4},
+            new object[] {"5", 5},
+            new object[] {"6", 6},
+            new object[] {"7", 7},
+            new object[] {"8", 8},
+            new object[] {"9", 9},
+            new object[] {"10", 10},
+            new object[] {"11", 11},
+            new object[] {"29", 29},
+            new object[] {"-0", 0},
+            new object[] {"-0123", -123},
+            new object[] {"-6.9000", -6.9},
+            new object[] {"57473.3458382", 57473.3458382},
+            new object[] { "123", 123},
+            new object[] { "43445", 43445},
+            new object[] { "+17", 17},
+            new object[] { "-98", -98},
+            new object[] { "34.5", 34.5},
+            new object[] { "-3.62", -3.62},
+            new object[] { "+123.6", 123.6},
+            new object[] { "4.", 4},
+            new object[] { "-.002", -0.002},
+            new object[] { "0.0", 0},
+            new object[] {"1.57e3", 1570}
         };
 
         [Theory]
         [MemberData(nameof(ValidNumberTestData))]
-        public void ParsesValidNumbers(string s, decimal expected)
+        public void ParsesValidNumbers(string s, double expected)
         {
             var input = StringBytesTestConverter.Convert(s);
 
@@ -80,7 +80,7 @@
             var result = tokenizer.TryTokenize(input.First, input.Bytes, out var token);
 
             Assert.True(result);
-            Assert.Equal(135.6654m, AssertNumericToken(token).Data);
+            Assert.Equal(135.6654, AssertNumericToken(token).Data);
 
             Assert.Equal('/', (char)input.Bytes.CurrentByte);
         }
@@ -93,7 +93,7 @@
             var result = tokenizer.TryTokenize(input.First, input.Bytes, out var token);
 
             Assert.True(result);
-            Assert.Equal(0m, AssertNumericToken(token).Data);
+            Assert.Equal(0, AssertNumericToken(token).Data);
         }
 
         [Fact]
@@ -105,7 +105,7 @@
             var result = tokenizer.TryTokenize(input.First, input.Bytes, out var token);
 
             Assert.True(result);
-            Assert.Equal(-10.25m, AssertNumericToken(token).Data);
+            Assert.Equal(-10.25, AssertNumericToken(token).Data);
         }
 
         [Fact]
@@ -116,7 +116,7 @@
             var result = tokenizer.TryTokenize(input.First, input.Bytes, out var token);
 
             Assert.True(result);
-            Assert.Equal(0m, AssertNumericToken(token).Data);
+            Assert.Equal(0, AssertNumericToken(token).Data);
         }
 
         private static NumericToken AssertNumericToken(IToken token)

--- a/src/UglyToad.PdfPig.Tests/Tokenization/Scanner/CoreTokenScannerTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Tokenization/Scanner/CoreTokenScannerTests.cs
@@ -31,8 +31,8 @@ namespace UglyToad.PdfPig.Tests.Tokenization.Scanner
                 tokens.Add(scanner.CurrentToken);
             }
 
-            AssertCorrectToken<NumericToken, decimal>(tokens[0], 549);
-            AssertCorrectToken<NumericToken, decimal>(tokens[1], 3.14m);
+            AssertCorrectToken<NumericToken, double>(tokens[0], 549);
+            AssertCorrectToken<NumericToken, double>(tokens[1], 3.14);
             AssertCorrectToken<BooleanToken, bool>(tokens[2], false);
             AssertCorrectToken<StringToken, string>(tokens[3], "Ralph");
             AssertCorrectToken<NameToken, string>(tokens[4], "SomeName");
@@ -61,9 +61,9 @@ namespace UglyToad.PdfPig.Tests.Tokenization.Scanner
             AssertCorrectToken<NameToken, string>(tokens[2], NameToken.Subtype.Data);
             AssertCorrectToken<NameToken, string>(tokens[3], "DictionaryExample");
             AssertCorrectToken<NameToken, string>(tokens[4], NameToken.Version.Data);
-            AssertCorrectToken<NumericToken, decimal>(tokens[5], 0.01m);
+            AssertCorrectToken<NumericToken, double>(tokens[5], 0.01);
             AssertCorrectToken<NameToken, string>(tokens[6], "IntegerItem");
-            AssertCorrectToken<NumericToken, decimal>(tokens[7], 12m);
+            AssertCorrectToken<NumericToken, double>(tokens[7], 12);
             AssertCorrectToken<NameToken, string>(tokens[8], "StringItem");
             AssertCorrectToken<StringToken, string>(tokens[9], "a string");
         }
@@ -84,8 +84,8 @@ endobj";
                 tokens.Add(scanner.CurrentToken);
             }
 
-            AssertCorrectToken<NumericToken, decimal>(tokens[0], 12);
-            AssertCorrectToken<NumericToken, decimal>(tokens[1], 0);
+            AssertCorrectToken<NumericToken, double>(tokens[0], 12);
+            AssertCorrectToken<NumericToken, double>(tokens[1], 0);
             Assert.Equal(tokens[2], OperatorToken.StartObject);
             AssertCorrectToken<StringToken, string>(tokens[3], "Brillig");
             Assert.Equal(tokens[4], OperatorToken.EndObject);
@@ -137,14 +137,14 @@ endobj";
             Assert.Equal(30, tokens.Count);
 
             AssertCorrectToken<OperatorToken, string>(tokens[29], "Td");
-            AssertCorrectToken<NumericToken, decimal>(tokens[28], 0);
-            AssertCorrectToken<NumericToken, decimal>(tokens[27], 16.12m);
+            AssertCorrectToken<NumericToken, double>(tokens[28], 0);
+            AssertCorrectToken<NumericToken, double>(tokens[27], 16.12);
             AssertCorrectToken<OperatorToken, string>(tokens[26], "Tw");
 
             var array = Assert.IsType<ArrayToken>(tokens[21]);
 
             AssertCorrectToken<StringToken, string>(array.Data[array.Data.Count - 1], ")");
-            AssertCorrectToken<NumericToken, decimal>(array.Data[array.Data.Count - 2], 1.9m);
+            AssertCorrectToken<NumericToken, double>(array.Data[array.Data.Count - 2], 1.9);
         }
 
         [Fact]
@@ -167,7 +167,7 @@ endobj";
             AssertCorrectToken<OperatorToken, string>(tokens[0], "T*");
             AssertCorrectToken<StringToken, string>(tokens[1], "");
             AssertCorrectToken<OperatorToken, string>(tokens[2], "Tj");
-            AssertCorrectToken<NumericToken, decimal>(tokens[3], -91);
+            AssertCorrectToken<NumericToken, double>(tokens[3], -91);
         }
 
         [Fact]
@@ -188,11 +188,11 @@ endobj";
 
             Assert.Equal(6, tokens.Count);
 
-            AssertCorrectToken<NumericToken, decimal>(tokens[0], 0m);
-            AssertCorrectToken<NumericToken, decimal>(tokens[1], -21.72m);
+            AssertCorrectToken<NumericToken, double>(tokens[0], 0);
+            AssertCorrectToken<NumericToken, double>(tokens[1], -21.72);
             AssertCorrectToken<OperatorToken, string>(tokens[2], "TD");
             AssertCorrectToken<NameToken, string>(tokens[3], "F1");
-            AssertCorrectToken<NumericToken, decimal>(tokens[4], 8m);
+            AssertCorrectToken<NumericToken, double>(tokens[4], 8);
             AssertCorrectToken<OperatorToken, string>(tokens[5], "Tf");
 
         }

--- a/src/UglyToad.PdfPig.Tests/Writer/Fonts/Standard14WritingFontTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Writer/Fonts/Standard14WritingFontTests.cs
@@ -899,7 +899,7 @@
             double maxCharacterWidth;
             {
                 var point = new PdfPoint(10, 10);
-                var characterRectangles = unicodesCharacters.Select(v => page.MeasureText($"{v}", 12m, point, font)[0].GlyphRectangle);
+                var characterRectangles = unicodesCharacters.Select(v => page.MeasureText($"{v}", 12, point, font)[0].GlyphRectangle);
                 maxCharacterHeight = characterRectangles.Max(v => v.Height);
                 maxCharacterWidth = characterRectangles.Max(v => v.Height);
             }
@@ -922,7 +922,7 @@
             var stampTextUTC = "  UTC: " + DateTime.UtcNow.ToString("yyyy-MMM-dd HH:mm");
             var stampTextLocal = "Local: " + DateTimeOffset.Now.ToString("yyyy-MMM-dd HH:mm zzz");
 
-            const decimal fontSize = 7m;
+            const double fontSize = 7;
 
             var indentFromLeft = page.PageSize.Width - cm;
             {
@@ -936,13 +936,13 @@
 
             {
                 point = new PdfPoint(indentFromLeft, point.Y);
-                var letters = page.AddText(stampTextUTC, 7m, point, courierFont);
+                var letters = page.AddText(stampTextUTC, 7, point, courierFont);
                 var maxHeight = letters.Max(v => v.GlyphRectangle.Height);
                 point = new PdfPoint(indentFromLeft, point.Y - maxHeight * 1.2);
             }
 
             {
-                var letters = page.AddText(stampTextLocal, 7m, point, courierFont);
+                var letters = page.AddText(stampTextLocal, 7, point, courierFont);
             }
         }
     }

--- a/src/UglyToad.PdfPig.Tests/Writer/PdfDocumentBuilderTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Writer/PdfDocumentBuilderTests.cs
@@ -266,8 +266,8 @@
             page.SetStrokeColor(250, 132, 131);
             page.DrawLine(new PdfPoint(25, 70), new PdfPoint(100, 70), 3);
             page.ResetColor();
-            page.DrawRectangle(new PdfPoint(30, 200), 250, 100, 0.5m);
-            page.DrawRectangle(new PdfPoint(30, 100), 250, 100, 0.5m);
+            page.DrawRectangle(new PdfPoint(30, 200), 250, 100, 0.5);
+            page.DrawRectangle(new PdfPoint(30, 100), 250, 100, 0.5);
 
             var file = TrueTypeTestHelper.GetFileBytes("Andada-Regular.ttf");
 
@@ -493,10 +493,10 @@
             page1.AddText("incididunt ut labore et dolore magna aliqua.", 9, new PdfPoint(30, topLine.Y - letters.Max(x => x.GlyphRectangle.Height) - 5), font);
 
             var page2Letters = page2.AddText("The very hungry caterpillar ate all the apples in the garden.", 12, topLine, font);
-            var left = (decimal)page2Letters[0].GlyphRectangle.Left;
-            var bottom = (decimal)page2Letters.Min(x => x.GlyphRectangle.Bottom);
-            var right = (decimal)page2Letters[page2Letters.Count - 1].GlyphRectangle.Right;
-            var top = (decimal)page2Letters.Max(x => x.GlyphRectangle.Top);
+            var left = page2Letters[0].GlyphRectangle.Left;
+            var bottom = page2Letters.Min(x => x.GlyphRectangle.Bottom);
+            var right = page2Letters[page2Letters.Count - 1].GlyphRectangle.Right;
+            var top = page2Letters.Max(x => x.GlyphRectangle.Top);
             page2.SetStrokeColor(10, 250, 69);
             page2.DrawRectangle(new PdfPoint(left, bottom), right - left, top - bottom);
 
@@ -738,7 +738,7 @@
             page.SetTextAndFillColor(255, 0, 0);
             page.SetStrokeColor(0, 0, 255);
 
-            page.DrawRectangle(new PdfPoint(20, 100), 200, 100, 1.5m, true);
+            page.DrawRectangle(new PdfPoint(20, 100), 200, 100, 1.5, true);
 
             var file = builder.Build();
             WriteFile(nameof(CanCreateDocumentWithFilledRectangle), file);
@@ -847,8 +847,8 @@
             page.SetStrokeColor(250, 132, 131);
             page.DrawLine(new PdfPoint(25, 70), new PdfPoint(100, 70), 3);
             page.ResetColor();
-            page.DrawRectangle(new PdfPoint(30, 200), 250, 100, 0.5m);
-            page.DrawRectangle(new PdfPoint(30, 100), 250, 100, 0.5m);
+            page.DrawRectangle(new PdfPoint(30, 200), 250, 100, 0.5);
+            page.DrawRectangle(new PdfPoint(30, 100), 250, 100, 0.5);
 
             var file = TrueTypeTestHelper.GetFileBytes("Andada-Regular.ttf");
 

--- a/src/UglyToad.PdfPig.Tests/Writer/PdfMergerTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Writer/PdfMergerTests.cs
@@ -56,7 +56,7 @@
                 Assert.Equal(2, document.NumberOfPages);
                 if (checkVersion)
                 {
-                    Assert.Equal(1.5m, document.Version);
+                    Assert.Equal(1.5, document.Version);
                 }
 
                 var page1 = document.GetPage(1);

--- a/src/UglyToad.PdfPig.Tests/Writer/PdfPageBuilderTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Writer/PdfPageBuilderTests.cs
@@ -4,7 +4,6 @@
     using System.IO;
     using System.Linq;
     using UglyToad.PdfPig;
-    using UglyToad.PdfPig.Content;
     using UglyToad.PdfPig.Core;
     using UglyToad.PdfPig.Fonts.Standard14Fonts;
     using UglyToad.PdfPig.Writer;
@@ -12,8 +11,6 @@
 
     public class PdfPageBuilderTests
     {
-
-
         [Fact]
         public void CanAddPng()
         {
@@ -44,7 +41,6 @@
                 }
                 pdfBytes = pdfBuilder.Build();
             }
-
 
             File.WriteAllBytes(@"PdfPageBuilderTests_CanAddPng.pdf", pdfBytes);
 
@@ -93,19 +89,14 @@
                     Assert.Equal(8, image1.BitsPerComponent);
                 }
             }
-            
-            
-
-
         }
-
 
         [Fact]
         public void CanAddPngTestPattern1()
         {
             const string subfolderName = "TestPattern1";
             byte[] pdfBytes;
-            
+
             using (var pdfBuilder = new PdfDocumentBuilder())
             {
                 var courierFont = pdfBuilder.AddStandard14Font(Standard14Font.Courier);
@@ -115,7 +106,6 @@
                 AddPageWithImage(pdfBuilder, subfolderName, "tp1-003-8bitRGB-Interlaced-withExif~ColorProfile.png", 150, courierFont);
                 AddPageWithImage(pdfBuilder, subfolderName, "tp1-004-8bitRGBA-Interlaced-withExif~ColorProfile.png", 200, courierFont);
 
-
                 AddPageWithImage(pdfBuilder, subfolderName, "tp1-101-16bitRGB-withExif~Thumbnail~ColorProfile.png", 150, courierFont);
                 AddPageWithImage(pdfBuilder, subfolderName, "tp1-102-16bitRGBA-withExif~Thumbnail~ColorProfile.png", 200, courierFont);
 
@@ -124,7 +114,6 @@
                 AddPageWithImage(pdfBuilder, subfolderName, "tp1-301-16bitFloatRGB-withExif~Thumbnail~ColorProfile.png", 150, courierFont);
 
                 AddPageWithImage(pdfBuilder, subfolderName, "tp1-401-32bitFloatRGB-withExif~Thumbnail~ColorProfile.png", 150, courierFont);
-
 
                 pdfBytes = pdfBuilder.Build();
             }
@@ -227,10 +216,6 @@
                     Assert.Equal(8, image1.BitsPerComponent);
                 }
             }
-
-
-
-
         }
 
         private static void AddPageWithImage(PdfDocumentBuilder pdfBuilder, string subfolderName, string imageFileName, double imageHeight, PdfDocumentBuilder.AddedFont font)
@@ -245,9 +230,9 @@
 
             var page = pdfBuilder.AddPage(595d, 842d); // A4
             var dataPNG = LoadPng(imageFileName, subfolderName);
-            page.DrawRectangle(borderPlacement, (decimal)imagePlacement.Width, (decimal)imagePlacement.Height, 3, true);
+            page.DrawRectangle(borderPlacement, imagePlacement.Width, imagePlacement.Height, 3, true);
             page.AddPng(dataPNG, imagePlacement);
-            page.AddText(imageFileName, 12m, labelPlacement, font);
+            page.AddText(imageFileName, 12, labelPlacement, font);
         }
 
         private static byte[] LoadPng(string name, string subfolderName = null)

--- a/src/UglyToad.PdfPig.Tokenization/NumericTokenizer.cs
+++ b/src/UglyToad.PdfPig.Tokenization/NumericTokenizer.cs
@@ -153,7 +153,7 @@
                         token = NumericToken.OneThousand;
                         return true;
                     default:
-                        if (!decimal.TryParse(str, NumberStyles.Any, CultureInfo.InvariantCulture, out var value))
+                        if (!double.TryParse(str, NumberStyles.Any, CultureInfo.InvariantCulture, out var value))
                         {
                             if (TryParseInvalidNumber(str, out value))
                             {
@@ -178,7 +178,7 @@
             }
         }
 
-        private static bool TryParseInvalidNumber(string numeric, out decimal result)
+        private static bool TryParseInvalidNumber(string numeric, out double result)
         {
             result = 0;
 
@@ -196,7 +196,7 @@
 
             foreach (var part in parts)
             {
-                if (!decimal.TryParse(part, NumberStyles.Any, CultureInfo.InvariantCulture, out var partNumber))
+                if (!double.TryParse(part, NumberStyles.Any, CultureInfo.InvariantCulture, out var partNumber))
                 {
                     return false;
                 }

--- a/src/UglyToad.PdfPig.Tokens/NumericToken.cs
+++ b/src/UglyToad.PdfPig.Tokens/NumericToken.cs
@@ -1,5 +1,6 @@
 ﻿namespace UglyToad.PdfPig.Tokens
 {
+    using System;
     using System.Globalization;
 
     /// <inheritdoc />
@@ -8,7 +9,7 @@
     /// Real objects  approximate mathematical real numbers, but with limited range and precision.
     /// This token represents both types and they are used interchangeably in the specification.
     /// </summary>
-    public class NumericToken : IDataToken<decimal>
+    public class NumericToken : IDataToken<double>
     {
         /// <summary>
         /// Single instance of numeric token for -1.
@@ -135,12 +136,12 @@
         public static readonly NumericToken OneThousand = new NumericToken(1000);
 
         /// <inheritdoc />
-        public decimal Data { get; }
+        public double Data { get; }
 
         /// <summary>
-        /// Whether the number represented has a non-zero decimal part.
+        /// Whether the number represented has a non-zero double part.
         /// </summary>
-        public bool HasDecimalPlaces => decimal.Floor(Data) != Data;
+        public bool HasDecimalPlaces => Math.Floor(Data) != Data;
 
         /// <summary>
         /// The value of this number as an <see langword="int"/>.
@@ -155,13 +156,13 @@
         /// <summary>
         /// The value of this number as a <see langword="double"/>.
         /// </summary>
-        public double Double => (double)Data;
+        public double Double => Data;
 
         /// <summary>
         /// Create a <see cref="NumericToken"/>.
         /// </summary>
         /// <param name="value">The number to represent.</param>
-        public NumericToken(decimal value)
+        public NumericToken(double value)
         {
             Data = value;
         }

--- a/src/UglyToad.PdfPig/Annotations/AnnotationBorder.cs
+++ b/src/UglyToad.PdfPig/Annotations/AnnotationBorder.cs
@@ -16,28 +16,28 @@
         /// <summary>
         /// The horizontal corner radius in user space units.
         /// </summary>
-        public decimal HorizontalCornerRadius { get; }
+        public double HorizontalCornerRadius { get; }
 
         /// <summary>
         /// The vertical corner radius in user space units.
         /// </summary>
-        public decimal VerticalCornerRadius { get; }
+        public double VerticalCornerRadius { get; }
 
         /// <summary>
         /// The width of the border in user space units.
         /// </summary>
-        public decimal BorderWidth { get; }
+        public double BorderWidth { get; }
 
         /// <summary>
         /// The dash pattern for the border lines if provided. Optional.
         /// </summary>
         [CanBeNull]
-        public IReadOnlyList<decimal> LineDashPattern { get; }
+        public IReadOnlyList<double> LineDashPattern { get; }
 
         /// <summary>
         /// Create a new <see cref="AnnotationBorder"/>.
         /// </summary>
-        public AnnotationBorder(decimal horizontalCornerRadius, decimal verticalCornerRadius, decimal borderWidth, IReadOnlyList<decimal> lineDashPattern)
+        public AnnotationBorder(double horizontalCornerRadius, double verticalCornerRadius, double borderWidth, IReadOnlyList<double> lineDashPattern)
         {
             HorizontalCornerRadius = horizontalCornerRadius;
             VerticalCornerRadius = verticalCornerRadius;

--- a/src/UglyToad.PdfPig/Annotations/AnnotationProvider.cs
+++ b/src/UglyToad.PdfPig/Annotations/AnnotationProvider.cs
@@ -67,7 +67,7 @@
                     var horizontal = borderArray.GetNumeric(0).Data;
                     var vertical = borderArray.GetNumeric(1).Data;
                     var width = borderArray.GetNumeric(2).Data;
-                    var dashes = default(IReadOnlyList<decimal>);
+                    var dashes = default(IReadOnlyList<double>);
 
                     if (borderArray.Length == 4 && borderArray.Data[4] is ArrayToken dashArray)
                     {
@@ -80,7 +80,7 @@
                 var quadPointRectangles = new List<QuadPointsQuadrilateral>();
                 if (annotationDictionary.TryGet(NameToken.Quadpoints, tokenScanner, out ArrayToken quadPointsArray))
                 {
-                    var values = new List<decimal>();
+                    var values = new List<double>();
                     for (var i = 0; i < quadPointsArray.Length; i++)
                     {
                         if (!(quadPointsArray[i] is NumericToken value))

--- a/src/UglyToad.PdfPig/Content/HeaderVersion.cs
+++ b/src/UglyToad.PdfPig/Content/HeaderVersion.cs
@@ -4,7 +4,7 @@
 
     internal class HeaderVersion
     {
-        public decimal Version { get; }
+        public double Version { get; }
 
         public string VersionString { get; }
 
@@ -13,7 +13,7 @@
         /// </summary>
         public long OffsetInFile { get; }
 
-        public HeaderVersion(decimal version, string versionString, long offsetInFile)
+        public HeaderVersion(double version, string versionString, long offsetInFile)
         {
             Version = version;
             VersionString = versionString;

--- a/src/UglyToad.PdfPig/Content/IPdfImage.cs
+++ b/src/UglyToad.PdfPig/Content/IPdfImage.cs
@@ -60,7 +60,7 @@
         /// The value from the image data is then interpolated into the values relevant to the <see cref="ColorSpace"/>
         /// using the corresponding values of the decode array.
         /// </summary>
-        IReadOnlyList<decimal> Decode { get; }
+        IReadOnlyList<double> Decode { get; }
 
         /// <summary>
         /// Specifies whether interpolation is to be performed. Interpolation smooths images where a single component in the image

--- a/src/UglyToad.PdfPig/Content/InlineImage.cs
+++ b/src/UglyToad.PdfPig/Content/InlineImage.cs
@@ -35,7 +35,7 @@
         public bool IsImageMask { get; }
 
         /// <inheritdoc />
-        public IReadOnlyList<decimal> Decode { get; }
+        public IReadOnlyList<double> Decode { get; }
 
         /// <inheritdoc />
         public bool IsInlineImage { get; } = true;
@@ -62,7 +62,7 @@
         internal InlineImage(PdfRectangle bounds, int widthInSamples, int heightInSamples, int bitsPerComponent, bool isImageMask,
             RenderingIntent renderingIntent,
             bool interpolate,
-            IReadOnlyList<decimal> decode,
+            IReadOnlyList<double> decode,
             IReadOnlyList<byte> bytes,
             IReadOnlyList<IFilter> filters,
             DictionaryToken streamDictionary,

--- a/src/UglyToad.PdfPig/Content/PageRotationDegrees.cs
+++ b/src/UglyToad.PdfPig/Content/PageRotationDegrees.cs
@@ -21,7 +21,7 @@
         /// <summary>
         /// Get the rotation expressed in radians (anti-clockwise).
         /// </summary>
-        public decimal Radians
+        public double Radians
         {
             get
             {
@@ -30,11 +30,11 @@
                     case 0:
                         return 0;
                     case 90:
-                        return -(decimal)(0.5 * Math.PI);
+                        return -0.5 * Math.PI;
                     case 180:
-                        return -(decimal) Math.PI;
+                        return -Math.PI;
                     case 270:
-                        return -(decimal) (1.5 * Math.PI);
+                        return -1.5 * Math.PI;
                     default:
                         throw new InvalidOperationException($"Invalid value for rotation: {Value}.");
                 }

--- a/src/UglyToad.PdfPig/Graphics/ColorSpaceContext.cs
+++ b/src/UglyToad.PdfPig/Graphics/ColorSpaceContext.cs
@@ -33,7 +33,7 @@
             currentStateFunc().CurrentStrokingColor = CurrentStrokingColorSpace.GetInitializeColor();
         }
 
-        public void SetStrokingColor(IReadOnlyList<decimal> operands, NameToken patternName)
+        public void SetStrokingColor(IReadOnlyList<double> operands, NameToken patternName)
         {
             if (CurrentStrokingColorSpace is UnsupportedColorSpaceDetails)
             {
@@ -47,26 +47,26 @@
             }
             else
             {
-                currentStateFunc().CurrentStrokingColor = CurrentStrokingColorSpace.GetColor(operands.Select(v => (double)v).ToArray());
+                currentStateFunc().CurrentStrokingColor = CurrentStrokingColorSpace.GetColor(operands.ToArray());
             }
         }
 
-        public void SetStrokingColorGray(decimal gray)
+        public void SetStrokingColorGray(double gray)
         {
             CurrentStrokingColorSpace = DeviceGrayColorSpaceDetails.Instance;
-            currentStateFunc().CurrentStrokingColor = CurrentStrokingColorSpace.GetColor((double)gray);
+            currentStateFunc().CurrentStrokingColor = CurrentStrokingColorSpace.GetColor(gray);
         }
 
-        public void SetStrokingColorRgb(decimal r, decimal g, decimal b)
+        public void SetStrokingColorRgb(double r, double g, double b)
         {
             CurrentStrokingColorSpace = DeviceRgbColorSpaceDetails.Instance;
-            currentStateFunc().CurrentStrokingColor = CurrentStrokingColorSpace.GetColor((double)r, (double)g, (double)b);
+            currentStateFunc().CurrentStrokingColor = CurrentStrokingColorSpace.GetColor(r, g, b);
         }
 
-        public void SetStrokingColorCmyk(decimal c, decimal m, decimal y, decimal k)
+        public void SetStrokingColorCmyk(double c, double m, double y, double k)
         {
             CurrentStrokingColorSpace = DeviceCmykColorSpaceDetails.Instance;
-            currentStateFunc().CurrentStrokingColor = CurrentStrokingColorSpace.GetColor((double)c, (double)m, (double)y, (double)k);
+            currentStateFunc().CurrentStrokingColor = CurrentStrokingColorSpace.GetColor(c, m, y, k);
         }
 
         public void SetNonStrokingColorspace(NameToken colorspace, DictionaryToken dictionary = null)
@@ -80,7 +80,7 @@
             currentStateFunc().CurrentNonStrokingColor = CurrentNonStrokingColorSpace.GetInitializeColor();
         }
 
-        public void SetNonStrokingColor(IReadOnlyList<decimal> operands, NameToken patternName)
+        public void SetNonStrokingColor(IReadOnlyList<double> operands, NameToken patternName)
         {
             if (CurrentNonStrokingColorSpace is UnsupportedColorSpaceDetails)
             {
@@ -94,26 +94,26 @@
             }
             else
             {
-                currentStateFunc().CurrentNonStrokingColor = CurrentNonStrokingColorSpace.GetColor(operands.Select(v => (double)v).ToArray());
+                currentStateFunc().CurrentNonStrokingColor = CurrentNonStrokingColorSpace.GetColor(operands.ToArray());
             }
         }
 
-        public void SetNonStrokingColorGray(decimal gray)
+        public void SetNonStrokingColorGray(double gray)
         {
             CurrentNonStrokingColorSpace = DeviceGrayColorSpaceDetails.Instance;
-            currentStateFunc().CurrentNonStrokingColor = CurrentNonStrokingColorSpace.GetColor((double)gray);
+            currentStateFunc().CurrentNonStrokingColor = CurrentNonStrokingColorSpace.GetColor(gray);
         }
 
-        public void SetNonStrokingColorRgb(decimal r, decimal g, decimal b)
+        public void SetNonStrokingColorRgb(double r, double g, double b)
         {
             CurrentNonStrokingColorSpace = DeviceRgbColorSpaceDetails.Instance;
-            currentStateFunc().CurrentNonStrokingColor = CurrentNonStrokingColorSpace.GetColor((double)r, (double)g, (double)b);
+            currentStateFunc().CurrentNonStrokingColor = CurrentNonStrokingColorSpace.GetColor(r, g, b);
         }
 
-        public void SetNonStrokingColorCmyk(decimal c, decimal m, decimal y, decimal k)
+        public void SetNonStrokingColorCmyk(double c, double m, double y, double k)
         {
             CurrentNonStrokingColorSpace = DeviceCmykColorSpaceDetails.Instance;
-            currentStateFunc().CurrentNonStrokingColor = CurrentNonStrokingColorSpace.GetColor((double)c, (double)m, (double)y, (double)k);
+            currentStateFunc().CurrentNonStrokingColor = CurrentNonStrokingColorSpace.GetColor(c, m, y, k);
         }
 
         public IColorSpaceContext DeepClone()

--- a/src/UglyToad.PdfPig/Graphics/Colors/ColorSpaceDetails.cs
+++ b/src/UglyToad.PdfPig/Graphics/Colors/ColorSpaceDetails.cs
@@ -1249,7 +1249,7 @@
             // initialize all components of the corresponding current colour to 0.0 (unless the range of valid
             // values for a given component does not include 0.0, in which case the nearest valid value shall
             // be substituted.)
-            double v = PdfFunction.ClipToRange(0.0, (double)Range[0], (double)Range[1]);
+            double v = PdfFunction.ClipToRange(0.0, Range[0], Range[1]);
             double[] init = Enumerable.Repeat(v, NumberOfColorComponents).ToArray();
             return GetColor(init);
         }

--- a/src/UglyToad.PdfPig/Graphics/ContentStreamProcessor.cs
+++ b/src/UglyToad.PdfPig/Graphics/ContentStreamProcessor.cs
@@ -501,8 +501,8 @@
                  * A conforming reader shall implicitly reset this parameter to its initial value at the beginning of execution of a
                  * transparency group XObject (see 11.6.6, "Transparency Group XObjects"). Initial value: 1.0.
                  */
-                startState.AlphaConstantNonStroking = 1.0m;
-                startState.AlphaConstantStroking = 1.0m;
+                startState.AlphaConstantNonStroking = 1.0;
+                startState.AlphaConstantStroking = 1.0;
 
                 if (formGroupToken.TryGet(NameToken.Cs, pdfScanner, out NameToken csNameToken))
                 {
@@ -851,7 +851,7 @@
                 && fontArray.Data[0] is IndirectReferenceToken fontReference && fontArray.Data[1] is NumericToken sizeToken)
             {
                 currentGraphicsState.FontState.FromExtendedGraphicsState = true;
-                currentGraphicsState.FontState.FontSize = (double)sizeToken.Data;
+                currentGraphicsState.FontState.FontSize = sizeToken.Data;
                 activeExtendedGraphicsStateFont = resourceStore.GetFontDirectly(fontReference);
             }
 
@@ -986,7 +986,7 @@
             TextMatrices.TextMatrix = matrix.Multiply(TextMatrices.TextMatrix);
         }
 
-        public void SetFlatnessTolerance(decimal tolerance)
+        public void SetFlatnessTolerance(double tolerance)
         {
             GetCurrentState().Flatness = tolerance;
         }
@@ -1006,19 +1006,19 @@
             GetCurrentState().JoinStyle = join;
         }
 
-        public void SetLineWidth(decimal width)
+        public void SetLineWidth(double width)
         {
             GetCurrentState().LineWidth = width;
         }
 
-        public void SetMiterLimit(decimal limit)
+        public void SetMiterLimit(double limit)
         {
             GetCurrentState().MiterLimit = limit;
         }
 
         public void MoveToNextLineWithOffset()
         {
-            var tdOperation = new MoveToNextLineWithOffset(0, -1 * (decimal)GetCurrentState().FontState.Leading);
+            var tdOperation = new MoveToNextLineWithOffset(0, -1.0 * GetCurrentState().FontState.Leading);
             tdOperation.Run(this);
         }
 

--- a/src/UglyToad.PdfPig/Graphics/Core/LineDashPattern.cs
+++ b/src/UglyToad.PdfPig/Graphics/Core/LineDashPattern.cs
@@ -7,7 +7,7 @@
 
     /// <summary>
     /// The line dash pattern controls the pattern of dashes and gaps used to stroke paths.
-    /// It is specified by a dash array and a dash phase. 
+    /// It is specified by a dash array and a dash phase.
     /// </summary>
     public struct LineDashPattern
     {
@@ -20,14 +20,14 @@
         /// The numbers that specify the lengths of alternating dashes and gaps.
         /// </summary>
         [NotNull]
-        public IReadOnlyList<decimal> Array { get; }
+        public IReadOnlyList<double> Array { get; }
 
         /// <summary>
         /// Create a new <see cref="LineDashPattern"/>.
         /// </summary>
         /// <param name="phase">The phase. <see cref="Phase"/>.</param>
         /// <param name="array">The array. <see cref="Array"/>.</param>
-        public LineDashPattern(int phase, [NotNull]IReadOnlyList<decimal> array)
+        public LineDashPattern(int phase, [NotNull]IReadOnlyList<double> array)
         {
             Phase = phase;
             Array = array ?? throw new ArgumentNullException(nameof(array));
@@ -37,7 +37,7 @@
         /// The default solid line.
         /// </summary>
         public static LineDashPattern Solid { get; }
-            = new LineDashPattern(0, new decimal[0]);
+            = new LineDashPattern(0, new double[0]);
 
         /// <inheritdoc />
         public override string ToString()

--- a/src/UglyToad.PdfPig/Graphics/CurrentGraphicsState.cs
+++ b/src/UglyToad.PdfPig/Graphics/CurrentGraphicsState.cs
@@ -26,7 +26,7 @@ namespace UglyToad.PdfPig.Graphics
         /// <summary>
         /// Thickness in user space units of path to be stroked.
         /// </summary>
-        public decimal LineWidth { get; set; } = 1;
+        public double LineWidth { get; set; } = 1;
 
         /// <summary>
         /// Specifies the shape of line ends for open stroked paths.
@@ -41,7 +41,7 @@ namespace UglyToad.PdfPig.Graphics
         /// <summary>
         /// Maximum length of mitered line joins for paths before becoming a bevel.
         /// </summary>
-        public decimal MiterLimit { get; set; } = 10;
+        public double MiterLimit { get; set; } = 10;
 
         /// <summary>
         /// The pattern to be used for stroked lines.
@@ -61,12 +61,12 @@ namespace UglyToad.PdfPig.Graphics
         /// <summary>
         /// Opacity value to be used for transparent imaging.
         /// </summary>
-        public decimal AlphaConstantStroking { get; set; } = 1;
+        public double AlphaConstantStroking { get; set; } = 1;
 
         /// <summary>
         /// Opacity value to be used for transparent imaging.
         /// </summary>
-        public decimal AlphaConstantNonStroking { get; set; } = 1;
+        public double AlphaConstantNonStroking { get; set; } = 1;
 
         /// <summary>
         /// Should soft mask and alpha constant values be interpreted as shape (<see langword="true"/>) or opacity (<see langword="false"/>) values?
@@ -110,17 +110,17 @@ namespace UglyToad.PdfPig.Graphics
         /// In DeviceCMYK color space a value of 0 for a component will erase a component (0)
         /// or leave it unchanged (1) for overprinting.
         /// </summary>
-        public decimal OverprintMode { get; set; }
+        public double OverprintMode { get; set; }
 
         /// <summary>
         /// The precision for rendering curves, smaller numbers give smoother curves.
         /// </summary>
-        public decimal Flatness { get; set; } = 1;
+        public double Flatness { get; set; } = 1;
 
         /// <summary>
         /// The precision for rendering color gradients on the output device.
         /// </summary>
-        public decimal Smoothness { get; set; } = 0;
+        public double Smoothness { get; set; } = 0;
         #endregion
 
         /// <inheritdoc />

--- a/src/UglyToad.PdfPig/Graphics/IColorSpaceContext.cs
+++ b/src/UglyToad.PdfPig/Graphics/IColorSpaceContext.cs
@@ -37,13 +37,13 @@
         /// <summary>
         /// Set the color to use for stroking operations using the current color space.
         /// </summary>
-        void SetStrokingColor(IReadOnlyList<decimal> operands, NameToken patternName = null);
+        void SetStrokingColor(IReadOnlyList<double> operands, NameToken patternName = null);
 
         /// <summary>
         /// Set the stroking color space to DeviceGray and set the gray level to use for stroking operations.
         /// </summary>
         /// <param name="gray">A number between 0.0 (black) and 1.0 (white).</param>
-        void SetStrokingColorGray(decimal gray);
+        void SetStrokingColorGray(double gray);
 
         /// <summary>
         /// Set the stroking color space to DeviceRGB and set the color to use for stroking operations.
@@ -51,7 +51,7 @@
         /// <param name="r">Red - A number between 0 (minimum intensity) and 1 (maximum intensity).</param>
         /// <param name="g">Green - A number between 0 (minimum intensity) and 1 (maximum intensity).</param>
         /// <param name="b">Blue - A number between 0 (minimum intensity) and 1 (maximum intensity).</param>
-        void SetStrokingColorRgb(decimal r, decimal g, decimal b);
+        void SetStrokingColorRgb(double r, double g, double b);
 
         /// <summary>
         /// Set the stroking color space to DeviceCMYK and set the color to use for stroking operations. 
@@ -60,18 +60,18 @@
         /// <param name="m">Magenta - A number between 0 (minimum concentration) and 1 (maximum concentration).</param>
         /// <param name="y">Yellow - A number between 0 (minimum concentration) and 1 (maximum concentration).</param>
         /// <param name="k">Black - A number between 0 (minimum concentration) and 1 (maximum concentration).</param>
-        void SetStrokingColorCmyk(decimal c, decimal m, decimal y, decimal k);
+        void SetStrokingColorCmyk(double c, double m, double y, double k);
 
         /// <summary>
         /// Set the color to use for nonstroking operations using the current color space.
         /// </summary>
-        void SetNonStrokingColor(IReadOnlyList<decimal> operands, NameToken patternName = null);
+        void SetNonStrokingColor(IReadOnlyList<double> operands, NameToken patternName = null);
 
         /// <summary>
         /// Set the nonstroking color space to DeviceGray and set the gray level to use for nonstroking operations.
         /// </summary>
         /// <param name="gray">A number between 0.0 (black) and 1.0 (white).</param>
-        void SetNonStrokingColorGray(decimal gray);
+        void SetNonStrokingColorGray(double gray);
 
         /// <summary>
         /// Set the nonstroking color space to DeviceRGB and set the color to use for nonstroking operations.
@@ -79,7 +79,7 @@
         /// <param name="r">Red - A number between 0 (minimum intensity) and 1 (maximum intensity).</param>
         /// <param name="g">Green - A number between 0 (minimum intensity) and 1 (maximum intensity).</param>
         /// <param name="b">Blue - A number between 0 (minimum intensity) and 1 (maximum intensity).</param>
-        void SetNonStrokingColorRgb(decimal r, decimal g, decimal b);
+        void SetNonStrokingColorRgb(double r, double g, double b);
 
         /// <summary>
         /// Set the nonstroking color space to DeviceCMYK and set the color to use for nonstroking operations.
@@ -88,6 +88,6 @@
         /// <param name="m">Magenta - A number between 0 (minimum concentration) and 1 (maximum concentration).</param>
         /// <param name="y">Yellow - A number between 0 (minimum concentration) and 1 (maximum concentration).</param>
         /// <param name="k">Black - A number between 0 (minimum concentration) and 1 (maximum concentration).</param>
-        void SetNonStrokingColorCmyk(decimal c, decimal m, decimal y, decimal k);
+        void SetNonStrokingColorCmyk(double c, double m, double y, double k);
     }
 }

--- a/src/UglyToad.PdfPig/Graphics/IOperationContext.cs
+++ b/src/UglyToad.PdfPig/Graphics/IOperationContext.cs
@@ -170,7 +170,7 @@
         /// Flatness is a number in the range 0 to 100; a value of 0 specifies the output device’s default flatness tolerance.
         /// </summary>
         /// <param name="tolerance"></param>
-        void SetFlatnessTolerance(decimal tolerance);
+        void SetFlatnessTolerance(double tolerance);
 
         /// <summary>
         /// Set the line cap style in the graphics state.
@@ -190,12 +190,12 @@
         /// <summary>
         /// Set the line width in the graphics state.
         /// </summary>
-        void SetLineWidth(decimal width);
+        void SetLineWidth(double width);
 
         /// <summary>
         /// Set the miter limit in the graphics state.
         /// </summary>
-        void SetMiterLimit(decimal limit);
+        void SetMiterLimit(double limit);
 
         /// <summary>
         /// Move to the start of the next line.

--- a/src/UglyToad.PdfPig/Graphics/Operations/General/SetFlatnessTolerance.cs
+++ b/src/UglyToad.PdfPig/Graphics/Operations/General/SetFlatnessTolerance.cs
@@ -21,13 +21,13 @@
         /// The flatness tolerance controls the maximum permitted distance in device pixels
         /// between the mathematically correct path and an approximation constructed from straight line segments.
         /// </summary>
-        public decimal Tolerance { get; }
+        public double Tolerance { get; }
 
         /// <summary>
         /// Create new <see cref="SetFlatnessTolerance"/>.
         /// </summary>
         /// <param name="tolerance">The flatness tolerance.</param>
-        public SetFlatnessTolerance(decimal tolerance)
+        public SetFlatnessTolerance(double tolerance)
         {
             Tolerance = tolerance;
         }

--- a/src/UglyToad.PdfPig/Graphics/Operations/General/SetLineDashPattern.cs
+++ b/src/UglyToad.PdfPig/Graphics/Operations/General/SetLineDashPattern.cs
@@ -21,11 +21,11 @@
         /// The line dash pattern.
         /// </summary>
         public LineDashPattern Pattern { get; }
-        
+
         /// <summary>
         /// Create a new <see cref="SetLineDashPattern"/>.
         /// </summary>
-        public SetLineDashPattern(decimal[] array, int phase)
+        public SetLineDashPattern(double[] array, int phase)
         {
             Pattern = new LineDashPattern(phase, array);
         }

--- a/src/UglyToad.PdfPig/Graphics/Operations/General/SetLineWidth.cs
+++ b/src/UglyToad.PdfPig/Graphics/Operations/General/SetLineWidth.cs
@@ -19,13 +19,13 @@
         /// <summary>
         /// The line width.
         /// </summary>
-        public decimal Width { get; }
+        public double Width { get; }
 
         /// <summary>
         /// Create a new <see cref="SetLineWidth"/>.
         /// </summary>
         /// <param name="width">The line width.</param>
-        public SetLineWidth(decimal width)
+        public SetLineWidth(double width)
         {
             Width = width;
         }

--- a/src/UglyToad.PdfPig/Graphics/Operations/General/SetMiterLimit.cs
+++ b/src/UglyToad.PdfPig/Graphics/Operations/General/SetMiterLimit.cs
@@ -20,12 +20,12 @@
         /// The miter limit. The miter limit imposes a maximum on the ratio of the miter length to the line width. 
         /// When the limit is exceeded, the join is converted from a miter to a bevel. 
         /// </summary>
-        public decimal Limit { get; }
+        public double Limit { get; }
 
         /// <summary>
         /// Create a new <see cref="SetMiterLimit"/>.
         /// </summary>
-        public SetMiterLimit(decimal limit)
+        public SetMiterLimit(double limit)
         {
             Limit = limit;
         }

--- a/src/UglyToad.PdfPig/Graphics/Operations/OperationWriteHelper.cs
+++ b/src/UglyToad.PdfPig/Graphics/Operations/OperationWriteHelper.cs
@@ -36,12 +36,12 @@
             stream.WriteByte(NewLine);
         }
 
-        public static void WriteDecimal(this Stream stream, decimal value)
+        public static void WriteDecimal(this Stream stream, double value)
         {
             stream.WriteText(value.ToString("G", CultureInfo.InvariantCulture));
         }
 
-        public static void WriteNumberText(this Stream stream, decimal number, string text)
+        public static void WriteNumberText(this Stream stream, double number, string text)
         {
             stream.WriteDecimal(number);
             stream.WriteWhiteSpace();

--- a/src/UglyToad.PdfPig/Graphics/Operations/PathConstruction/AppendDualControlPointBezierCurve.cs
+++ b/src/UglyToad.PdfPig/Graphics/Operations/PathConstruction/AppendDualControlPointBezierCurve.cs
@@ -1,7 +1,6 @@
 ﻿namespace UglyToad.PdfPig.Graphics.Operations.PathConstruction
 {
     using System.IO;
-    using PdfPig.Core;
 
     /// <inheritdoc />
     /// <summary>
@@ -21,32 +20,32 @@
         /// <summary>
         /// First control point x.
         /// </summary>
-        public decimal X1 { get; }
+        public double X1 { get; }
 
         /// <summary>
         /// First control point y.
         /// </summary>
-        public decimal Y1 { get; }
+        public double Y1 { get; }
 
         /// <summary>
         /// Second control point x.
         /// </summary>
-        public decimal X2 { get; }
+        public double X2 { get; }
 
         /// <summary>
         /// Second control point y.
         /// </summary>
-        public decimal Y2 { get; }
+        public double Y2 { get; }
 
         /// <summary>
         /// End point x.
         /// </summary>
-        public decimal X3 { get; }
+        public double X3 { get; }
 
         /// <summary>
         /// End point y.
         /// </summary>
-        public decimal Y3 { get; }
+        public double Y3 { get; }
 
         /// <summary>
         /// Create a new <see cref="AppendDualControlPointBezierCurve"/>.
@@ -57,7 +56,7 @@
         /// <param name="y2">Control point 2 y coordinate.</param>
         /// <param name="x3">End point x coordinate.</param>
         /// <param name="y3">End point y coordinate.</param>
-        public AppendDualControlPointBezierCurve(decimal x1, decimal y1, decimal x2, decimal y2, decimal x3, decimal y3)
+        public AppendDualControlPointBezierCurve(double x1, double y1, double x2, double y2, double x3, double y3)
         {
             X1 = x1;
             Y1 = y1;
@@ -65,13 +64,12 @@
             Y2 = y2;
             X3 = x3;
             Y3 = y3;
-
         }
 
         /// <inheritdoc />
         public void Run(IOperationContext operationContext)
         {
-            operationContext.BezierCurveTo((double)X1, (double)Y1, (double)X2, (double)Y2, (double)X3, (double)Y3);
+            operationContext.BezierCurveTo(X1, Y1, X2, Y2, X3, Y3);
         }
 
         /// <inheritdoc />

--- a/src/UglyToad.PdfPig/Graphics/Operations/PathConstruction/AppendEndControlPointBezierCurve.cs
+++ b/src/UglyToad.PdfPig/Graphics/Operations/PathConstruction/AppendEndControlPointBezierCurve.cs
@@ -1,7 +1,6 @@
 ﻿namespace UglyToad.PdfPig.Graphics.Operations.PathConstruction
 {
     using System.IO;
-    using PdfPig.Core;
 
     /// <inheritdoc />
     /// <summary>
@@ -21,23 +20,23 @@
         /// <summary>
         /// The x coordinate of the first control point.
         /// </summary>
-        public decimal X1 { get; }
+        public double X1 { get; }
 
         /// <summary>
         /// The y coordinate of the first control point.
         /// </summary>
-        public decimal Y1 { get; }
+        public double Y1 { get; }
 
         /// <summary>
         /// The x coordinate of the end point.
         /// </summary>
-        public decimal X3 { get; }
+        public double X3 { get; }
 
         /// <summary>
         /// The y coordinate of the end point.
         /// </summary>
-        public decimal Y3 { get; }
-        
+        public double Y3 { get; }
+
         /// <summary>
         /// Create a new <see cref="AppendEndControlPointBezierCurve"/>.
         /// </summary>
@@ -45,18 +44,18 @@
         /// <param name="y1">Control point 1 y coordinate.</param>
         /// <param name="x3">Control point 2/End x coordinate.</param>
         /// <param name="y3">Control point 2/End y coordinate.</param>
-        public AppendEndControlPointBezierCurve(decimal x1, decimal y1, decimal x3, decimal y3)
+        public AppendEndControlPointBezierCurve(double x1, double y1, double x3, double y3)
         {
             X1 = x1;
             Y1 = y1;
             X3 = x3;
             Y3 = y3;
         }
-        
+
         /// <inheritdoc />
         public void Run(IOperationContext operationContext)
         {
-            operationContext.BezierCurveTo((double)X1, (double)Y1, (double)X3, (double)Y3, (double)X3, (double)Y3);
+            operationContext.BezierCurveTo(X1, Y1, X3, Y3, X3, Y3);
         }
 
         /// <inheritdoc />

--- a/src/UglyToad.PdfPig/Graphics/Operations/PathConstruction/AppendRectangle.cs
+++ b/src/UglyToad.PdfPig/Graphics/Operations/PathConstruction/AppendRectangle.cs
@@ -20,22 +20,22 @@
         /// <summary>
         /// The x coordinate of the lower left corner.
         /// </summary>
-        public decimal LowerLeftX { get; }
+        public double LowerLeftX { get; }
 
         /// <summary>
         /// The y coordinate of the lower left corner.
         /// </summary>
-        public decimal LowerLeftY { get; }
+        public double LowerLeftY { get; }
 
         /// <summary>
         /// The width of the rectangle.
         /// </summary>
-        public decimal Width { get; }
+        public double Width { get; }
 
         /// <summary>
         /// The height of the rectangle.
         /// </summary>
-        public decimal Height { get; }
+        public double Height { get; }
 
         /// <summary>
         /// Create a new <see cref="AppendRectangle"/>.
@@ -44,7 +44,7 @@
         /// <param name="y">The y coordinate of the lower left corner.</param>
         /// <param name="width">The width of the rectangle.</param>
         /// <param name="height">The height of the rectangle.</param>
-        public AppendRectangle(decimal x, decimal y, decimal width, decimal height)
+        public AppendRectangle(double x, double y, double width, double height)
         {
             LowerLeftX = x;
             LowerLeftY = y;
@@ -56,7 +56,7 @@
         /// <inheritdoc />
         public void Run(IOperationContext operationContext)
         {
-            operationContext.Rectangle((double)LowerLeftX, (double)LowerLeftY, (double)Width, (double)Height);
+            operationContext.Rectangle(LowerLeftX, LowerLeftY, Width, Height);
         }
 
         /// <inheritdoc />

--- a/src/UglyToad.PdfPig/Graphics/Operations/PathConstruction/AppendStartControlPointBezierCurve.cs
+++ b/src/UglyToad.PdfPig/Graphics/Operations/PathConstruction/AppendStartControlPointBezierCurve.cs
@@ -21,22 +21,22 @@
         /// <summary>
         /// The x coordinate of the second control point.
         /// </summary>
-        public decimal X2 { get; }
+        public double X2 { get; }
 
         /// <summary>
         /// The y coordinate of the second control point.
         /// </summary>
-        public decimal Y2 { get; }
+        public double Y2 { get; }
 
         /// <summary>
         /// The x coordinate of the end point of the curve.
         /// </summary>
-        public decimal X3 { get; }
+        public double X3 { get; }
 
         /// <summary>
         /// The y coordinate of the end point of the curve.
         /// </summary>
-        public decimal Y3 { get; }
+        public double Y3 { get; }
 
         /// <summary>
         /// Create a new <see cref="AppendStartControlPointBezierCurve"/>.
@@ -45,7 +45,7 @@
         /// <param name="y2">The y coordinate of the second control point.</param>
         /// <param name="x3">The x coordinate of the end point.</param>
         /// <param name="y3">The y coordinate of the end point.</param>
-        public AppendStartControlPointBezierCurve(decimal x2, decimal y2, decimal x3, decimal y3)
+        public AppendStartControlPointBezierCurve(double x2, double y2, double x3, double y3)
         {
             X2 = x2;
             Y2 = y2;
@@ -56,7 +56,7 @@
         /// <inheritdoc />
         public void Run(IOperationContext operationContext)
         {
-            operationContext.BezierCurveTo((double)X2, (double)Y2, (double)X3, (double)Y3);
+            operationContext.BezierCurveTo(X2, Y2, X3, Y3);
         }
 
         /// <inheritdoc />

--- a/src/UglyToad.PdfPig/Graphics/Operations/PathConstruction/AppendStraightLineSegment.cs
+++ b/src/UglyToad.PdfPig/Graphics/Operations/PathConstruction/AppendStraightLineSegment.cs
@@ -20,19 +20,19 @@
         /// <summary>
         /// The x coordinate of the end point of the line.
         /// </summary>
-        public decimal X { get; }
+        public double X { get; }
 
         /// <summary>
         /// The y coordinate of the end point of the line.
         /// </summary>
-        public decimal Y { get; }
+        public double Y { get; }
         
         /// <summary>
         /// Create a new <see cref="AppendStraightLineSegment"/>.
         /// </summary>
         /// <param name="x">The x coordinate of the line's end point.</param>
         /// <param name="y">The y coordinate of the line's end point.</param>
-        public AppendStraightLineSegment(decimal x, decimal y)
+        public AppendStraightLineSegment(double x, double y)
         {
             X = x;
             Y = y;
@@ -41,7 +41,7 @@
         /// <inheritdoc />
         public void Run(IOperationContext operationContext)
         {
-            operationContext.LineTo((double)X, (double)Y);
+            operationContext.LineTo(X, Y);
         }
 
         /// <inheritdoc />

--- a/src/UglyToad.PdfPig/Graphics/Operations/PathConstruction/BeginNewSubpath.cs
+++ b/src/UglyToad.PdfPig/Graphics/Operations/PathConstruction/BeginNewSubpath.cs
@@ -20,19 +20,19 @@
         /// <summary>
         /// The x coordinate for the subpath to begin at.
         /// </summary>
-        public decimal X { get; }
+        public double X { get; }
 
         /// <summary>
         /// The y coordinate for the subpath to begin at.
         /// </summary>
-        public decimal Y { get; }
+        public double Y { get; }
         
         /// <summary>
         /// Create a new <see cref="BeginNewSubpath"/>.
         /// </summary>
         /// <param name="x">The x coordinate.</param>
         /// <param name="y">The y coordinate.</param>
-        public BeginNewSubpath(decimal x, decimal y)
+        public BeginNewSubpath(double x, double y)
         {
             X = x;
             Y = y;
@@ -41,7 +41,7 @@
         /// <inheritdoc />
         public void Run(IOperationContext operationContext)
         {
-            operationContext.MoveTo((double)X, (double)Y);
+            operationContext.MoveTo(X, Y);
         }
 
         /// <inheritdoc />

--- a/src/UglyToad.PdfPig/Graphics/Operations/SetNonStrokeColor.cs
+++ b/src/UglyToad.PdfPig/Graphics/Operations/SetNonStrokeColor.cs
@@ -21,13 +21,13 @@
         /// <summary>
         /// The values for the color, 1 for grayscale, 3 for RGB, 4 for CMYK.
         /// </summary>
-        public IReadOnlyList<decimal> Operands { get; }
+        public IReadOnlyList<double> Operands { get; }
 
         /// <summary>
         /// Create a new <see cref="SetNonStrokeColor"/>.
         /// </summary>
         /// <param name="operands">The color operands.</param>
-        public SetNonStrokeColor(decimal[] operands)
+        public SetNonStrokeColor(double[] operands)
         {
             Operands = operands;
         }

--- a/src/UglyToad.PdfPig/Graphics/Operations/SetNonStrokeColorAdvanced.cs
+++ b/src/UglyToad.PdfPig/Graphics/Operations/SetNonStrokeColorAdvanced.cs
@@ -25,7 +25,7 @@
         /// <summary>
         /// The values for the color.
         /// </summary>
-        public IReadOnlyList<decimal> Operands { get; }
+        public IReadOnlyList<double> Operands { get; }
 
         /// <summary>
         /// The name of an entry in the Pattern subdictionary of the current resource dictionary.
@@ -36,7 +36,7 @@
         /// Create a new <see cref="SetNonStrokeColorAdvanced"/>.
         /// </summary>
         /// <param name="operands">The color operands.</param>
-        public SetNonStrokeColorAdvanced(IReadOnlyList<decimal> operands)
+        public SetNonStrokeColorAdvanced(IReadOnlyList<double> operands)
         {
             Operands = operands;
         }
@@ -46,7 +46,7 @@
         /// </summary>
         /// <param name="operands">The color operands.</param>
         /// <param name="patternName">The pattern name.</param>
-        public SetNonStrokeColorAdvanced(IReadOnlyList<decimal> operands, NameToken patternName)
+        public SetNonStrokeColorAdvanced(IReadOnlyList<double> operands, NameToken patternName)
         {
             Operands = operands;
             PatternName = patternName;

--- a/src/UglyToad.PdfPig/Graphics/Operations/SetNonStrokeColorDeviceCmyk.cs
+++ b/src/UglyToad.PdfPig/Graphics/Operations/SetNonStrokeColorDeviceCmyk.cs
@@ -19,22 +19,22 @@
         /// <summary>
         /// The cyan level between 0 and 1.
         /// </summary>
-        public decimal C { get; }
+        public double C { get; }
 
         /// <summary>
         /// The magenta level between 0 and 1.
         /// </summary>
-        public decimal M { get; }
+        public double M { get; }
 
         /// <summary>
         /// The yellow level between 0 and 1.
         /// </summary>
-        public decimal Y { get; }
+        public double Y { get; }
 
         /// <summary>
         /// The key level between 0 and 1.
         /// </summary>
-        public decimal K { get; }
+        public double K { get; }
 
         /// <summary>
         /// Create a new <see cref="SetNonStrokeColorDeviceCmyk"/>.
@@ -43,7 +43,7 @@
         /// <param name="m">The magenta level.</param>
         /// <param name="y">The yellow level.</param>
         /// <param name="k">The key level.</param>
-        public SetNonStrokeColorDeviceCmyk(decimal c, decimal m, decimal y, decimal k)
+        public SetNonStrokeColorDeviceCmyk(double c, double m, double y, double k)
         {
             C = c;
             M = m;

--- a/src/UglyToad.PdfPig/Graphics/Operations/SetNonStrokeColorDeviceGray.cs
+++ b/src/UglyToad.PdfPig/Graphics/Operations/SetNonStrokeColorDeviceGray.cs
@@ -19,13 +19,13 @@
         /// <summary>
         /// The gray level between 0 (black) and 1 (white).
         /// </summary>
-        public decimal Gray { get; }
+        public double Gray { get; }
 
         /// <summary>
         /// Create a new <see cref="SetNonStrokeColorDeviceGray"/>.
         /// </summary>
         /// <param name="gray">The gray level.</param>
-        public SetNonStrokeColorDeviceGray(decimal gray)
+        public SetNonStrokeColorDeviceGray(double gray)
         {
             Gray = gray;
         }

--- a/src/UglyToad.PdfPig/Graphics/Operations/SetNonStrokeColorDeviceRgb.cs
+++ b/src/UglyToad.PdfPig/Graphics/Operations/SetNonStrokeColorDeviceRgb.cs
@@ -19,17 +19,17 @@
         /// <summary>
         /// The red level between 0 and 1.
         /// </summary>
-        public decimal R { get; }
+        public double R { get; }
 
         /// <summary>
         /// The green level between 0 and 1.
         /// </summary>
-        public decimal G { get; }
+        public double G { get; }
 
         /// <summary>
         /// The blue level between 0 and 1.
         /// </summary>
-        public decimal B { get; }
+        public double B { get; }
 
         /// <summary>
         /// Create a new <see cref="SetNonStrokeColorDeviceRgb"/>.
@@ -37,7 +37,7 @@
         /// <param name="r">The red level.</param>
         /// <param name="g">The green level.</param>
         /// <param name="b">The blue level.</param>
-        public SetNonStrokeColorDeviceRgb(decimal r, decimal g, decimal b)
+        public SetNonStrokeColorDeviceRgb(double r, double g, double b)
         {
             R = r;
             G = g;

--- a/src/UglyToad.PdfPig/Graphics/Operations/SetStrokeColor.cs
+++ b/src/UglyToad.PdfPig/Graphics/Operations/SetStrokeColor.cs
@@ -21,13 +21,13 @@
         /// <summary>
         /// The values for the color, 1 for grayscale, 3 for RGB, 4 for CMYK.
         /// </summary>
-        public IReadOnlyList<decimal> Operands { get; }
+        public IReadOnlyList<double> Operands { get; }
 
         /// <summary>
         /// Create a new <see cref="SetStrokeColor"/>.
         /// </summary>
         /// <param name="operands">The color operands.</param>
-        public SetStrokeColor(decimal[] operands)
+        public SetStrokeColor(double[] operands)
         {
             Operands = operands;
         }

--- a/src/UglyToad.PdfPig/Graphics/Operations/SetStrokeColorAdvanced.cs
+++ b/src/UglyToad.PdfPig/Graphics/Operations/SetStrokeColorAdvanced.cs
@@ -25,7 +25,7 @@
         /// <summary>
         /// The values for the color.
         /// </summary>
-        public IReadOnlyList<decimal> Operands { get; }
+        public IReadOnlyList<double> Operands { get; }
 
         /// <summary>
         /// The name of an entry in the Pattern subdictionary of the current resource dictionary.
@@ -36,7 +36,7 @@
         /// Create a new <see cref="SetStrokeColor"/>.
         /// </summary>
         /// <param name="operands">The color operands.</param>
-        public SetStrokeColorAdvanced(IReadOnlyList<decimal> operands)
+        public SetStrokeColorAdvanced(IReadOnlyList<double> operands)
         {
             Operands = operands;
         }
@@ -46,7 +46,7 @@
         /// </summary>
         /// <param name="operands">The color operands.</param>
         /// <param name="patternName">The pattern name.</param>
-        public SetStrokeColorAdvanced(IReadOnlyList<decimal> operands, NameToken patternName)
+        public SetStrokeColorAdvanced(IReadOnlyList<double> operands, NameToken patternName)
         {
             Operands = operands;
             PatternName = patternName;

--- a/src/UglyToad.PdfPig/Graphics/Operations/SetStrokeColorDeviceCmyk.cs
+++ b/src/UglyToad.PdfPig/Graphics/Operations/SetStrokeColorDeviceCmyk.cs
@@ -19,22 +19,22 @@
         /// <summary>
         /// The cyan level between 0 and 1.
         /// </summary>
-        public decimal C { get; }
+        public double C { get; }
 
         /// <summary>
         /// The magenta level between 0 and 1.
         /// </summary>
-        public decimal M { get; }
+        public double M { get; }
 
         /// <summary>
         /// The yellow level between 0 and 1.
         /// </summary>
-        public decimal Y { get; }
+        public double Y { get; }
 
         /// <summary>
         /// The key level between 0 and 1.
         /// </summary>
-        public decimal K { get; }
+        public double K { get; }
 
         /// <summary>
         /// Create a new <see cref="SetStrokeColorDeviceCmyk"/>.
@@ -43,7 +43,7 @@
         /// <param name="m">The magenta level.</param>
         /// <param name="y">The yellow level.</param>
         /// <param name="k">The key level.</param>
-        public SetStrokeColorDeviceCmyk(decimal c, decimal m, decimal y, decimal k)
+        public SetStrokeColorDeviceCmyk(double c, double m, double y, double k)
         {
             C = c;
             M = m;

--- a/src/UglyToad.PdfPig/Graphics/Operations/SetStrokeColorDeviceGray.cs
+++ b/src/UglyToad.PdfPig/Graphics/Operations/SetStrokeColorDeviceGray.cs
@@ -19,13 +19,13 @@
         /// <summary>
         /// The gray level between 0 (black) and 1 (white).
         /// </summary>
-        public decimal Gray { get; }
+        public double Gray { get; }
 
         /// <summary>
         /// Create a new <see cref="SetStrokeColorDeviceGray"/>.
         /// </summary>
         /// <param name="gray">The gray level.</param>
-        public SetStrokeColorDeviceGray(decimal gray)
+        public SetStrokeColorDeviceGray(double gray)
         {
             Gray = gray;
         }

--- a/src/UglyToad.PdfPig/Graphics/Operations/SetStrokeColorDeviceRgb.cs
+++ b/src/UglyToad.PdfPig/Graphics/Operations/SetStrokeColorDeviceRgb.cs
@@ -19,17 +19,17 @@
         /// <summary>
         /// The red level between 0 and 1.
         /// </summary>
-        public decimal R { get; }
+        public double R { get; }
 
         /// <summary>
         /// The green level between 0 and 1.
         /// </summary>
-        public decimal G { get; }
+        public double G { get; }
 
         /// <summary>
         /// The blue level between 0 and 1.
         /// </summary>
-        public decimal B { get; }
+        public double B { get; }
 
         /// <summary>
         /// Create a new <see cref="SetStrokeColorDeviceRgb"/>.
@@ -37,7 +37,7 @@
         /// <param name="r">The red level.</param>
         /// <param name="g">The green level.</param>
         /// <param name="b">The blue level.</param>
-        public SetStrokeColorDeviceRgb(decimal r, decimal g, decimal b)
+        public SetStrokeColorDeviceRgb(double r, double g, double b)
         {
             R = r;
             G = g;

--- a/src/UglyToad.PdfPig/Graphics/Operations/SpecialGraphicsState/ModifyCurrentTransformationMatrix.cs
+++ b/src/UglyToad.PdfPig/Graphics/Operations/SpecialGraphicsState/ModifyCurrentTransformationMatrix.cs
@@ -2,7 +2,6 @@
 {
     using System;
     using System.IO;
-    using PdfPig.Core;
 
     /// <inheritdoc />
     /// <summary>
@@ -21,13 +20,13 @@
         /// <summary>
         /// The 6 values for the transformation matrix.
         /// </summary>
-        public decimal[] Value { get; }
+        public double[] Value { get; }
 
         /// <summary>
         /// Create a new <see cref="ModifyCurrentTransformationMatrix"/>.
         /// </summary>
         /// <param name="value">The 6 transformation matrix values.</param>
-        public ModifyCurrentTransformationMatrix(decimal[] value)
+        public ModifyCurrentTransformationMatrix(double[] value)
         {
             if (value == null)
             {
@@ -44,7 +43,7 @@
         /// <inheritdoc />
         public void Run(IOperationContext operationContext)
         {
-            operationContext.ModifyCurrentTransformationMatrix(Array.ConvertAll(Value, x => (double)x));
+            operationContext.ModifyCurrentTransformationMatrix(Value);
         }
 
         /// <inheritdoc />

--- a/src/UglyToad.PdfPig/Graphics/Operations/TextPositioning/MoveToNextLineWithOffset.cs
+++ b/src/UglyToad.PdfPig/Graphics/Operations/TextPositioning/MoveToNextLineWithOffset.cs
@@ -26,19 +26,19 @@
         /// <summary>
         /// The x value of the offset.
         /// </summary>
-        public decimal Tx { get; }
+        public double Tx { get; }
 
         /// <summary>
         /// The y value of the offset.
         /// </summary>
-        public decimal Ty { get; }
+        public double Ty { get; }
 
         /// <summary>
         /// Create a new <see cref="MoveToNextLineWithOffset"/>.
         /// </summary>
         /// <param name="tx">The x offset.</param>
         /// <param name="ty">The y offset.</param>
-        public MoveToNextLineWithOffset(decimal tx, decimal ty)
+        public MoveToNextLineWithOffset(double tx, double ty)
         {
             Tx = tx;
             Ty = ty;
@@ -49,7 +49,7 @@
         {
             var currentTextLineMatrix = operationContext.TextMatrices.TextLineMatrix;
             
-            var matrix = TransformationMatrix.FromValues(1, 0, 0, 1, (double)Tx, (double)Ty);
+            var matrix = TransformationMatrix.FromValues(1, 0, 0, 1, Tx, Ty);
 
             var transformed = matrix.Multiply(currentTextLineMatrix);
 

--- a/src/UglyToad.PdfPig/Graphics/Operations/TextPositioning/MoveToNextLineWithOffsetSetLeading.cs
+++ b/src/UglyToad.PdfPig/Graphics/Operations/TextPositioning/MoveToNextLineWithOffsetSetLeading.cs
@@ -21,19 +21,19 @@
         /// <summary>
         /// The x value of the offset.
         /// </summary>
-        public decimal Tx { get; }
+        public double Tx { get; }
 
         /// <summary>
         /// The y value of the offset and the inverse of the leading parameter.
         /// </summary>
-        public decimal Ty { get; }
+        public double Ty { get; }
 
         /// <summary>
         /// Create a new <see cref="MoveToNextLineWithOffsetSetLeading"/>.
         /// </summary>
         /// <param name="tx">The x value of the offset.</param>
         /// <param name="ty">The y value of the offset and the inverse of the leading parameter.</param>
-        public MoveToNextLineWithOffsetSetLeading(decimal tx, decimal ty)
+        public MoveToNextLineWithOffsetSetLeading(double tx, double ty)
         {
             Tx = tx;
             Ty = ty;

--- a/src/UglyToad.PdfPig/Graphics/Operations/TextPositioning/SetTextMatrix.cs
+++ b/src/UglyToad.PdfPig/Graphics/Operations/TextPositioning/SetTextMatrix.cs
@@ -21,13 +21,13 @@
         /// <summary>
         /// The values of the text matrix.
         /// </summary>
-        public decimal[] Value { get; }
+        public double[] Value { get; }
 
         /// <summary>
         /// Create a new <see cref="SetTextMatrix"/>.
         /// </summary>
         /// <param name="value">The values of the text matrix.</param>
-        public SetTextMatrix(decimal[] value)
+        public SetTextMatrix(double[] value)
         {
             if (value.Length != 6)
             {

--- a/src/UglyToad.PdfPig/Graphics/Operations/TextShowing/MoveToNextLineShowTextWithSpacing.cs
+++ b/src/UglyToad.PdfPig/Graphics/Operations/TextShowing/MoveToNextLineShowTextWithSpacing.cs
@@ -22,12 +22,12 @@
         /// <summary>
         /// The word spacing.
         /// </summary>
-        public decimal WordSpacing { get; }
+        public double WordSpacing { get; }
 
         /// <summary>
         /// The character spacing.
         /// </summary>
-        public decimal CharacterSpacing { get; }
+        public double CharacterSpacing { get; }
 
         /// <summary>
         /// The bytes of the text.
@@ -47,7 +47,7 @@
         /// <param name="wordSpacing">The word spacing.</param>
         /// <param name="characterSpacing">The character spacing.</param>
         /// <param name="text">The text to show.</param>
-        public MoveToNextLineShowTextWithSpacing(decimal wordSpacing, decimal characterSpacing, string text)
+        public MoveToNextLineShowTextWithSpacing(double wordSpacing, double characterSpacing, string text)
         {
             WordSpacing = wordSpacing;
             CharacterSpacing = characterSpacing;
@@ -60,7 +60,7 @@
         /// <param name="wordSpacing">The word spacing.</param>
         /// <param name="characterSpacing">The character spacing.</param>
         /// <param name="hexBytes">The bytes of the text to show.</param>
-        public MoveToNextLineShowTextWithSpacing(decimal wordSpacing, decimal characterSpacing, byte[] hexBytes)
+        public MoveToNextLineShowTextWithSpacing(double wordSpacing, double characterSpacing, byte[] hexBytes)
         {
             WordSpacing = wordSpacing;
             CharacterSpacing = characterSpacing;

--- a/src/UglyToad.PdfPig/Graphics/Operations/TextState/SetCharacterSpacing.cs
+++ b/src/UglyToad.PdfPig/Graphics/Operations/TextState/SetCharacterSpacing.cs
@@ -5,7 +5,7 @@
     /// <inheritdoc />
     /// <summary>
     /// Set the character spacing to a number expressed in unscaled text space units.
-    /// Initial value: 0. 
+    /// Initial value: 0.
     /// </summary>
     public class SetCharacterSpacing : IGraphicsStateOperation
     {
@@ -20,13 +20,13 @@
         /// <summary>
         /// The character spacing.
         /// </summary>
-        public decimal Spacing { get; }
+        public double Spacing { get; }
 
         /// <summary>
         /// Create a new <see cref="SetCharacterSpacing"/>.
         /// </summary>
         /// <param name="spacing">The character spacing.</param>
-        public SetCharacterSpacing(decimal spacing)
+        public SetCharacterSpacing(double spacing)
         {
             Spacing = spacing;
         }
@@ -34,7 +34,7 @@
         /// <inheritdoc />
         public void Run(IOperationContext operationContext)
         {
-            operationContext.SetCharacterSpacing((double)Spacing);
+            operationContext.SetCharacterSpacing(Spacing);
         }
 
         /// <inheritdoc />

--- a/src/UglyToad.PdfPig/Graphics/Operations/TextState/SetFontAndSize.cs
+++ b/src/UglyToad.PdfPig/Graphics/Operations/TextState/SetFontAndSize.cs
@@ -8,7 +8,7 @@
 
     /// <inheritdoc />
     /// <summary>
-    /// Set the font and the font size. 
+    /// Set the font and the font size.
     /// Font is the name of a font resource in the Font subdictionary of the current resource dictionary.
     /// Size is a number representing a scale factor.
     /// </summary>
@@ -32,14 +32,14 @@
         /// The font program defines glyphs for a standard size. This standard size is set so that each line of text will occupy 1 unit in user space.
         /// The size is the scale factor used to scale glyphs from the standard size to the display size rather than the font size in points.
         /// </summary>
-        public decimal Size { get; }
+        public double Size { get; }
 
         /// <summary>
         /// Create a new <see cref="SetFontAndSize"/>.
         /// </summary>
         /// <param name="font">The font name.</param>
         /// <param name="size">The font size.</param>
-        public SetFontAndSize(NameToken font, decimal size)
+        public SetFontAndSize(NameToken font, double size)
         {
             Font = font ?? throw new ArgumentNullException(nameof(font));
             Size = size;
@@ -48,7 +48,7 @@
         /// <inheritdoc />
         public void Run(IOperationContext operationContext)
         {
-            operationContext.SetFontAndSize(Font, (double)Size);
+            operationContext.SetFontAndSize(Font, Size);
         }
 
         /// <inheritdoc />

--- a/src/UglyToad.PdfPig/Graphics/Operations/TextState/SetHorizontalScaling.cs
+++ b/src/UglyToad.PdfPig/Graphics/Operations/TextState/SetHorizontalScaling.cs
@@ -16,13 +16,13 @@
         /// <summary>
         /// A number specifying the percentage of the normal width.
         /// </summary>
-        public decimal Scale { get; }
+        public double Scale { get; }
 
         /// <summary>
         /// Create a new <see cref="SetHorizontalScaling"/>.
         /// </summary>
         /// <param name="scale">The horizontal scaling percentage.</param>
-        public SetHorizontalScaling(decimal scale)
+        public SetHorizontalScaling(double scale)
         {
             Scale = scale;
         }
@@ -30,7 +30,7 @@
         /// <inheritdoc />
         public void Run(IOperationContext operationContext)
         {
-            operationContext.SetHorizontalScaling((double)Scale);
+            operationContext.SetHorizontalScaling(Scale);
         }
 
         /// <inheritdoc />

--- a/src/UglyToad.PdfPig/Graphics/Operations/TextState/SetTextLeading.cs
+++ b/src/UglyToad.PdfPig/Graphics/Operations/TextState/SetTextLeading.cs
@@ -19,13 +19,13 @@
         /// <summary>
         /// The text leading in unscaled text space units.
         /// </summary>
-        public decimal Leading { get; }
+        public double Leading { get; }
 
         /// <summary>
         /// Create a new <see cref="SetTextLeading"/>.
         /// </summary>
         /// <param name="leading">The text leading.</param>
-        public SetTextLeading(decimal leading)
+        public SetTextLeading(double leading)
         {
             Leading = leading;
         }
@@ -33,7 +33,7 @@
         /// <inheritdoc />
         public void Run(IOperationContext operationContext)
         {
-            operationContext.SetTextLeading((double)Leading);
+            operationContext.SetTextLeading(Leading);
         }
 
         /// <inheritdoc />

--- a/src/UglyToad.PdfPig/Graphics/Operations/TextState/SetTextRise.cs
+++ b/src/UglyToad.PdfPig/Graphics/Operations/TextState/SetTextRise.cs
@@ -19,13 +19,13 @@
         /// <summary>
         /// The amount of text rise - how far to move the baseline up or down from its default location.
         /// </summary>
-        public decimal Rise { get; }
+        public double Rise { get; }
 
         /// <summary>
         /// Create a new <see cref="SetTextRise"/>.
         /// </summary>
         /// <param name="rise">The text rise.</param>
-        public SetTextRise(decimal rise)
+        public SetTextRise(double rise)
         {
             Rise = rise;
         }
@@ -33,7 +33,7 @@
         /// <inheritdoc />
         public void Run(IOperationContext operationContext)
         {
-            operationContext.SetTextRise((double)Rise);
+            operationContext.SetTextRise(Rise);
         }
 
         /// <inheritdoc />

--- a/src/UglyToad.PdfPig/Graphics/Operations/TextState/SetWordSpacing.cs
+++ b/src/UglyToad.PdfPig/Graphics/Operations/TextState/SetWordSpacing.cs
@@ -20,13 +20,13 @@
         /// writing positive values increase the gap between words separated by space, for vertical writing
         /// positive values decrease the gap.
         /// </summary>
-        public decimal Spacing { get; }
+        public double Spacing { get; }
 
         /// <summary>
         /// Create a new <see cref="SetWordSpacing"/>.
         /// </summary>
         /// <param name="spacing">The word spacing.</param>
-        public SetWordSpacing(decimal spacing)
+        public SetWordSpacing(double spacing)
         {
             Spacing = spacing;
         }
@@ -34,7 +34,7 @@
         /// <inheritdoc />
         public void Run(IOperationContext operationContext)
         {
-            operationContext.SetWordSpacing((double)Spacing);
+            operationContext.SetWordSpacing(Spacing);
         }
 
         /// <inheritdoc />

--- a/src/UglyToad.PdfPig/Graphics/Operations/TextState/Type3SetGlyphWidth.cs
+++ b/src/UglyToad.PdfPig/Graphics/Operations/TextState/Type3SetGlyphWidth.cs
@@ -22,19 +22,19 @@
         /// <summary>
         /// The horizontal displacement in the glyph coordinate system.
         /// </summary>
-        public decimal HorizontalDisplacement { get; }
+        public double HorizontalDisplacement { get; }
 
         /// <summary>
         /// The vertical displacement in the glyph coordinate system. Must be 0.
         /// </summary>
-        public decimal VerticalDisplacement { get; }
+        public double VerticalDisplacement { get; }
 
         /// <summary>
         /// Create a new <see cref="Type3SetGlyphWidth"/>.
         /// </summary>
         /// <param name="horizontalDisplacement">The horizontal displacement in the glyph coordinate system.</param>
         /// <param name="verticalDisplacement">The vertical displacement in the glyph coordinate system.</param>
-        public Type3SetGlyphWidth(decimal horizontalDisplacement, decimal verticalDisplacement)
+        public Type3SetGlyphWidth(double horizontalDisplacement, double verticalDisplacement)
         {
             HorizontalDisplacement = horizontalDisplacement;
             VerticalDisplacement = verticalDisplacement;

--- a/src/UglyToad.PdfPig/Graphics/Operations/TextState/Type3SetGlyphWidthAndBoundingBox.cs
+++ b/src/UglyToad.PdfPig/Graphics/Operations/TextState/Type3SetGlyphWidthAndBoundingBox.cs
@@ -20,32 +20,32 @@
         /// <summary>
         /// The horizontal displacement in the glyph coordinate system.
         /// </summary>
-        public decimal HorizontalDisplacement { get; }
+        public double HorizontalDisplacement { get; }
 
         /// <summary>
         /// The vertical displacement in the glyph coordinate system. Must be 0.
         /// </summary>
-        public decimal VerticalDisplacement { get; }
+        public double VerticalDisplacement { get; }
 
         /// <summary>
         /// The lower left x coordinate of the glyph bounding box.
         /// </summary>
-        public decimal LowerLeftX { get; }
+        public double LowerLeftX { get; }
 
         /// <summary>
         /// The lower left y coordinate of the glyph bounding box.
         /// </summary>
-        public decimal LowerLeftY { get; }
+        public double LowerLeftY { get; }
 
         /// <summary>
         /// The upper right x coordinate of the glyph bounding box.
         /// </summary>
-        public decimal UpperRightX { get; }
+        public double UpperRightX { get; }
 
         /// <summary>
         /// The upper right y coordinate of the glyph bounding box.
         /// </summary>
-        public decimal UpperRightY { get; }
+        public double UpperRightY { get; }
         
         /// <summary>
         /// Create a new <see cref="Type3SetGlyphWidthAndBoundingBox"/>.
@@ -56,11 +56,11 @@
         /// <param name="lowerLeftY">The lower left y coordinate of the glyph bounding box.</param>
         /// <param name="upperRightX">The upper right x coordinate of the glyph bounding box.</param>
         /// <param name="upperRightY">The upper right y coordinate of the glyph bounding box.</param>
-        public Type3SetGlyphWidthAndBoundingBox(decimal horizontalDisplacement, decimal verticalDisplacement,
-            decimal lowerLeftX, 
-            decimal lowerLeftY, 
-            decimal upperRightX,
-            decimal upperRightY)
+        public Type3SetGlyphWidthAndBoundingBox(double horizontalDisplacement, double verticalDisplacement,
+            double lowerLeftX, 
+            double lowerLeftY, 
+            double upperRightX,
+            double upperRightY)
         {
             HorizontalDisplacement = horizontalDisplacement;
             VerticalDisplacement = verticalDisplacement;

--- a/src/UglyToad.PdfPig/Graphics/PdfPath.cs
+++ b/src/UglyToad.PdfPig/Graphics/PdfPath.cs
@@ -44,7 +44,7 @@
         /// <summary>
         /// Thickness in user space units of path to be stroked.
         /// </summary>
-        public decimal LineWidth { get; internal set; }
+        public double LineWidth { get; internal set; }
 
         /// <summary>
         /// The pattern to be used for stroked lines.

--- a/src/UglyToad.PdfPig/Graphics/ReflectionGraphicsStateOperationFactory.cs
+++ b/src/UglyToad.PdfPig/Graphics/ReflectionGraphicsStateOperationFactory.cs
@@ -24,7 +24,7 @@ namespace UglyToad.PdfPig.Graphics
 
     internal class ReflectionGraphicsStateOperationFactory : IGraphicsStateOperationFactory
     {
-        private static readonly ListPool<decimal> DecimalListPool = new ListPool<decimal>(10);
+        private static readonly ListPool<double> DecimalListPool = new ListPool<double>(10);
 
         private readonly IReadOnlyDictionary<string, Type> operations;
 
@@ -54,7 +54,7 @@ namespace UglyToad.PdfPig.Graphics
             operations = result;
         }
 
-        private static decimal[] TokensToDecimalArray(IReadOnlyList<IToken> tokens, bool exceptLast = false)
+        private static double[] TokensToDecimalArray(IReadOnlyList<IToken> tokens, bool exceptLast = false)
         {
             var result = DecimalListPool.Borrow();
 
@@ -104,7 +104,7 @@ namespace UglyToad.PdfPig.Graphics
             return numeric.Int;
         }
 
-        private static decimal OperandToDecimal(IToken token)
+        private static double OperandToDecimal(IToken token)
         {
             if (!(token is NumericToken numeric))
             {
@@ -417,7 +417,7 @@ namespace UglyToad.PdfPig.Graphics
                     throw new InvalidOperationException($"Fewer operands {operands.Count} found than required ({offset + 1}) for operator: {op.Data}.");
                 }
 
-                if (parameter.ParameterType == typeof(decimal))
+                if (parameter.ParameterType == typeof(double))
                 {
                     if (operands[offset] is NumericToken numeric)
                     {
@@ -425,7 +425,7 @@ namespace UglyToad.PdfPig.Graphics
                     }
                     else
                     {
-                        throw new InvalidOperationException($"Expected a decimal parameter for operation type {operationType.FullName}. Instead got: {operands[offset]}");
+                        throw new InvalidOperationException($"Expected a double parameter for operation type {operationType.FullName}. Instead got: {operands[offset]}");
                     }
 
                     offset++;
@@ -443,7 +443,7 @@ namespace UglyToad.PdfPig.Graphics
 
                     offset++;
                 }
-                else if (parameter.ParameterType == typeof(decimal[]))
+                else if (parameter.ParameterType == typeof(double[]))
                 {
                     if (operands[offset] is ArrayToken arr)
                     {
@@ -452,7 +452,7 @@ namespace UglyToad.PdfPig.Graphics
                         continue;
                     }
 
-                    var array = new List<decimal>();
+                    var array = new List<double>();
                     while (offset < operands.Count && operands[offset] is NumericToken numeric)
                     {
                         array.Add(numeric.Data);
@@ -473,7 +473,7 @@ namespace UglyToad.PdfPig.Graphics
                     }
                     else
                     {
-                        throw new InvalidOperationException($"Expected a decimal array parameter for operation type {operationType.FullName}. Instead got: {operands[offset]}");
+                        throw new InvalidOperationException($"Expected a double array parameter for operation type {operationType.FullName}. Instead got: {operands[offset]}");
                     }
 
                     offset++;

--- a/src/UglyToad.PdfPig/Outline/Destinations/ExplicitDestinationCoordinates.cs
+++ b/src/UglyToad.PdfPig/Outline/Destinations/ExplicitDestinationCoordinates.cs
@@ -13,27 +13,27 @@
         /// <summary>
         /// The left side of the region to display.
         /// </summary>
-        public decimal? Left { get; }
+        public double? Left { get; }
 
         /// <summary>
         /// The top edge of the region to display.
         /// </summary>
-        public decimal? Top { get; }
+        public double? Top { get; }
 
         /// <summary>
         /// The right side of the region to display
         /// </summary>
-        public decimal? Right { get; }
+        public double? Right { get; }
 
         /// <summary>
         /// The bottom edge of the region to display.
         /// </summary>
-        public decimal? Bottom { get; }
+        public double? Bottom { get; }
 
         /// <summary>
         /// Create a new <see cref="ExplicitDestinationCoordinates"/>.
         /// </summary>
-        public ExplicitDestinationCoordinates(decimal? left)
+        public ExplicitDestinationCoordinates(double? left)
         {
             Left = left;
         }
@@ -41,7 +41,7 @@
         /// <summary>
         /// Create a new <see cref="ExplicitDestinationCoordinates"/>.
         /// </summary>
-        public ExplicitDestinationCoordinates(decimal? left, decimal? top)
+        public ExplicitDestinationCoordinates(double? left, double? top)
         {
             Left = left;
             Top = top;
@@ -50,7 +50,7 @@
         /// <summary>
         /// Create a new <see cref="ExplicitDestinationCoordinates"/>.
         /// </summary>
-        public ExplicitDestinationCoordinates(decimal? left, decimal? top, decimal? right, decimal? bottom)
+        public ExplicitDestinationCoordinates(double? left, double? top, double? right, double? bottom)
         {
             Left = left;
             Top = top;

--- a/src/UglyToad.PdfPig/Outline/Destinations/NamedDestinationsProvider.cs
+++ b/src/UglyToad.PdfPig/Outline/Destinations/NamedDestinationsProvider.cs
@@ -84,7 +84,7 @@
                 return false;
             }
 
-            decimal? GetPossibleEntry(int index)
+            double? GetPossibleEntry(int index)
             {
                 if (index >= explicitDestinationArray.Length)
                 {

--- a/src/UglyToad.PdfPig/Parser/FileStructure/FileHeaderParser.cs
+++ b/src/UglyToad.PdfPig/Parser/FileStructure/FileHeaderParser.cs
@@ -71,7 +71,7 @@
 
             const int toDecimalStartLength = 4;
 
-            if (!decimal.TryParse(comment.Data.Substring(toDecimalStartLength),
+            if (!double.TryParse(comment.Data.Substring(toDecimalStartLength),
                 NumberStyles.Number,
                 CultureInfo.InvariantCulture,
                 out var version))
@@ -120,7 +120,7 @@
                 if (actualIndex >= 0 && content.Length - actualIndex >= versionLength)
                 {
                     var numberPart = content.Substring(actualIndex + 5, 3);
-                    if (decimal.TryParse(
+                    if (double.TryParse(
                             numberPart,
                             NumberStyles.Number,
                             CultureInfo.InvariantCulture,
@@ -152,7 +152,7 @@
             {
                 log.Warn($"Did not find a version header of the correct format, defaulting to 1.4 since lenient. Header was: {comment.Data}.");
 
-                return new HeaderVersion(1.4m, "PDF-1.4", 0);
+                return new HeaderVersion(1.4, "PDF-1.4", 0);
             }
 
             throw new PdfDocumentFormatException($"The comment which should have provided the version was in the wrong format: {comment.Data}.");

--- a/src/UglyToad.PdfPig/PdfDocument.cs
+++ b/src/UglyToad.PdfPig/PdfDocument.cs
@@ -64,7 +64,7 @@
         /// <summary>
         /// The version number of the PDF specification which this file conforms to, for example 1.4.
         /// </summary>
-        public decimal Version => version.Version;
+        public double Version => version.Version;
 
         /// <summary>
         /// Get the number of pages in this document.

--- a/src/UglyToad.PdfPig/PdfFonts/CidFonts/Type0CidFont.cs
+++ b/src/UglyToad.PdfPig/PdfFonts/CidFonts/Type0CidFont.cs
@@ -80,13 +80,13 @@
             {
                 return defaultWidth.Value;
             }
-            
+
             if (Descriptor == null)
             {
                 return 1000;
             }
 
-            return (double)Descriptor.MissingWidth;
+            return Descriptor.MissingWidth;
         }
 
         public PdfRectangle GetBoundingBox(int characterIdentifier)

--- a/src/UglyToad.PdfPig/PdfFonts/CidFonts/Type2CidFont.cs
+++ b/src/UglyToad.PdfPig/PdfFonts/CidFonts/Type2CidFont.cs
@@ -87,7 +87,7 @@
                 return defaultWidth.Value;
             }
 
-            return (double)(Descriptor?.MissingWidth ?? 1000);
+            return Descriptor?.MissingWidth ?? 1000;
         }
 
         public PdfRectangle GetBoundingBox(int characterIdentifier)

--- a/src/UglyToad.PdfPig/PdfFonts/FontDescriptor.cs
+++ b/src/UglyToad.PdfPig/PdfFonts/FontDescriptor.cs
@@ -53,7 +53,7 @@
         /// 900<br/>
         /// Optional
         /// </remarks>
-        public decimal FontWeight { get; }
+        public double FontWeight { get; }
 
         /// <summary>
         /// Defines various font characteristics. See <see cref="FontDescriptorFlags"/>.
@@ -75,69 +75,69 @@
         /// </summary>
         /// <example>9 o'clock is represented by 90 degrees. 3 o'clock is -90 degrees.</example>
         /// <remarks>Required</remarks>
-        public decimal ItalicAngle { get; }
+        public double ItalicAngle { get; }
 
         /// <summary>
         /// The maximum height above the baseline for any glyph from this font (except for accents).
         /// </summary>
         /// <remarks>Required (Except Type 3)</remarks>
-        public decimal Ascent { get; }
+        public double Ascent { get; }
 
         /// <summary>
         /// The maximum depth below the baseline for any glyph in the font. This is negative.
         /// </summary>
         /// <remarks>Required (Except Type 3)</remarks>
-        public decimal Descent { get; }
+        public double Descent { get; }
 
         /// <summary>
         /// The spacing between consecutive lines of text. Default 0.
         /// </summary>
         /// <remarks>Optional</remarks>
-        public decimal Leading { get; }
+        public double Leading { get; }
 
         /// <summary>
         /// The vertical distance of the top of flat capital letters from the baseline.
         /// </summary>
         /// <remarks>Required (Where Latin Characters, Except Type 3)</remarks>
-        public decimal CapHeight { get; }
+        public double CapHeight { get; }
 
         /// <summary>
         /// The x height of the font. The vertical distance of the top of flat non-ascending
         /// lowercase letters (e.g. x) from the baseline. Default 0.
         /// </summary>
         /// <remarks>Optional</remarks>
-        public decimal XHeight { get; }
+        public double XHeight { get; }
 
         /// <summary>
         /// The horizontal thickness of vertical stems of glyphs.
         /// </summary>
         /// <remarks>Required (Except Type 3)</remarks>
-        public decimal StemVertical { get; }
+        public double StemVertical { get; }
 
         /// <summary>
         /// The vertical thickness of horizontal stems of glyphs. Default 0.
         /// </summary>
         /// <remarks>Optional</remarks>
-        public decimal StemHorizontal { get; }
+        public double StemHorizontal { get; }
 
         /// <summary>
         /// The average glyph width in the font. Default 0.
         /// </summary>
         /// <remarks>Optional</remarks>
-        public decimal AverageWidth { get; }
+        public double AverageWidth { get; }
 
         /// <summary>
         /// The maximum glyph width in the font. Default 0.
         /// </summary>
         /// <remarks>Optional</remarks>
-        public decimal MaxWidth { get; }
+        public double MaxWidth { get; }
 
         /// <summary>
         /// The width for character codes whose widths are not present in the Widths
         /// array of the font dictionary. Default 0.
         /// </summary>
         /// <remarks>Optional</remarks>
-        public decimal MissingWidth { get; }
+        public double MissingWidth { get; }
 
         /// <summary>
         /// The bytes of the font program.
@@ -210,7 +210,7 @@
             /// <summary>
             /// Sets the <see cref="FontDescriptor.FontWeight"/>.
             /// </summary>
-            public decimal FontWeight { get; set; } = 400;
+            public double FontWeight { get; set; } = 400;
 
             /// <summary>
             /// Sets the <see cref="FontDescriptor.Flags"/>.
@@ -225,57 +225,57 @@
             /// <summary>
             /// Sets the <see cref="FontDescriptor.ItalicAngle"/>.
             /// </summary>
-            public decimal ItalicAngle { get; set; }
+            public double ItalicAngle { get; set; }
 
             /// <summary>
             /// Sets the <see cref="FontDescriptor.Ascent"/>.
             /// </summary>
-            public decimal Ascent { get; set; }
+            public double Ascent { get; set; }
 
             /// <summary>
             /// Sets the <see cref="FontDescriptor.Descent"/>.
             /// </summary>
-            public decimal Descent { get; set; }
+            public double Descent { get; set; }
 
             /// <summary>
             /// Sets the <see cref="FontDescriptor.Leading"/>.
             /// </summary>
-            public decimal Leading { get; set; }
+            public double Leading { get; set; }
 
             /// <summary>
             /// Sets the <see cref="FontDescriptor.CapHeight"/>.
             /// </summary>
-            public decimal CapHeight { get; set; }
+            public double CapHeight { get; set; }
 
             /// <summary>
             /// Sets the <see cref="FontDescriptor.XHeight"/>.
             /// </summary>
-            public decimal XHeight { get; set; }
+            public double XHeight { get; set; }
 
             /// <summary>
             /// Sets the <see cref="FontDescriptor.StemVertical"/>.
             /// </summary>
-            public decimal StemVertical { get; set; }
+            public double StemVertical { get; set; }
 
             /// <summary>
             /// Sets the <see cref="FontDescriptor.StemHorizontal"/>.
             /// </summary>
-            public decimal StemHorizontal { get; set; }
+            public double StemHorizontal { get; set; }
 
             /// <summary>
             /// Sets the <see cref="FontDescriptor.AverageWidth"/>.
             /// </summary>
-            public decimal AverageWidth { get; set; }
+            public double AverageWidth { get; set; }
 
             /// <summary>
             /// Sets the <see cref="FontDescriptor.MaxWidth"/>.
             /// </summary>
-            public decimal MaxWidth { get; set; }
+            public double MaxWidth { get; set; }
 
             /// <summary>
             /// Sets the <see cref="FontDescriptor.MissingWidth"/>.
             /// </summary>
-            public decimal MissingWidth { get; set; }
+            public double MissingWidth { get; set; }
 
             /// <summary>
             /// Sets the <see cref="FontDescriptor.FontFile"/>.

--- a/src/UglyToad.PdfPig/PdfFonts/Parser/Parts/FontDescriptorFactory.cs
+++ b/src/UglyToad.PdfPig/PdfFonts/Parser/Parts/FontDescriptorFactory.cs
@@ -46,7 +46,7 @@
             }.Build();
         }
 
-        private static decimal GetDecimalOrDefault(DictionaryToken dictionary, NameToken name)
+        private static double GetDecimalOrDefault(DictionaryToken dictionary, NameToken name)
         {
             if (!dictionary.TryGet(name, out var token) || !(token is NumericToken number))
             {

--- a/src/UglyToad.PdfPig/PdfFonts/Simple/TrueTypeSimpleFont.cs
+++ b/src/UglyToad.PdfPig/PdfFonts/Simple/TrueTypeSimpleFont.cs
@@ -317,7 +317,7 @@
 
             if (index < 0 || index >= widths.Length)
             {
-                return (double)descriptor.MissingWidth;
+                return descriptor.MissingWidth;
             }
 
             return widths[index];

--- a/src/UglyToad.PdfPig/PdfFonts/Simple/Type1FontSimple.cs
+++ b/src/UglyToad.PdfPig/PdfFonts/Simple/Type1FontSimple.cs
@@ -163,7 +163,7 @@
 
             if (fontDescriptor?.MissingWidth != null)
             {
-                return (double)fontDescriptor.MissingWidth;
+                return fontDescriptor.MissingWidth;
             }
 
             return boundingBox.Width;

--- a/src/UglyToad.PdfPig/Util/PatternParser.cs
+++ b/src/UglyToad.PdfPig/Util/PatternParser.cs
@@ -47,7 +47,7 @@
             else
             {
                 // optional - Default value: the identity matrix [1 0 0 1 0 0]
-                matrix = TransformationMatrix.FromArray(new decimal[] { 1, 0, 0, 1, 0, 0 });
+                matrix = TransformationMatrix.FromArray(new double[] { 1, 0, 0, 1, 0, 0 });
             }
 
             DictionaryToken patternExtGState = null;

--- a/src/UglyToad.PdfPig/Util/ShadingParser.cs
+++ b/src/UglyToad.PdfPig/Util/ShadingParser.cs
@@ -151,7 +151,7 @@
             else
             {
                 // Optional - Default value: the identity matrix [1 0 0 1 0 0]
-                matrix = TransformationMatrix.FromArray(new decimal[] { 1, 0, 0, 1, 0, 0 });
+                matrix = TransformationMatrix.FromArray(new double[] { 1, 0, 0, 1, 0, 0 });
             }
 
             if (!shadingDictionary.ContainsKey(NameToken.Function))

--- a/src/UglyToad.PdfPig/Writer/Fonts/TrueTypeWritingFont.cs
+++ b/src/UglyToad.PdfPig/Writer/Fonts/TrueTypeWritingFont.cs
@@ -63,7 +63,7 @@
 
             var bbox = font.TableRegister.HeaderTable.Bounds;
 
-            var scaling = 1000m / font.TableRegister.HeaderTable.UnitsPerEm;
+            var scaling = 1000.0 / font.TableRegister.HeaderTable.UnitsPerEm;
             var descriptorDictionary = new Dictionary<NameToken, IToken>
             {
                 { NameToken.Type, NameToken.FontDescriptor },
@@ -71,7 +71,7 @@
                 // TODO: get flags TrueTypeEmbedder.java
                 { NameToken.Flags, new NumericToken((int)FontDescriptorFlags.Symbolic) },
                 { NameToken.FontBbox, GetBoundingBox(bbox, scaling) },
-                { NameToken.ItalicAngle, new NumericToken((decimal)postscript.ItalicAngle) },
+                { NameToken.ItalicAngle, new NumericToken((double)postscript.ItalicAngle) },
                 { NameToken.Ascent, new NumericToken(Math.Round(hhead.Ascent * scaling, 2)) },
                 { NameToken.Descent, new NumericToken(Math.Round(hhead.Descent * scaling, 2)) },
                 { NameToken.CapHeight, new NumericToken(90) },
@@ -91,7 +91,7 @@
                 descriptorDictionary[NameToken.Xheight] = new NumericToken(twoPlus.XHeight);
             }
 
-            descriptorDictionary[NameToken.StemV] = new NumericToken(((decimal)bbox.Width) * scaling * 0.13m);
+            descriptorDictionary[NameToken.StemV] = new NumericToken((bbox.Width) * scaling * 0.13);
 
             var lastCharacter = 0;
             var widths = new List<NumericToken> { NumericToken.Zero };
@@ -103,7 +103,7 @@
                 }
 
                 var glyphId = font.WindowsUnicodeCMap.CharacterCodeToGlyphIndex(kvp.Key);
-                var width = decimal.Round(font.TableRegister.HorizontalMetricsTable.GetAdvanceWidth(glyphId) * scaling, 2);
+                var width = Math.Round(font.TableRegister.HorizontalMetricsTable.GetAdvanceWidth(glyphId) * scaling, 2);
 
                 widths.Add(new NumericToken(width));
             }
@@ -162,14 +162,14 @@
             }
         }
 
-        private static ArrayToken GetBoundingBox(PdfRectangle boundingBox, decimal scaling)
+        private static ArrayToken GetBoundingBox(PdfRectangle boundingBox, double scaling)
         {
             return new ArrayToken(new[]
             {
-                new NumericToken(Math.Round((decimal)boundingBox.Left * scaling, 2)),
-                new NumericToken(Math.Round((decimal)boundingBox.Bottom * scaling, 2)),
-                new NumericToken(Math.Round((decimal)boundingBox.Right * scaling, 2)),
-                new NumericToken(Math.Round((decimal)boundingBox.Top * scaling, 2))
+                new NumericToken(Math.Round(boundingBox.Left * scaling, 2)),
+                new NumericToken(Math.Round(boundingBox.Bottom * scaling, 2)),
+                new NumericToken(Math.Round(boundingBox.Right * scaling, 2)),
+                new NumericToken(Math.Round(boundingBox.Top * scaling, 2))
             });
         }
     }

--- a/src/UglyToad.PdfPig/Writer/IPdfStreamWriter.cs
+++ b/src/UglyToad.PdfPig/Writer/IPdfStreamWriter.cs
@@ -1,9 +1,7 @@
 ﻿namespace UglyToad.PdfPig.Writer
 {
     using System;
-    using System.Collections.Generic;
     using System.IO;
-    using System.Text;
     using Tokens;
 
     internal interface IPdfStreamWriter : IDisposable
@@ -47,7 +45,7 @@
         /// Initializes the PDF stream with pdf header.
         /// </summary>
         /// <param name="version">Version of PDF.</param>
-        void InitializePdf(decimal version);
+        void InitializePdf(double version);
 
         /// <summary>
         /// Completes the PDF writing trailing PDF information.

--- a/src/UglyToad.PdfPig/Writer/PdfABaselineRuleBuilder.cs
+++ b/src/UglyToad.PdfPig/Writer/PdfABaselineRuleBuilder.cs
@@ -13,7 +13,7 @@ namespace UglyToad.PdfPig.Writer
             PdfAStandard archiveStandard)
         {
             catalog[NameToken.OutputIntents] = OutputIntentsFactory.GetOutputIntentsArray(writerFunc);
-            var xmpStream = XmpWriter.GenerateXmpStream(documentInformationBuilder, 1.7m, archiveStandard);
+            var xmpStream = XmpWriter.GenerateXmpStream(documentInformationBuilder, 1.7, archiveStandard);
             var xmpObj = writerFunc(xmpStream);
             catalog[NameToken.Metadata] = xmpObj;
         }

--- a/src/UglyToad.PdfPig/Writer/PdfDocumentBuilder.cs
+++ b/src/UglyToad.PdfPig/Writer/PdfDocumentBuilder.cs
@@ -77,14 +77,14 @@ namespace UglyToad.PdfPig.Writer
         public PdfDocumentBuilder()
         {
             context = new PdfStreamWriter(new MemoryStream(), true);
-            context.InitializePdf(1.7m);
+            context.InitializePdf(1.7);
         }
 
         /// <summary>
         /// Creates a document builder keeping resources in memory.
         /// </summary>
         /// <param name="version">Pdf version to use in header.</param>
-        public PdfDocumentBuilder(decimal version)
+        public PdfDocumentBuilder(double version)
         {
             context = new PdfStreamWriter(new MemoryStream(), true);
             context.InitializePdf(version);
@@ -98,7 +98,7 @@ namespace UglyToad.PdfPig.Writer
         /// <param name="type">Type of pdf stream writer to use</param>
         /// <param name="version">Pdf version to use in header.</param>
         /// <param name="tokenWriter">Token writer to use</param>
-        public PdfDocumentBuilder(Stream stream, bool disposeStream = false, PdfWriterType type = PdfWriterType.Default, decimal version = 1.7m, ITokenWriter tokenWriter = null)
+        public PdfDocumentBuilder(Stream stream, bool disposeStream = false, PdfWriterType type = PdfWriterType.Default, double version = 1.7, ITokenWriter tokenWriter = null)
         {
             switch (type)
             {
@@ -762,7 +762,8 @@ namespace UglyToad.PdfPig.Writer
                 {
                     var currentTreeDepth = (int)Math.Ceiling(Math.Log(pagesNodes.Count, desiredLeafSize));
                     var perBranch = (int)Math.Ceiling(Math.Pow(desiredLeafSize, currentTreeDepth - 1));
-                    var branches = (int)Math.Ceiling(decimal.Divide(pagesNodes.Count, (decimal)perBranch));
+
+                    var branches = (int)Math.Ceiling(pagesNodes.Count / (double)perBranch);
                     for (var i = 0; i < branches; i++)
                     {
                         var part = pagesNodes.Skip(i * perBranch).Take(perBranch).ToList();
@@ -827,10 +828,10 @@ namespace UglyToad.PdfPig.Writer
         {
             return new ArrayToken(new[]
             {
-                new NumericToken((decimal)rectangle.BottomLeft.X),
-                new NumericToken((decimal)rectangle.BottomLeft.Y),
-                new NumericToken((decimal)rectangle.TopRight.X),
-                new NumericToken((decimal)rectangle.TopRight.Y)
+                new NumericToken(rectangle.BottomLeft.X),
+                new NumericToken(rectangle.BottomLeft.Y),
+                new NumericToken(rectangle.TopRight.X),
+                new NumericToken(rectangle.TopRight.Y)
             });
         }
 

--- a/src/UglyToad.PdfPig/Writer/PdfPageBuilder.cs
+++ b/src/UglyToad.PdfPig/Writer/PdfPageBuilder.cs
@@ -193,15 +193,15 @@
         /// <param name="from">The first point on the line.</param>
         /// <param name="to">The last point on the line.</param>
         /// <param name="lineWidth">The width of the line in user space units.</param>
-        public PdfPageBuilder DrawLine(PdfPoint from, PdfPoint to, decimal lineWidth = 1)
+        public PdfPageBuilder DrawLine(PdfPoint from, PdfPoint to, double lineWidth = 1)
         {
             if (lineWidth != 1)
             {
                 currentStream.Add(new SetLineWidth(lineWidth));
             }
 
-            currentStream.Add(new BeginNewSubpath((decimal)from.X, (decimal)from.Y));
-            currentStream.Add(new AppendStraightLineSegment((decimal)to.X, (decimal)to.Y));
+            currentStream.Add(new BeginNewSubpath(from.X, from.Y));
+            currentStream.Add(new AppendStraightLineSegment(to.X, to.Y));
             currentStream.Add(StrokePath.Value);
 
             if (lineWidth != 1)
@@ -220,14 +220,14 @@
         /// <param name="height">The height of the rectangle.</param>
         /// <param name="lineWidth">The width of the line border of the rectangle.</param>
         /// <param name="fill">Whether to fill with the color set by <see cref="SetTextAndFillColor"/>.</param>
-        public PdfPageBuilder DrawRectangle(PdfPoint position, decimal width, decimal height, decimal lineWidth = 1, bool fill = false)
+        public PdfPageBuilder DrawRectangle(PdfPoint position, double width, double height, double lineWidth = 1, bool fill = false)
         {
             if (lineWidth != 1)
             {
                 currentStream.Add(new SetLineWidth(lineWidth));
             }
 
-            currentStream.Add(new AppendRectangle((decimal)position.X, (decimal)position.Y, width, height));
+            currentStream.Add(new AppendRectangle(position.X, position.Y, width, height));
 
             if (fill)
             {
@@ -263,17 +263,17 @@
         /// <param name="point3">Position of the third corner of the triangle.</param>
         /// <param name="lineWidth">The width of the line border of the triangle.</param>
         /// <param name="fill">Whether to fill with the color set by <see cref="SetTextAndFillColor"/>.</param>
-        public PdfPageBuilder DrawTriangle(PdfPoint point1, PdfPoint point2, PdfPoint point3, decimal lineWidth = 1, bool fill = false)
+        public PdfPageBuilder DrawTriangle(PdfPoint point1, PdfPoint point2, PdfPoint point3, double lineWidth = 1, bool fill = false)
         {
             if (lineWidth != 1)
             {
                 currentStream.Add(new SetLineWidth(lineWidth));
             }
 
-            currentStream.Add(new BeginNewSubpath((decimal)point1.X, (decimal)point1.Y));
-            currentStream.Add(new AppendStraightLineSegment((decimal)point2.X, (decimal)point2.Y));
-            currentStream.Add(new AppendStraightLineSegment((decimal)point3.X, (decimal)point3.Y));
-            currentStream.Add(new AppendStraightLineSegment((decimal)point1.X, (decimal)point1.Y));
+            currentStream.Add(new BeginNewSubpath(point1.X, point1.Y));
+            currentStream.Add(new AppendStraightLineSegment(point2.X, point2.Y));
+            currentStream.Add(new AppendStraightLineSegment(point3.X, point3.Y));
+            currentStream.Add(new AppendStraightLineSegment(point1.X, point1.Y));
 
             if (fill)
             {
@@ -299,7 +299,7 @@
         /// <param name="diameter">The diameter of the circle.</param>
         /// <param name="lineWidth">The width of the line border of the circle.</param>
         /// <param name="fill">Whether to fill with the color set by <see cref="SetTextAndFillColor"/>.</param>
-        public PdfPageBuilder DrawCircle(PdfPoint center, decimal diameter, decimal lineWidth = 1, bool fill = false)
+        public PdfPageBuilder DrawCircle(PdfPoint center, double diameter, double lineWidth = 1, bool fill = false)
         {
             DrawEllipsis(center, diameter, diameter, lineWidth, fill);
 
@@ -314,39 +314,39 @@
         /// <param name="height">The height of the ellipsis.</param>
         /// <param name="lineWidth">The width of the line border of the ellipsis.</param>
         /// <param name="fill">Whether to fill with the color set by <see cref="SetTextAndFillColor"/>.</param>
-        public PdfPageBuilder DrawEllipsis(PdfPoint center, decimal width, decimal height, decimal lineWidth = 1, bool fill = false)
+        public PdfPageBuilder DrawEllipsis(PdfPoint center, double width, double height, double lineWidth = 1, bool fill = false)
         {
             width /= 2;
             height /= 2;
 
             // See here: https://spencermortensen.com/articles/bezier-circle/
-            decimal cc = 0.55228474983079m;
+            const double cc = 0.55228474983079;
 
             if (lineWidth != 1)
             {
                 currentStream.Add(new SetLineWidth(lineWidth));
             }
 
-            currentStream.Add(new BeginNewSubpath((decimal)center.X - width, (decimal)center.Y));
+            currentStream.Add(new BeginNewSubpath(center.X - width, center.Y));
             currentStream.Add(new AppendDualControlPointBezierCurve(
-                (decimal)center.X - width, (decimal)center.Y + height * cc,
-                (decimal)center.X - width * cc, (decimal)center.Y + height,
-                (decimal)center.X, (decimal)center.Y + height
+                center.X - width, center.Y + height * cc,
+                center.X - width * cc, center.Y + height,
+                center.X, center.Y + height
             ));
             currentStream.Add(new AppendDualControlPointBezierCurve(
-                (decimal)center.X + width * cc, (decimal)center.Y + height,
-                (decimal)center.X + width, (decimal)center.Y + height * cc,
-                (decimal)center.X + width, (decimal)center.Y
+                center.X + width * cc, center.Y + height,
+                center.X + width, center.Y + height * cc,
+                center.X + width, center.Y
             ));
             currentStream.Add(new AppendDualControlPointBezierCurve(
-                (decimal)center.X + width, (decimal)center.Y - height * cc,
-                (decimal)center.X + width * cc, (decimal)center.Y - height,
-                (decimal)center.X, (decimal)center.Y - height
+                center.X + width, center.Y - height * cc,
+                center.X + width * cc, center.Y - height,
+                center.X, center.Y - height
             ));
             currentStream.Add(new AppendDualControlPointBezierCurve(
-                (decimal)center.X - width * cc, (decimal)center.Y - height,
-                (decimal)center.X - width, (decimal)center.Y - height * cc,
-                (decimal)center.X - width, (decimal)center.Y
+                center.X - width * cc, center.Y - height,
+                center.X - width, center.Y - height * cc,
+                center.X - width, center.Y
             ));
 
             if (fill)
@@ -381,12 +381,12 @@
         }
 
         /// <summary>
-        /// Sets the stroke color with the exact decimal value between 0 and 1 for any following operations to the RGB value. Use <see cref="ResetColor"/> to reset.
+        /// Sets the stroke color with the exact double value between 0 and 1 for any following operations to the RGB value. Use <see cref="ResetColor"/> to reset.
         /// </summary>
         /// <param name="r">Red - 0 to 1</param>
         /// <param name="g">Green - 0 to 1</param>
         /// <param name="b">Blue - 0 to 1</param>
-        internal PdfPageBuilder SetStrokeColorExact(decimal r, decimal g, decimal b)
+        internal PdfPageBuilder SetStrokeColorExact(double r, double g, double b)
         {
             currentStream.Add(Push.Value);
             currentStream.Add(new SetStrokeColorDeviceRgb(CheckRgbDecimal(r, nameof(r)),
@@ -430,7 +430,7 @@
         /// or <see cref="PdfDocumentBuilder.AddStandard14Font"/> methods.
         /// </param> 
         /// <returns>The letters from the input text with their corresponding size and position.</returns>
-        public IReadOnlyList<Letter> MeasureText(string text, decimal fontSize, PdfPoint position, PdfDocumentBuilder.AddedFont font)
+        public IReadOnlyList<Letter> MeasureText(string text, double fontSize, PdfPoint position, PdfDocumentBuilder.AddedFont font)
         {
             if (font == null)
             {
@@ -475,7 +475,7 @@
         /// or <see cref="PdfDocumentBuilder.AddStandard14Font"/> methods.
         /// </param> 
         /// <returns>The letters from the input text with their corresponding size and position.</returns>
-        public IReadOnlyList<Letter> AddText(string text, decimal fontSize, PdfPoint position, PdfDocumentBuilder.AddedFont font)
+        public IReadOnlyList<Letter> AddText(string text, double fontSize, PdfPoint position, PdfDocumentBuilder.AddedFont font)
         {
             if (font == null)
             {
@@ -510,7 +510,7 @@
 
             currentStream.Add(BeginText.Value);
             currentStream.Add(new SetFontAndSize(fontName, fontSize));
-            currentStream.Add(new MoveToNextLineWithOffset((decimal)position.X, (decimal)position.Y));
+            currentStream.Add(new MoveToNextLineWithOffset(position.X, position.Y));
             var bytesPerShow = new List<byte>();
             foreach (var letter in text)
             {
@@ -620,9 +620,9 @@
             // This needs to be the placement rectangle.
             currentStream.Add(new ModifyCurrentTransformationMatrix(new []
             {
-                (decimal)placementRectangle.Width, 0,
-                0, (decimal)placementRectangle.Height,
-                (decimal)placementRectangle.BottomLeft.X, (decimal)placementRectangle.BottomLeft.Y
+                placementRectangle.Width, 0,
+                0, placementRectangle.Height,
+                placementRectangle.BottomLeft.X, placementRectangle.BottomLeft.Y
             }));
             currentStream.Add(new InvokeNamedXObject(key));
             currentStream.Add(Pop.Value);
@@ -654,9 +654,9 @@
             // This needs to be the placement rectangle.
             currentStream.Add(new ModifyCurrentTransformationMatrix(new[]
             {
-                (decimal)placementRectangle.Width, 0,
-                0, (decimal)placementRectangle.Height,
-                (decimal)placementRectangle.BottomLeft.X, (decimal)placementRectangle.BottomLeft.Y
+                placementRectangle.Width, 0,
+                0, placementRectangle.Height,
+                placementRectangle.BottomLeft.X, placementRectangle.BottomLeft.Y
             }));
             currentStream.Add(new InvokeNamedXObject(key));
             currentStream.Add(Pop.Value);
@@ -774,9 +774,9 @@
             // This needs to be the placement rectangle.
             currentStream.Add(new ModifyCurrentTransformationMatrix(new[]
             {
-                (decimal)placementRectangle.Width, 0,
-                0, (decimal)placementRectangle.Height,
-                (decimal)placementRectangle.BottomLeft.X, (decimal)placementRectangle.BottomLeft.Y
+                placementRectangle.Width, 0,
+                0, placementRectangle.Height,
+                placementRectangle.BottomLeft.X, placementRectangle.BottomLeft.Y
             }));
             currentStream.Add(new InvokeNamedXObject(key));
             currentStream.Add(Pop.Value);
@@ -973,14 +973,14 @@
             return this;
         }
 
-        private List<Letter> DrawLetters(NameToken name, string text, IWritingFont font, TransformationMatrix fontMatrix, decimal fontSize, TransformationMatrix textMatrix)
+        private List<Letter> DrawLetters(NameToken name, string text, IWritingFont font, TransformationMatrix fontMatrix, double fontSize, TransformationMatrix textMatrix)
         {
             var horizontalScaling = 1;
             var rise = 0;
             var letters = new List<Letter>();
 
             var renderingMatrix =
-                TransformationMatrix.FromValues((double)fontSize * horizontalScaling, 0, 0, (double)fontSize, 0, rise);
+                TransformationMatrix.FromValues(fontSize * horizontalScaling, 0, 0, fontSize, 0, rise);
 
             var width = 0.0;
 
@@ -1006,17 +1006,17 @@
                 var documentSpace = textMatrix.Transform(renderingMatrix.Transform(fontMatrix.Transform(rect)));
 
                 var letter = new Letter(
-                    c.ToString(), 
-                    documentSpace, 
-                    advanceRect.BottomLeft, 
-                    advanceRect.BottomRight, 
-                    width, 
-                    (double)fontSize, 
+                    c.ToString(),
+                    documentSpace,
+                    advanceRect.BottomLeft,
+                    advanceRect.BottomRight,
+                    width,
+                    fontSize,
                     FontDetails.GetDefault(name),
                     TextRenderingMode.Fill,
                     GrayColor.Black,
                     GrayColor.Black,
-                    (double)fontSize,
+                    fontSize,
                     textSequence);
 
                 letters.Add(letter);
@@ -1034,24 +1034,24 @@
             return letters;
         }
 
-        private static decimal RgbToDecimal(byte value)
+        private static double RgbToDecimal(byte value)
         {
-            var res = Math.Max(0, value / (decimal)byte.MaxValue);
+            var res = Math.Max(0, value / (double)byte.MaxValue);
             res = Math.Round(Math.Min(1, res), 4);
 
             return res;
         }
 
-        private static decimal CheckRgbDecimal(decimal value, string argument)
+        private static double CheckRgbDecimal(double value, string argument)
         {
             if (value < 0)
             {
-                throw new ArgumentOutOfRangeException(argument, $"Provided decimal for RGB color was less than zero: {value}.");
+                throw new ArgumentOutOfRangeException(argument, $"Provided double for RGB color was less than zero: {value}.");
             }
 
             if (value > 1)
             {
-                throw new ArgumentOutOfRangeException(argument, $"Provided decimal for RGB color was greater than one: {value}.");
+                throw new ArgumentOutOfRangeException(argument, $"Provided double for RGB color was greater than one: {value}.");
             }
 
             return value;

--- a/src/UglyToad.PdfPig/Writer/PdfStreamWriter.cs
+++ b/src/UglyToad.PdfPig/Writer/PdfStreamWriter.cs
@@ -13,7 +13,7 @@
     /// </summary>
     internal class PdfStreamWriter : IPdfStreamWriter
     {
-        protected const decimal DefaultVersion = 1.2m;
+        protected const double DefaultVersion = 1.2;
         protected Dictionary<IndirectReference, long> offsets = new Dictionary<IndirectReference, long>();
         protected bool DisposeStream { get; set; }
         protected bool Initialized { get; set; }
@@ -66,7 +66,7 @@
             return new IndirectReferenceToken(new IndirectReference(CurrentNumber++, 0));
         }
 
-        public void InitializePdf(decimal version)
+        public void InitializePdf(double version)
         {
             WriteString($"%PDF-{version.ToString("0.0", CultureInfo.InvariantCulture)}", Stream);
 

--- a/src/UglyToad.PdfPig/Writer/Xmp/XmpWriter.cs
+++ b/src/UglyToad.PdfPig/Writer/Xmp/XmpWriter.cs
@@ -15,7 +15,6 @@ namespace UglyToad.PdfPig.Writer.Xmp
         private const string XmpMetaPrefix = "x";
         private const string XmpMetaNamespace = "adobe:ns:meta/";
 
-
         private const string DublinCorePrefix = "dc";
         private const string DublinCoreNamespace = "http://purl.org/dc/elements/1.1/";
 
@@ -36,7 +35,7 @@ namespace UglyToad.PdfPig.Writer.Xmp
         private const string PdfAIdentificationExtensionPrefix = "pdfaid";
         private const string PdfAIdentificationExtensionNamespace = "http://www.aiim.org/pdfa/ns/id/";
         
-        public static StreamToken GenerateXmpStream(PdfDocumentBuilder.DocumentInformationBuilder builder, decimal version,
+        public static StreamToken GenerateXmpStream(PdfDocumentBuilder.DocumentInformationBuilder builder, double version,
             PdfAStandard standard)
         {
             XNamespace xmpMeta = XmpMetaNamespace;

--- a/src/UglyToad.PdfPig/XObjects/XObjectFactory.cs
+++ b/src/UglyToad.PdfPig/XObjects/XObjectFactory.cs
@@ -110,7 +110,7 @@
             var decodedBytes = supportsFilters ? new Lazy<IReadOnlyList<byte>>(() => streamToken.Decode(filterProvider, pdfScanner))
                 : null;
 
-            var decode = EmptyArray<decimal>.Instance;
+            var decode = EmptyArray<double>.Instance;
 
             if (dictionary.TryGet(NameToken.Decode, pdfScanner, out ArrayToken decodeArrayToken))
             {

--- a/src/UglyToad.PdfPig/XObjects/XObjectImage.cs
+++ b/src/UglyToad.PdfPig/XObjects/XObjectImage.cs
@@ -45,7 +45,7 @@
         public bool IsImageMask { get; }
 
         /// <inheritdoc />
-        public IReadOnlyList<decimal> Decode { get; }
+        public IReadOnlyList<double> Decode { get; }
 
         /// <inheritdoc />
         public bool Interpolate { get; }
@@ -74,7 +74,7 @@
             bool isImageMask,
             RenderingIntent renderingIntent,
             bool interpolate,
-            IReadOnlyList<decimal> decode,
+            IReadOnlyList<double> decode,
             DictionaryToken imageDictionary,
             IReadOnlyList<byte> rawBytes,
             Lazy<IReadOnlyList<byte>> bytes,


### PR DESCRIPTION
Replacing `decimal` with `double` accross the code base as I don't think we really need to use `decimal` for what we do. I also tried to remove useless casting.

Really not an important PR, but makes the code more efficient. Given the big number of files to reviews versus the actual little improvement, feel free to not merge it @EliotJones 