### PR TITLE
Fix code analyzer suggestions coming from the updated xUnit packages

### DIFF
--- a/src/UglyToad.PdfPig.Tests/Fonts/CompactFontFormat/CompactFontFormatParserTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Fonts/CompactFontFormat/CompactFontFormatParserTests.cs
@@ -16,7 +16,7 @@
             var font = CompactFontFormatParser.Parse(new CompactFontFormatData(fileBytes));
 
             Assert.Equal(1, font.Header.MajorVersion);
-            Assert.Equal(1, font.Fonts.Count);
+            Assert.Single(font.Fonts);
             Assert.True(font.Fonts.ContainsKey("MinionPro-It"));
         }
 

--- a/src/UglyToad.PdfPig.Tests/Fonts/Parser/CMapParserTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Fonts/Parser/CMapParserTests.cs
@@ -91,7 +91,7 @@ endbfchar";
 
             var cmap = cMapParser.Parse(input.Bytes);
 
-            Assert.Equal(1, cmap.CodespaceRanges.Count);
+            Assert.Single(cmap.CodespaceRanges);
 
             Assert.Equal(0, cmap.CodespaceRanges[0].StartInt);
             Assert.Equal(65535, cmap.CodespaceRanges[0].EndInt);
@@ -135,7 +135,7 @@ endbfchar";
 
             var cmap = cMapParser.Parse(input);
 
-            Assert.Equal(1, cmap.CodespaceRanges.Count);
+            Assert.Single(cmap.CodespaceRanges);
 
             var range = cmap.CodespaceRanges[0];
 

--- a/src/UglyToad.PdfPig.Tests/Integration/EmbeddedFileAttachmentTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Integration/EmbeddedFileAttachmentTests.cs
@@ -29,7 +29,7 @@
             {
                 Assert.True(document.Advanced.TryGetEmbeddedFiles(out var files));
 
-                Assert.Equal(1, files.Count);
+                Assert.Single(files);
 
                 Assert.Equal(20668, files[0].Bytes.Count);
             }

--- a/src/UglyToad.PdfPig.Tests/Integration/MarkedContentExtractionTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Integration/MarkedContentExtractionTests.cs
@@ -55,7 +55,7 @@ namespace UglyToad.PdfPig.Tests.Integration
 
                 int index = 8;
                 var mc = mcs[index];
-                Assert.Equal(1, mc.Children.Count);
+                Assert.Single(mc.Children);
                 Assert.Equal(index, mc.Index);
                 Assert.NotEmpty(mc.Children);
                 Assert.Equal(index, mc.Children[0].Index);
@@ -63,7 +63,7 @@ namespace UglyToad.PdfPig.Tests.Integration
 
                 index = 9;
                 mc = mcs[index];
-                Assert.Equal(1, mc.Children.Count);
+                Assert.Single(mc.Children);
                 Assert.Equal(index, mc.Index);
                 Assert.NotEmpty(mc.Children);
                 Assert.Equal(index, mc.Children[0].Index);
@@ -71,7 +71,7 @@ namespace UglyToad.PdfPig.Tests.Integration
 
                 index = 75;
                 mc = mcs[index];
-                Assert.Equal(1, mc.Children.Count);
+                Assert.Single(mc.Children);
                 Assert.Equal(index, mc.Index);
                 Assert.NotEmpty(mc.Children);
                 Assert.Equal(index, mc.Children[0].Index);
@@ -113,7 +113,7 @@ namespace UglyToad.PdfPig.Tests.Integration
 
                 Assert.Equal(33, artifact.Letters.Count);
                 Assert.Equal(8, artifact.Paths.Count);
-                Assert.Equal(0, artifact.Images.Count);
+                Assert.Empty(artifact.Images);
             }
         }
 

--- a/src/UglyToad.PdfPig.Tests/Integration/OptionalContentTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Integration/OptionalContentTests.cs
@@ -14,7 +14,7 @@ namespace UglyToad.PdfPig.Tests.Integration
                 var page = document.GetPage(1);
                 var oc = page.ExperimentalAccess.GetOptionalContents();
 
-                Assert.Equal(0, oc.Count);
+                Assert.Empty(oc);
             }
         }
 
@@ -32,9 +32,9 @@ namespace UglyToad.PdfPig.Tests.Integration
                 Assert.Contains("Dimentions", oc);
                 Assert.Contains("Text", oc);
 
-                Assert.Equal(1, oc["0"].Count);
+                Assert.Single(oc["0"]);
                 Assert.Equal(2, oc["Dimentions"].Count);
-                Assert.Equal(1, oc["Text"].Count);
+                Assert.Single(oc["Text"]);
             }
         }
 

--- a/src/UglyToad.PdfPig.Tests/Tokenization/ArrayTokenizerTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Tokenization/ArrayTokenizerTests.cs
@@ -47,7 +47,7 @@
 
             var array = AssertArrayToken(token);
 
-            Assert.Equal(1, array.Data.Count);
+            Assert.Single(array.Data);
 
             Assert.Equal(dataValue, ((dynamic)token).Data[0].Data);
         }

--- a/src/UglyToad.PdfPig.Tests/Writer/Fonts/Standard14WritingFontTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Writer/Fonts/Standard14WritingFontTests.cs
@@ -829,7 +829,7 @@
 
 
             Assert.NotNull(letter);                         // We should get back something.
-            Assert.Equal(1, letter.Count);                  // There should be only one letter returned after the add operation.
+            Assert.Single(letter);                          // There should be only one letter returned after the add operation.
             Assert.Equal(stringToAdd, letter[0].Value);     // Check we got back the name letter (eg. "v")
                                                             //Debug.WriteLine($"{letter[0]}");
 

--- a/src/UglyToad.PdfPig.Tests/Writer/Fonts/ToUnicodeCMapBuilderTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Writer/Fonts/ToUnicodeCMapBuilderTests.cs
@@ -28,7 +28,7 @@
 
             var result = new CMapParser().Parse(new ByteArrayInputBytes(cmapStream));
 
-            Assert.Equal(1, result.CodespaceRanges.Count);
+            Assert.Single(result.CodespaceRanges);
 
             var range = result.CodespaceRanges[0];
 


### PR DESCRIPTION
It seems that the update to xUnit has resulted in a number of analyzer suggestions that are coming out as warnings in the CI build:

![image](https://github.com/UglyToad/PdfPig/assets/1178570/1b523741-1552-4a7b-8d3c-3936fc1236bb)

So I'm having a go at making the suggested changes to fix the warnings