### PR TITLE
Set the RuntimeFrameworkVersion for the .NET Core 2.1 unit tests to 2…

### DIFF
--- a/src/UglyToad.PdfPig.Tests/UglyToad.PdfPig.Tests.csproj
+++ b/src/UglyToad.PdfPig.Tests/UglyToad.PdfPig.Tests.csproj
@@ -8,6 +8,7 @@
     <LangVersion>latest</LangVersion>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\pdfpig.snk</AssemblyOriginatorKeyFile>
+    <RuntimeFrameworkVersion Condition="'$(TargetFramework)'=='netcoreapp2.1'">2.1.30</RuntimeFrameworkVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
….1.30

refs #771 

According to the listings on NuGet.org, all the versions of the Microsoft.NETCore.App NuGet package before 2.1.29 are at least one of deprecated, or have security vulnerabilities (Current versions of Visual Studio 2022 display warnings about them when you open the solution)
However - the build likes to set that reference to the minimum version for the curent .NET Core  - i.e. 2.1.0

So, this is an attempt to set the version to use to 2.1.30 (the latest) explicitly, to fix the security warnings.
The RuntimeFrameworkVersion is conditioned on the .NET Core version, so it shouldn't have any effect on the .NET 6.0 test builds.