### PR TITLE
Improve UnpackComponents() method performance

### DIFF
--- a/src/UglyToad.PdfPig/Images/ColorSpaceDetailsByteConverter.cs
+++ b/src/UglyToad.PdfPig/Images/ColorSpaceDetailsByteConverter.cs
@@ -51,18 +51,22 @@
 
         private static byte[] UnpackComponents(IReadOnlyList<byte> input, int bitsPerComponent)
         {
-            IEnumerable<byte> Unpack(byte b)
-            {
-                int right = (int)Math.Pow(2, bitsPerComponent) - 1;
+            int end = 8 - bitsPerComponent;
+            var unpacked = new byte[input.Count * (int)Math.Ceiling((end + 1) / (double)bitsPerComponent)];
 
+            int right = (int)Math.Pow(2, bitsPerComponent) - 1;
+
+            int u = 0;
+            foreach (byte b in input)
+            {
                 // Enumerate bits in bitsPerComponent-sized chunks from MSB to LSB, masking on the appropriate bits
-                for (int i = 8 - bitsPerComponent; i >= 0; i -= bitsPerComponent)
+                for (int i = end; i >= 0; i -= bitsPerComponent)
                 {
-                    yield return (byte)((b >> i) & right);
+                    unpacked[u++] = (byte)((b >> i) & right);
                 }
             }
 
-            return input.SelectMany(Unpack).ToArray();
+            return unpacked;
         }
 
         private static byte[] RemoveStridePadding(byte[] input, int strideWidth, int imageWidth, int imageHeight, int multiplier)


### PR DESCRIPTION
Improve performance of the `UnpackComponents()` method. See benchmark below (new method is `OutsideArray`).

(array size is 1.6m bytes and bitsPerComponent set to 1)

![image](https://github.com/UglyToad/PdfPig/assets/38405645/6e30f25d-15f7-40f6-a5d6-65bccacaf038)
