### PR TITLE
Fix writing explicit XYZ coordinates

### DIFF
--- a/src/UglyToad.PdfPig/Writer/PdfDocumentBuilder.cs
+++ b/src/UglyToad.PdfPig/Writer/PdfDocumentBuilder.cs
@@ -921,7 +921,8 @@ namespace UglyToad.PdfPig.Writer
                         page,
                         NameToken.XYZ,
                         new NumericToken(destination.Coordinates.Left ?? 0),
-                        new NumericToken(destination.Coordinates.Top ?? 0)
+                        new NumericToken(destination.Coordinates.Top ?? 0),
+                        new NumericToken(0)
                     });
 
                 case ExplicitDestinationType.FitPage:


### PR DESCRIPTION
The `/XYZ` destination needs a zoom value for PDF readers to parse correctly. This PR fixes destination linking problem by adding a NULL zoom value.

Per PDF spec:
> [page /XYZ left top zoom] Display the page designated by page, with the coordinates (left, top) positioned at the top-left corner of the window and the contents of the page magnified by the factor zoom. A null value for any of the parameters left, top, or
zoom specifies that the current value of that parameter is to be retained unchanged. A zoom value of 0 has the same meaning as a null value. 

[#9352](https://github.com/dotnet/docfx/pull/9352)