### PR TITLE
Fix exception messages

### DIFF
--- a/src/UglyToad.PdfPig.Fonts/CompactFontFormat/Dictionaries/CompactFontFormatTopLevelDictionaryReader.cs
+++ b/src/UglyToad.PdfPig.Fonts/CompactFontFormat/Dictionaries/CompactFontFormatTopLevelDictionaryReader.cs
@@ -81,7 +81,7 @@
                                     }
                                     else
                                     {
-                                        throw new InvalidOperationException($"Expected four values for the font matrix, instead got: {array}.");
+                                        throw new InvalidOperationException($"Expected four values for the font matrix, instead got: {array.Length}.");
                                     }
                                 }
                                 break;

--- a/src/UglyToad.PdfPig/AcroForms/AcroFormFactory.cs
+++ b/src/UglyToad.PdfPig/AcroForms/AcroFormFactory.cs
@@ -403,7 +403,7 @@
                     {
                         if (optionArrayToken.Length != 2)
                         {
-                            throw new PdfDocumentFormatException($"An option array containing array elements should contain 2 strings, instead got: {optionArrayToken}.");
+                            throw new PdfDocumentFormatException($"An option array containing array elements should contain 2 strings, instead got: {optionArrayToken.Length}.");
                         }
 
                         string exportValue;

--- a/src/UglyToad.PdfPig/Graphics/Operations/SpecialGraphicsState/ModifyCurrentTransformationMatrix.cs
+++ b/src/UglyToad.PdfPig/Graphics/Operations/SpecialGraphicsState/ModifyCurrentTransformationMatrix.cs
@@ -36,7 +36,7 @@
 
             if (value.Length != 6)
             {
-                throw new ArgumentException("The cm operator must pass 6 numbers. Instead got: " + value);
+                throw new ArgumentException("The cm operator must pass 6 numbers. Instead got: " + value.Length);
             }
             Value = value;
         }

--- a/src/UglyToad.PdfPig/Graphics/Operations/TextPositioning/SetTextMatrix.cs
+++ b/src/UglyToad.PdfPig/Graphics/Operations/TextPositioning/SetTextMatrix.cs
@@ -31,7 +31,7 @@
         {
             if (value.Length != 6)
             {
-                throw new ArgumentException("Text matrix must provide 6 values. Instead got: " + value);
+                throw new ArgumentException("Text matrix must provide 6 values. Instead got: " + value.Length);
             }
 
             Value = value;

--- a/src/UglyToad.PdfPig/Util/DictionaryTokenExtensions.cs
+++ b/src/UglyToad.PdfPig/Util/DictionaryTokenExtensions.cs
@@ -169,7 +169,7 @@
 
             if (array.Data.Count != 4)
             {
-                throw new PdfDocumentFormatException($"Cannot convert array to rectangle, expected 4 values instead got: {array}.");
+                throw new PdfDocumentFormatException($"Cannot convert array to rectangle, expected 4 values instead got: {array.Data.Count}.");
             }
 
             return new PdfRectangle(DirectObjectFinder.Get<NumericToken>(array[0], tokenScanner).Double,
@@ -187,7 +187,7 @@
 
             if (array.Data.Count != 4)
             {
-                throw new PdfDocumentFormatException($"Cannot convert array to rectangle, expected 4 values instead got: {array}.");
+                throw new PdfDocumentFormatException($"Cannot convert array to rectangle, expected 4 values instead got: {array.Data.Count}.");
             }
 
             return new PdfRectangle(DirectObjectFinder.Get<NumericToken>(array[0], tokenScanner).Int,


### PR DESCRIPTION
Fix exception messages: these showed e.g.
"The cm operator must pass 6 numbers. Instead got: Decimal[]" 
instead of
"The cm operator must pass 6 numbers. Instead got: 4"