### PR TITLE
Use the plain Aes.Create() instead of  Aes.Create("AesManaged")

### DIFF
--- a/src/UglyToad.PdfPig/Encryption/EncryptionHandler.cs
+++ b/src/UglyToad.PdfPig/Encryption/EncryptionHandler.cs
@@ -688,7 +688,7 @@
 
             var iv = new byte[16];
 
-            using (var aes = Aes.Create("AesManaged")!)
+            using (var aes = Aes.Create())
             {
                 aes.Key = intermediateKey;
                 aes.IV = iv;


### PR DESCRIPTION
refs #746, #664

There is no indication in the code as to why it explicitly requests the managed AES implementation rather than just using the default, and there are other places in the library that just use ```Aes.Create()```, so this is an attempt at changing it to see if all the tests etc still work.

Also refs https://learn.microsoft.com/en-us/dotnet/api/system.security.cryptography.aes.create?view=net-7.0#system-security-cryptography-aes-create(system-string) which says that the version of ```Aes.Create``` that takes a string name has been obsoleted in .NET 7.0