### PR TITLE
Retarget the unit test project from .NET Core 2.0 to 2.1, and update the test SDK

### DIFF
--- a/src/UglyToad.PdfPig.Tests/UglyToad.PdfPig.Tests.csproj
+++ b/src/UglyToad.PdfPig.Tests/UglyToad.PdfPig.Tests.csproj
@@ -88,7 +88,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.3" />
     <PackageReference Include="SkiaSharp" Version="2.88.7" />
     <PackageReference Include="xunit" Version="2.6.6" />
     <PackageReference Include="xunit.extensibility.execution" Version="2.6.6" />

--- a/src/UglyToad.PdfPig.Tests/UglyToad.PdfPig.Tests.csproj
+++ b/src/UglyToad.PdfPig.Tests/UglyToad.PdfPig.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;net6.0</TargetFrameworks>
     <IsTestProject>true</IsTestProject>
     <IsPackable>false</IsPackable>
     <DebugType>full</DebugType>
@@ -92,7 +92,7 @@
     <PackageReference Include="SkiaSharp" Version="2.88.7" />
     <PackageReference Include="xunit" Version="2.6.6" />
     <PackageReference Include="xunit.extensibility.execution" Version="2.6.6" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
refs #771

I'm not entirely certain that this will work even though version 17.3.3 still lists older versions of .NET Core as supported TFMs (anything newer requires a newer .NET target in the test project, which is presently still targetting .NET Core 2,0 as well as 6.0)

Anyway - the idea is that it takes out references to a great deal of old libraries - 

with version 16.2.0 of the test SDK:

![image](https://github.com/UglyToad/PdfPig/assets/1178570/5b192f1d-299c-424f-a050-2a149fe5a900)

and with 17.3.3:

![image](https://github.com/UglyToad/PdfPig/assets/1178570/ab29cdd5-e9e9-41f5-a1a6-d73d3f59b107)

including an older version of Newtonsoft.Json which is listed as having security issues (i can't say whether it actually does in this usage)