### PR TITLE
Fix Type 0 font to use CID font's correct matrix and Charset when Encoding is null

### DIFF
--- a/src/UglyToad.PdfPig.Fonts/CompactFontFormat/CompactFontFormatFontCollection.cs
+++ b/src/UglyToad.PdfPig.Fonts/CompactFontFormat/CompactFontFormatFontCollection.cs
@@ -69,12 +69,9 @@
         {
             var font = FirstFont;
 
-            if (font.Encoding != null)
-            {
-                return font.Encoding.GetName(characterCode);
-            }
+            var name = font.GetCharacterName(characterCode);
 
-            return ".notdef";
+            return name ?? ".notdef";
         }
     }
 }

--- a/src/UglyToad.PdfPig/PdfFonts/CidFonts/ICidFont.cs
+++ b/src/UglyToad.PdfPig/PdfFonts/CidFonts/ICidFont.cs
@@ -54,6 +54,8 @@
 
         PdfVector GetDisplacementVector(int characterIdentifier);
 
+        TransformationMatrix GetFontMatrix(int characterIdentifier);
+
         /// <summary>
         /// Returns the glyph path for the given character code.
         /// </summary>

--- a/src/UglyToad.PdfPig/PdfFonts/CidFonts/ICidFontProgram.cs
+++ b/src/UglyToad.PdfPig/PdfFonts/CidFonts/ICidFontProgram.cs
@@ -19,9 +19,14 @@
 
         bool TryGetBoundingAdvancedWidth(int characterIdentifier, out double width);
 
-        bool TryGetPath(int characterName, out IReadOnlyList<PdfSubpath> path);
+        bool TryGetPath(int characterCode, out IReadOnlyList<PdfSubpath> path);
 
         bool TryGetPath(int characterCode, Func<int, int?> characterCodeToGlyphId, out IReadOnlyList<PdfSubpath> path);
+
+        /// <summary>
+        /// Try to get the font matrix if available.
+        /// </summary>
+        bool TryGetFontMatrix(int characterCode, out TransformationMatrix? matrix);
 
         int GetFontMatrixMultiplier();
     }

--- a/src/UglyToad.PdfPig/PdfFonts/CidFonts/PdfCidCompactFontFormatFont.cs
+++ b/src/UglyToad.PdfPig/PdfFonts/CidFonts/PdfCidCompactFontFormatFont.cs
@@ -7,6 +7,8 @@
 
     internal class PdfCidCompactFontFormatFont : ICidFontProgram
     {
+        private const string NotDefined = ".notdef";
+
         private readonly CompactFontFormatFontCollection fontCollection;
 
         public FontDetails Details { get; }
@@ -51,12 +53,12 @@
 
             var font = GetFont();
 
-            if (font.Encoding == null)
+            var characterName = GetCharacterName(characterIdentifier);
+
+            if (string.Equals(characterName, NotDefined, StringComparison.OrdinalIgnoreCase))
             {
                 return false;
             }
-
-            var characterName = GetCharacterName(characterIdentifier);
 
             boundingBox = font.GetCharacterBoundingBox(characterName) ?? new PdfRectangle(0, 0, 500, 0);
 
@@ -78,6 +80,19 @@
             throw new NotImplementedException();
         }
 
+        public bool TryGetFontMatrix(int characterCode, out TransformationMatrix? matrix)
+        {
+            var font = GetFont();
+            var name = font.GetCharacterName(characterCode);
+            if (name == null)
+            {
+                matrix = null;
+                return false;
+            }
+            matrix = font.GetFontMatrix(name);
+            return matrix.HasValue;
+        }
+
         public int GetFontMatrixMultiplier()
         {
             return 1000;
@@ -87,12 +102,9 @@
         {
             var font = GetFont();
 
-            if (font.Encoding != null)
-            {
-                return font.Encoding.GetName(characterCode);
-            }
+            var name = font.GetCharacterName(characterCode);
 
-            return ".notdef";
+            return name ?? NotDefined;
         }
 
         private CompactFontFormatFont GetFont()
@@ -113,12 +125,12 @@
 
             var font = GetFont();
 
-            if (font.Encoding == null)
+            var characterName = GetCharacterName(characterCode);
+
+            if (string.Equals(characterName, NotDefined, StringComparison.OrdinalIgnoreCase))
             {
                 return false;
             }
-
-            var characterName = GetCharacterName(characterCode);
 
             if (font.TryGetPath(characterName, out path))
             {

--- a/src/UglyToad.PdfPig/PdfFonts/CidFonts/PdfCidTrueTypeFont.cs
+++ b/src/UglyToad.PdfPig/PdfFonts/CidFonts/PdfCidTrueTypeFont.cs
@@ -33,6 +33,13 @@
         public bool TryGetBoundingAdvancedWidth(int characterIdentifier, Func<int, int?> characterCodeToGlyphId, out double width)
             => font.TryGetAdvanceWidth(characterIdentifier, characterCodeToGlyphId, out width);
 
+        public bool TryGetFontMatrix(int characterCode, out TransformationMatrix? matrix)
+        {
+            // We don't have a matrix here
+            matrix = null;
+            return false;
+        }
+
         public int GetFontMatrixMultiplier() => font.GetUnitsPerEm();
 
         public bool TryGetPath(int characterCode, out IReadOnlyList<PdfSubpath> path) => font.TryGetPath(characterCode, out path);

--- a/src/UglyToad.PdfPig/PdfFonts/Composite/Type0Font.cs
+++ b/src/UglyToad.PdfPig/PdfFonts/Composite/Type0Font.cs
@@ -117,30 +117,22 @@
                 return cached;
             }
 
-            var matrix = GetFontMatrix();
-
-            var boundingBox = GetBoundingBoxInGlyphSpace(characterCode);
-
-            boundingBox = matrix.Transform(boundingBox);
-
             var characterIdentifier = CMap.ConvertToCid(characterCode);
+
+            // Get the bounding box in glyph space
+            var boundingBox = CidFont.GetBoundingBox(characterIdentifier);
+
+            boundingBox = CidFont.GetFontMatrix(characterIdentifier).Transform(boundingBox);
 
             var width = CidFont.GetWidthFromFont(characterIdentifier);
 
-            var advanceWidth = matrix.TransformX(width);
+            var advanceWidth = GetFontMatrix().TransformX(width); // Not sure why we don't need CidFont.GetFontMatrix(characterCode)
 
             var result = new CharacterBoundingBox(boundingBox, advanceWidth);
 
             boundingBoxCache[characterCode] = result;
 
             return result;
-        }
-
-        public PdfRectangle GetBoundingBoxInGlyphSpace(int characterCode)
-        {
-            var characterIdentifier = CMap.ConvertToCid(characterCode);
-
-            return CidFont.GetBoundingBox(characterIdentifier);
         }
 
         public TransformationMatrix GetFontMatrix()
@@ -165,13 +157,17 @@
         /// <inheritdoc/>
         public bool TryGetPath(int characterCode, out IReadOnlyList<PdfSubpath> path)
         {
-            return CidFont.TryGetPath(characterCode, out path);
+            var characterIdentifier = CMap.ConvertToCid(characterCode);
+
+            return CidFont.TryGetPath(characterIdentifier, out path);
         }
 
         /// <inheritdoc/>
         public bool TryGetNormalisedPath(int characterCode, out IReadOnlyList<PdfSubpath> path)
         {
-            return CidFont.TryGetNormalisedPath(characterCode, out path);
+            var characterIdentifier = CMap.ConvertToCid(characterCode);
+
+            return CidFont.TryGetNormalisedPath(characterIdentifier, out path);
         }
     }
 }

--- a/src/UglyToad.PdfPig/PdfFonts/Simple/TrueTypeSimpleFont.cs
+++ b/src/UglyToad.PdfPig/PdfFonts/Simple/TrueTypeSimpleFont.cs
@@ -343,7 +343,7 @@
                 return false;
             }
 
-            path = GetFontMatrix().Transform(path).ToList();
+            path = GetFontMatrix().Transform(path).ToArray();
             return true;
         }
     }

--- a/src/UglyToad.PdfPig/PdfFonts/Simple/TrueTypeStandard14FallbackSimpleFont.cs
+++ b/src/UglyToad.PdfPig/PdfFonts/Simple/TrueTypeStandard14FallbackSimpleFont.cs
@@ -152,7 +152,7 @@
                 return false;
             }
 
-            path = GetFontMatrix().Transform(path).ToList();
+            path = GetFontMatrix().Transform(path).ToArray();
             return true;
         }
 

--- a/src/UglyToad.PdfPig/PdfFonts/Simple/Type1FontSimple.cs
+++ b/src/UglyToad.PdfPig/PdfFonts/Simple/Type1FontSimple.cs
@@ -267,7 +267,7 @@
         {
             if (TryGetPath(characterCode, out path))
             {
-                path = fontMatrix.Transform(path).ToList();
+                path = fontMatrix.Transform(path).ToArray();
                 return true;
             }
             return false;

--- a/src/UglyToad.PdfPig/PdfFonts/Simple/Type1Standard14Font.cs
+++ b/src/UglyToad.PdfPig/PdfFonts/Simple/Type1Standard14Font.cs
@@ -124,7 +124,7 @@ namespace UglyToad.PdfPig.PdfFonts.Simple
 
         /// <summary>
         /// <inheritdoc/>
-        /// <para>Not implemeted.</para>
+        /// <para>Not implemented.</para>
         /// </summary>
         public bool TryGetPath(int characterCode, out IReadOnlyList<PdfSubpath> path)
         {
@@ -135,7 +135,7 @@ namespace UglyToad.PdfPig.PdfFonts.Simple
 
         /// <summary>
         /// <inheritdoc/>
-        /// <para>Not implemeted.</para>
+        /// <para>Not implemented.</para>
         /// </summary>
         public bool TryGetNormalisedPath(int characterCode, out IReadOnlyList<PdfSubpath> path)
         {


### PR DESCRIPTION
- Fix Type 0 font to use CID font's correct matrix and `Charset` when `Encoding` is null
- Minor optimisation in fonts `TryGetNormalisedPath()`
