### PR TITLE
handle escaping in pdf doc encoded strings #730

### DIFF
--- a/src/UglyToad.PdfPig/Writer/TokenWriter.cs
+++ b/src/UglyToad.PdfPig/Writer/TokenWriter.cs
@@ -535,7 +535,7 @@
         {
             outputStream.WriteByte(StringStart);
 
-            if (stringToken.EncodedWith == StringToken.Encoding.Iso88591)
+            if (stringToken.EncodedWith == StringToken.Encoding.Iso88591 || stringToken.EncodedWith == StringToken.Encoding.PdfDocEncoding)
             {
                 // iso 88591 (or really PdfDocEncoding in non-contentstream circumstances shouldn't
                 // have these chars but seems like internally this isn't obeyed (see:


### PR DESCRIPTION
if the string token is in a pdf object then it has pdf doc encoding. in these strings escaping is necessary:

> Within a literal string, the backslash (\) is used as an escape character for various
> purposes, such as to include newline characters, nonprinting ASCII characters,
> unbalanced parentheses, or the backslash character itself in the string. The
> character immediately following the backslash determines its precise
> interpretation (see Table 3.2). If the character following the backslash is not one
> of those shown in the table, the backslash is ignored.

This was the issue in #730. Based on the comments in this code I'm not sure why it was not supported before