### PR TITLE
Fix typo in SystemFontFinder and fix #728

### DIFF
--- a/src/UglyToad.PdfPig.Fonts/SystemFonts/SystemFontFinder.cs
+++ b/src/UglyToad.PdfPig.Fonts/SystemFonts/SystemFontFinder.cs
@@ -13,7 +13,7 @@ namespace UglyToad.PdfPig.Fonts.SystemFonts
     using TrueType.Parser;
 
     /// <inheritdoc />
-    public class SystemFontFinder : ISystemFontFinder
+    public sealed class SystemFontFinder : ISystemFontFinder
     {
         private static readonly IReadOnlyDictionary<string, string[]> NameSubstitutes;
         private static readonly Lazy<IReadOnlyList<SystemFontRecord>> AvailableFonts;
@@ -41,7 +41,7 @@ namespace UglyToad.PdfPig.Fonts.SystemFonts
                 {"Times-Roman", new[] {"TimesNewRomanPSMT", "TimesNewRoman", "TimesNewRomanPS", "LiberationSerif", "NimbusRomNo9L-Regu"}},
                 {"Times-Bold", new[] {"TimesNewRomanPS-BoldMT", "TimesNewRomanPS-Bold", "TimesNewRoman-Bold", "LiberationSerif-Bold", "NimbusRomNo9L-Medi"}},
                 {"Times-Italic", new[] {"TimesNewRomanPS-ItalicMT", "TimesNewRomanPS-Italic", "TimesNewRoman-Italic", "LiberationSerif-Italic", "NimbusRomNo9L-ReguItal"}},
-                {"TimesNewRomanPS-BoldItalicMT", new[] {"TimesNewRomanPS-BoldItalic", "TimesNewRoman-BoldItalic", "LiberationSerif-BoldItalic", "NimbusRomNo9L-MediItal"}},
+                {"Times-BoldItalic", new[] {"TimesNewRomanPS-BoldItalicMT", "TimesNewRomanPS-BoldItalic", "TimesNewRoman-BoldItalic", "LiberationSerif-BoldItalic", "NimbusRomNo9L-MediItal"}},
                 {"Symbol", new[] {"SymbolMT", "StandardSymL"}},
                 {"ZapfDingbats", new[] {"ZapfDingbatsITC", "Dingbats", "MS-Gothic"}}
             };


### PR DESCRIPTION
Fixes a typo in the SystemFontFinder (see #728)

As a side note, the 'SPARC - v9 Architecture Manual' document could be used to add tests as it contains 'Times-BoldItalic'
![image](https://github.com/UglyToad/PdfPig/assets/38405645/22d57d4a-47b0-480d-9e93-6aaec127d035)
