### PR TITLE
Removed mistaken bracket in text replace operation

### DIFF
--- a/src/UglyToad.PdfPig/Graphics/Operations/TextShowing/ShowText.cs
+++ b/src/UglyToad.PdfPig/Graphics/Operations/TextShowing/ShowText.cs
@@ -82,7 +82,7 @@
             // as single-byte or multiple-byte character codes. 
 
             // Note: order of replacing is important. Replace slash first before brackets.
-            text = text.Replace(@"\", @"\\)");  // Escape any slash          '\'  -> '\\'
+            text = text.Replace(@"\", @"\\");  // Escape any slash          '\'  -> '\\'
             text = text.Replace("(", @"\(");    // Escape any open  brackets '('  -> '\('
             text = text.Replace(")", @"\)");    // Escape any close brackets ')'  -> '\)'
 


### PR DESCRIPTION
Hello, I apologise that I cannot provide the file which led to our discovery of this bug, but I hope that the change is self explanatory enough. A bracket appeared to have migrated inside a string replace operation which was resulting in some commands being corrupted when we re-output content. 
I'm not a regular contributor to any projects on github so I'm not sure if there is a protocol I should have followed, but in the worst case it should be quick enough for someone else to make this change to the main repo :D