### PR TITLE
#710 set colorspace based on jpeg info

### DIFF
--- a/src/UglyToad.PdfPig/Images/JpegHandler.cs
+++ b/src/UglyToad.PdfPig/Images/JpegHandler.cs
@@ -29,7 +29,6 @@
                 switch (marker)
                 {
                     case JpegMarker.StartOfImage:
-                    case JpegMarker.EndOfImage:
                     case JpegMarker.Restart0:
                     case JpegMarker.Restart1:
                     case JpegMarker.Restart2:
@@ -49,8 +48,9 @@
                             var bpp = stream.ReadByte();
                             var height = ReadShort(stream, shortBuffer);
                             var width = ReadShort(stream, shortBuffer);
+                            var numberOfComponents = stream.ReadByte();
 
-                            return new JpegInformation(width, height, bpp);
+                            return new JpegInformation(width, height, bpp, numberOfComponents);
                         }
                     case JpegMarker.ApplicationSpecific0:
                     case JpegMarker.ApplicationSpecific1:

--- a/src/UglyToad.PdfPig/Images/JpegInformation.cs
+++ b/src/UglyToad.PdfPig/Images/JpegInformation.cs
@@ -21,13 +21,19 @@
         public int BitsPerComponent { get; }
 
         /// <summary>
+        /// 1 grayscale, 3 RGB, 4 CMYK.
+        /// </summary>
+        public int NumberOfComponents { get; }
+
+        /// <summary>
         /// Create a new <see cref="JpegInformation"/>.
         /// </summary>
-        public JpegInformation(int width, int height, int bitsPerComponent)
+        public JpegInformation(int width, int height, int bitsPerComponent, int numberOfComponents)
         {
             Width = width;
             Height = height;
             BitsPerComponent = bitsPerComponent;
+            NumberOfComponents = numberOfComponents;
         }
     }
 }


### PR DESCRIPTION
JPEG files may have 1, 3 or 4 components per pixel. in #710 the image was grayscale but written to the PDF as RGB so the display was all kinds of messed up