### PR TITLE
Prevent PDF corruption when removing text (#538)

### DIFF
--- a/src/UglyToad.PdfPig.Tests/Writer/PdfDocumentBuilderTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Writer/PdfDocumentBuilderTests.cs
@@ -1279,6 +1279,7 @@
         public int Tokens { get; private set; }
         public int Objects { get; private set; }
         public bool WroteCrossReferenceTable { get; private set; }
+        public bool WritingPageContents { get; set; }
 
         public void WriteToken(IToken token, Stream outputStream)
         {

--- a/src/UglyToad.PdfPig/Writer/IPdfStreamWriter.cs
+++ b/src/UglyToad.PdfPig/Writer/IPdfStreamWriter.cs
@@ -1,9 +1,7 @@
 ﻿namespace UglyToad.PdfPig.Writer
 {
     using System;
-    using System.Collections.Generic;
     using System.IO;
-    using System.Text;
     using Tokens;
 
     internal interface IPdfStreamWriter : IDisposable
@@ -19,6 +17,11 @@
         /// The underlying stream used by the writer.
         /// </summary>
         Stream Stream { get; }
+
+        /// <summary>
+        /// Hints that the stream writer is used for writing page contents.
+        /// </summary>
+        bool WritingPageContents { get; set; }
 
         /// <summary>
         /// Writes a single token to the stream.

--- a/src/UglyToad.PdfPig/Writer/ITokenWriter.cs
+++ b/src/UglyToad.PdfPig/Writer/ITokenWriter.cs
@@ -37,5 +37,10 @@
             IReadOnlyDictionary<IndirectReference, long> objectOffsets,
             IndirectReference catalogToken, Stream outputStream,
             IndirectReference? documentInformationReference);
+
+        /// <summary>
+        /// Hints to the token writer that we are currently writing page contents.
+        /// </summary>
+        bool WritingPageContents { get; set; }
     }
 }

--- a/src/UglyToad.PdfPig/Writer/PdfDocumentBuilder.cs
+++ b/src/UglyToad.PdfPig/Writer/PdfDocumentBuilder.cs
@@ -360,6 +360,7 @@ namespace UglyToad.PdfPig.Writer
                 // dedup if on to avoid issues
                 var prev = context.AttemptDeduplication;
                 context.AttemptDeduplication = false;
+                context.WritingPageContents = true;
                 if (contentsToken is ArrayToken array)
                 {
                     foreach (var item in array.Data)
@@ -378,6 +379,7 @@ namespace UglyToad.PdfPig.Writer
                         WriterUtil.CopyToken(context, ir, document.Structure.TokenScanner, refs) as IndirectReferenceToken));
                 }
                 context.AttemptDeduplication = prev;
+                context.WritingPageContents = false;
             }
 
             // manually copy page dict / resources as we need to modify some
@@ -405,7 +407,6 @@ namespace UglyToad.PdfPig.Writer
                     copiedPageDict[NameToken.Rotate] = WriterUtil.CopyToken(context, rt, document.Structure.TokenScanner, refs);
                 }
             }
-
 
             foreach (var kvp in pageInfo.Page.Data)
             {

--- a/src/UglyToad.PdfPig/Writer/PdfStreamWriter.cs
+++ b/src/UglyToad.PdfPig/Writer/PdfStreamWriter.cs
@@ -25,6 +25,12 @@
 
         public bool AttemptDeduplication { get; set; } = true;
 
+        public bool WritingPageContents
+        {
+            get => TokenWriter.WritingPageContents;
+            set => TokenWriter.WritingPageContents = value;
+        }
+
         internal PdfStreamWriter(
             Stream baseStream,
             bool disposeStream = true,

--- a/src/UglyToad.PdfPig/Writer/PdfTextRemover.cs
+++ b/src/UglyToad.PdfPig/Writer/PdfTextRemover.cs
@@ -83,19 +83,22 @@ namespace UglyToad.PdfPig.Writer
         /// </summary>
         public static void RemoveText(PdfDocument file, Stream output, IReadOnlyList<int> pagesBundle = null)
         {
-            using (var document = new PdfDocumentBuilder(output, false, PdfWriterType.Default, file.Version, tokenWriter: new NoTextTokenWriter()))
+            var tokenWriter = new NoTextTokenWriter();
+            using (var document = new PdfDocumentBuilder(output, false, PdfWriterType.Default, file.Version, tokenWriter: tokenWriter))
             {
                 if (pagesBundle == null)
                 {
                     for (var i = 1; i <= file.NumberOfPages; i++)
                     {
+                        tokenWriter.Page = i;
                         document.AddPage(file, i);
                     }
-                } 
+                }
                 else
                 {
                     foreach (var i in pagesBundle)
                     {
+                        tokenWriter.Page = i;
                         document.AddPage(file, i);
                     }
                 }

--- a/src/UglyToad.PdfPig/Writer/TokenWriter.cs
+++ b/src/UglyToad.PdfPig/Writer/TokenWriter.cs
@@ -276,6 +276,12 @@
             outputStream.Write(Eof, 0, Eof.Length);
         }
 
+        /// <summary>
+        /// Indicates that we are writing page contents.
+        /// Can be used by a derived class.
+        /// </summary>
+        public bool WritingPageContents { get; set; }
+
         /// <inheritdoc cref="ITokenWriter.WriteObject" />
         public void WriteObject(long objectNumber, int generation, byte[] data, Stream outputStream)
         {


### PR DESCRIPTION
Prevents PDF corruption when removing text (PdfTextRemover) by skipping streams that are not (page) content streams or form streams. Also duplicate the original stream's data dictionary, to prevent disappearing elements (due to missing SubType / BBox e.g.)

Added skipping operation MoveToNextLineShowText as well (as suggested by @fnatzke).

This does not solve the array-of-streams / Beads issues mentioned by @fnatzke in issue 538.