### PR TITLE
Add a DynamicallyAccessedMembers attribute to AddPageFactory<TPage, T…

### DIFF
--- a/src/UglyToad.PdfPig/Content/Pages.cs
+++ b/src/UglyToad.PdfPig/Content/Pages.cs
@@ -117,7 +117,11 @@
             pageFactoryCache.Add(type, pageFactory);
         }
 
+#if NET6_0_OR_GREATER
+        internal void AddPageFactory<TPage, [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors)] TPageFactory>() where TPageFactory : IPageFactory<TPage>
+#else
         internal void AddPageFactory<TPage, TPageFactory>() where TPageFactory : IPageFactory<TPage>
+#endif
         {
             var constructor = typeof(TPageFactory).GetConstructor(new[]
             {

--- a/src/UglyToad.PdfPig/PdfDocument.cs
+++ b/src/UglyToad.PdfPig/PdfDocument.cs
@@ -148,7 +148,11 @@
         /// </summary>
         /// <typeparam name="TPage"></typeparam>
         /// <typeparam name="TPageFactory"></typeparam>
+#if NET6_0_OR_GREATER
+        public void AddPageFactory<TPage, [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors)] TPageFactory>() where TPageFactory : IPageFactory<TPage>
+#else
         public void AddPageFactory<TPage, TPageFactory>() where TPageFactory : IPageFactory<TPage>
+#endif
         {
             pages.AddPageFactory<TPage, TPageFactory>();
         }


### PR DESCRIPTION
…PageFactory>

A bit of a follow up to #664 - 

If I build the core library with the .NET 6.0 trimming analyzer enabled, then I get this warning from the PageFactory code:
```
PdfPig\src\UglyToad.PdfPig\Content\Pages.cs(122,31,129,15): warning IL2090: 'this' argument does not satisfy 'DynamicallyAccessedMemberTypes.PublicConstructors' in call to 'System.Type.GetConstructor(Type[])'. The generic parameter 'TPageFactory' of 'UglyToad.PdfPig.Content.Pages.AddPageFactory<TPage, TPageFactory>()' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.
```
which is warning that dynamic access to the constructors could fail if the constructors have got trimmed out.
This is an attempt to fix that by adding a ```System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers``` attribute to ```TPageFactory```.

Note: I fully qualified the names because when I tried ```using System.Diagnostics.CodeAnalysis``` I got conflicts between the ```NotNull``` attribute in there and the Jetbrains one already in use. (maybe that can be handled in a different way)