### PR TITLE
Use double instead of decimal in IPdfImage's Decode property

### DIFF
--- a/src/UglyToad.PdfPig.Tests/TestPdfImage.cs
+++ b/src/UglyToad.PdfPig.Tests/TestPdfImage.cs
@@ -24,7 +24,7 @@
 
         public bool IsImageMask { get; set; }
 
-        public IReadOnlyList<decimal> Decode { get; set; }
+        public IReadOnlyList<double> Decode { get; set; }
 
         public bool Interpolate { get; set; }
 

--- a/src/UglyToad.PdfPig/Content/IPdfImage.cs
+++ b/src/UglyToad.PdfPig/Content/IPdfImage.cs
@@ -37,7 +37,7 @@
         /// </summary>
         IReadOnlyList<byte> RawBytes { get; }
 
-            /// <summary>
+        /// <summary>
         /// The color rendering intent to be used when rendering the image.
         /// </summary>
         RenderingIntent RenderingIntent { get; }
@@ -60,7 +60,7 @@
         /// The value from the image data is then interpolated into the values relevant to the <see cref="ColorSpace"/>
         /// using the corresponding values of the decode array.
         /// </summary>
-        IReadOnlyList<decimal> Decode { get; }
+        IReadOnlyList<double> Decode { get; }
 
         /// <summary>
         /// Specifies whether interpolation is to be performed. Interpolation smooths images where a single component in the image

--- a/src/UglyToad.PdfPig/Content/InlineImage.cs
+++ b/src/UglyToad.PdfPig/Content/InlineImage.cs
@@ -35,7 +35,7 @@
         public bool IsImageMask { get; }
 
         /// <inheritdoc />
-        public IReadOnlyList<decimal> Decode { get; }
+        public IReadOnlyList<double> Decode { get; }
 
         /// <inheritdoc />
         public bool IsInlineImage { get; } = true;
@@ -62,7 +62,7 @@
         internal InlineImage(PdfRectangle bounds, int widthInSamples, int heightInSamples, int bitsPerComponent, bool isImageMask,
             RenderingIntent renderingIntent,
             bool interpolate,
-            IReadOnlyList<decimal> decode,
+            IReadOnlyList<double> decode,
             IReadOnlyList<byte> bytes,
             IReadOnlyList<IFilter> filters,
             DictionaryToken streamDictionary,

--- a/src/UglyToad.PdfPig/Graphics/InlineImageBuilder.cs
+++ b/src/UglyToad.PdfPig/Graphics/InlineImageBuilder.cs
@@ -100,7 +100,7 @@
 
             var decodeRaw = GetByKeys<ArrayToken>(NameToken.Decode, NameToken.D, false) ?? new ArrayToken(EmptyArray<IToken>.Instance);
 
-            var decode = decodeRaw.Data.OfType<NumericToken>().Select(x => x.Data).ToArray();
+            var decode = decodeRaw.Data.OfType<NumericToken>().Select(x => x.Double).ToArray();
 
             var interpolate = GetByKeys<BooleanToken>(NameToken.Interpolate, NameToken.I, false)?.Data ?? false;
 

--- a/src/UglyToad.PdfPig/XObjects/XObjectFactory.cs
+++ b/src/UglyToad.PdfPig/XObjects/XObjectFactory.cs
@@ -116,12 +116,12 @@
             var decodedBytes = supportsFilters ? new Lazy<IReadOnlyList<byte>>(() => streamToken.Decode(filterProvider, pdfScanner))
                 : null;
 
-            var decode = EmptyArray<decimal>.Instance;
+            var decode = EmptyArray<double>.Instance;
 
             if (dictionary.TryGet(NameToken.Decode, pdfScanner, out ArrayToken decodeArrayToken))
             {
                 decode = decodeArrayToken.Data.OfType<NumericToken>()
-                    .Select(x => x.Data)
+                    .Select(x => x.Double)
                     .ToArray();
             }
 

--- a/src/UglyToad.PdfPig/XObjects/XObjectImage.cs
+++ b/src/UglyToad.PdfPig/XObjects/XObjectImage.cs
@@ -45,7 +45,7 @@
         public bool IsImageMask { get; }
 
         /// <inheritdoc />
-        public IReadOnlyList<decimal> Decode { get; }
+        public IReadOnlyList<double> Decode { get; }
 
         /// <inheritdoc />
         public bool Interpolate { get; }
@@ -74,7 +74,7 @@
             bool isImageMask,
             RenderingIntent renderingIntent,
             bool interpolate,
-            IReadOnlyList<decimal> decode,
+            IReadOnlyList<double> decode,
             DictionaryToken imageDictionary,
             IReadOnlyList<byte> rawBytes,
             Lazy<IReadOnlyList<byte>> bytes,


### PR DESCRIPTION
A small PR to use `double` instead of `decimal` in `IPdfImage`'s `Decode` property. It does not change anything as the property is not used (as far as I know) yet. It's just part of the effort to move away from using `decimal`