### PR TITLE
Improve Code Quality 2

### DIFF
--- a/src/UglyToad.PdfPig/AcroForms/AcroFormFactory.cs
+++ b/src/UglyToad.PdfPig/AcroForms/AcroFormFactory.cs
@@ -213,7 +213,7 @@
             var fieldFlags = (uint) (fieldFlagsToken?.Long ?? 0);
 
             AcroFieldBase result;
-            if (fieldType == null)
+            if (fieldType is null)
             {
                 result = new AcroNonTerminalField(fieldDictionary, "Non-Terminal Field", fieldFlags, information, AcroFieldType.Unknown, children);
             }
@@ -562,7 +562,7 @@
                     continue;
                 }
 
-                if (selectedOptionIndices == null)
+                if (selectedOptionIndices is null)
                 {
                     return true;
                 }

--- a/src/UglyToad.PdfPig/AcroForms/Fields/AcroFieldCommonInformation.cs
+++ b/src/UglyToad.PdfPig/AcroForms/Fields/AcroFieldCommonInformation.cs
@@ -50,7 +50,7 @@
         {
             string AppendIfNotNull(string val, string label, string result)
             {
-                if (val == null)
+                if (val is null)
                 {
                     return result;
                 }

--- a/src/UglyToad.PdfPig/Annotations/AppearanceStream.cs
+++ b/src/UglyToad.PdfPig/Annotations/AppearanceStream.cs
@@ -53,7 +53,7 @@
         /// <exception cref="ArgumentOutOfRangeException"></exception>
         public StreamToken Get(string state)
         {
-            if (appearanceStreamsByState == null)
+            if (appearanceStreamsByState is null)
             {
                 throw new Exception("Cannot get appearance by state when this is a stateless appearance stream");
             }

--- a/src/UglyToad.PdfPig/Annotations/QuadPointsQuadrilateral.cs
+++ b/src/UglyToad.PdfPig/Annotations/QuadPointsQuadrilateral.cs
@@ -23,7 +23,7 @@
         /// </summary>
         public QuadPointsQuadrilateral(IReadOnlyList<PdfPoint> points)
         {
-            if (points == null)
+            if (points is null)
             {
                 throw new ArgumentNullException(nameof(points));
             }

--- a/src/UglyToad.PdfPig/Content/BasePageFactory.cs
+++ b/src/UglyToad.PdfPig/Content/BasePageFactory.cs
@@ -66,7 +66,7 @@
         public TPage Create(int number, DictionaryToken dictionary, PageTreeMembers pageTreeMembers,
              NamedDestinations namedDestinations)
         {
-            if (dictionary == null)
+            if (dictionary is null)
             {
                 throw new ArgumentNullException(nameof(dictionary));
             }
@@ -131,7 +131,7 @@
 
                     var contentStream = DirectObjectFinder.Get<StreamToken>(obj, PdfScanner);
 
-                    if (contentStream == null)
+                    if (contentStream is null)
                     {
                         throw new InvalidOperationException($"Could not find the contents for object {obj}.");
                     }
@@ -150,7 +150,7 @@
             {
                 var contentStream = DirectObjectFinder.Get<StreamToken>(contents, PdfScanner);
 
-                if (contentStream == null)
+                if (contentStream is null)
                 {
                     throw new InvalidOperationException("Failed to parse the content for the page: " + number);
                 }
@@ -181,7 +181,7 @@
         {
             IReadOnlyList<IGraphicsStateOperation> operations;
 
-            if (contentBytes == null || contentBytes.Count == 0)
+            if (contentBytes is null || contentBytes.Count == 0)
             {
                 operations = Array.Empty<IGraphicsStateOperation>();
             }
@@ -293,7 +293,7 @@
             {
                 mediaBox = pageTreeMembers.MediaBox;
 
-                if (mediaBox == null)
+                if (mediaBox is null)
                 {
                     ParsingOptions.Logger.Error(
                         $"The MediaBox was the wrong missing for page {number}. Using US Letter.");

--- a/src/UglyToad.PdfPig/Content/DocumentInformation.cs
+++ b/src/UglyToad.PdfPig/Content/DocumentInformation.cs
@@ -124,7 +124,7 @@
 
         private static void AppendPart(string name, string value, StringBuilder builder)
         {
-            if (value == null)
+            if (value is null)
             {
                 return;
             }

--- a/src/UglyToad.PdfPig/Content/InlineImage.cs
+++ b/src/UglyToad.PdfPig/Content/InlineImage.cs
@@ -108,7 +108,7 @@
         public bool TryGetBytes(out IReadOnlyList<byte> bytes)
         {
             bytes = null;
-            if (bytesFactory == null)
+            if (bytesFactory is null)
             {
                 return false;
             }

--- a/src/UglyToad.PdfPig/Content/Page.cs
+++ b/src/UglyToad.PdfPig/Content/Page.cs
@@ -122,7 +122,7 @@
 
         private static string GetText(PageContent content)
         {
-            if (content?.Letters == null)
+            if (content?.Letters is null)
             {
                 return string.Empty;
             }

--- a/src/UglyToad.PdfPig/Content/PageRotationDegrees.cs
+++ b/src/UglyToad.PdfPig/Content/PageRotationDegrees.cs
@@ -25,19 +25,13 @@
         {
             get
             {
-                switch (Value)
-                {
-                    case 0:
-                        return 0;
-                    case 90:
-                        return -0.5 * Math.PI;
-                    case 180:
-                        return -Math.PI;
-                    case 270:
-                        return -1.5 * Math.PI;
-                    default:
-                        throw new InvalidOperationException($"Invalid value for rotation: {Value}.");
-                }
+                return Value switch {
+                    0   => 0,
+                    90  => -0.5 * Math.PI,
+                    180 => -Math.PI,
+                    270 => -1.5 * Math.PI,
+                    _   => throw new InvalidOperationException($"Invalid value for rotation: {Value}.")
+                };
             }
         }
 

--- a/src/UglyToad.PdfPig/Content/PageTreeNode.cs
+++ b/src/UglyToad.PdfPig/Content/PageTreeNode.cs
@@ -49,7 +49,7 @@
         /// <summary>
         /// Whether this node is the root node.
         /// </summary>
-        public bool IsRoot => Parent == null;
+        public bool IsRoot => Parent is null;
 
         /// <summary>
         /// Create a new <see cref="PageTreeNode"/>.

--- a/src/UglyToad.PdfPig/Content/Pages.cs
+++ b/src/UglyToad.PdfPig/Content/Pages.cs
@@ -132,7 +132,7 @@
                 typeof(ParsingOptions)
             });
 
-            if (constructor == null)
+            if (constructor is null)
             {
                 throw new InvalidOperationException($"Could not find valid constructor for page factory of type '{typeof(TPageFactory)}'. " +
                                                     "The page factory should have a constructor with the following parameters: " +

--- a/src/UglyToad.PdfPig/Content/ResourceStore.cs
+++ b/src/UglyToad.PdfPig/Content/ResourceStore.cs
@@ -200,7 +200,7 @@
 
                     var fontObject = DirectObjectFinder.Get<DictionaryToken>(objectKey, scanner);
 
-                    if (fontObject == null)
+                    if (fontObject is null)
                     {
                         //This is a valid use case
                         continue;
@@ -269,7 +269,7 @@
         {
             namedToken = default(ResourceColorSpace);
 
-            if (name == null)
+            if (name is null)
             {
                 throw new ArgumentNullException(nameof(name));
             }
@@ -286,7 +286,7 @@
 
         public ColorSpaceDetails GetColorSpaceDetails(NameToken name, DictionaryToken dictionary)
         {
-            if (dictionary == null)
+            if (dictionary is null)
             {
                 dictionary = new DictionaryToken(new Dictionary<NameToken, IToken>());
             }

--- a/src/UglyToad.PdfPig/Content/Word.cs
+++ b/src/UglyToad.PdfPig/Content/Word.cs
@@ -42,7 +42,7 @@
         /// <param name="letters">The letters contained in the word, in the correct order.</param>
         public Word(IReadOnlyList<Letter> letters)
         {
-            if (letters == null)
+            if (letters is null)
             {
                 throw new ArgumentNullException(nameof(letters));
             }

--- a/src/UglyToad.PdfPig/CrossReference/CrossReferenceTable.cs
+++ b/src/UglyToad.PdfPig/CrossReference/CrossReferenceTable.cs
@@ -44,7 +44,7 @@
             TrailerDictionary trailer,
             IReadOnlyList<CrossReferenceOffset> crossReferenceOffsets)
         {
-            if (objectOffsets == null)
+            if (objectOffsets is null)
             {
                 throw new ArgumentNullException(nameof(objectOffsets));
             }

--- a/src/UglyToad.PdfPig/CrossReference/CrossReferenceTableBuilder.cs
+++ b/src/UglyToad.PdfPig/CrossReference/CrossReferenceTableBuilder.cs
@@ -20,7 +20,7 @@
         
         public void Add(CrossReferenceTablePart part)
         {
-            if (part == null)
+            if (part is null)
             {
                 throw new ArgumentNullException(nameof(part));
             }
@@ -38,7 +38,7 @@
 
             var currentPart = parts.FirstOrDefault(x => x.Offset == firstCrossReferenceOffset);
             
-            if (currentPart == null)
+            if (currentPart is null)
             {
                 // no XRef at given position
                 log.Warn($"Did not find an XRef object at the specified startxref position {firstCrossReferenceOffset}");
@@ -73,7 +73,7 @@
                     }
 
                     currentPart = parts.FirstOrDefault(x => x.Offset == prevBytePos || x.Offset == prevBytePos + offsetCorrection);
-                    if (currentPart == null)
+                    if (currentPart is null)
                     {
                         log.Warn("Did not found XRef object pointed to by 'Prev' key at position " + prevBytePos);
                         break;

--- a/src/UglyToad.PdfPig/CrossReference/TrailerDictionary.cs
+++ b/src/UglyToad.PdfPig/CrossReference/TrailerDictionary.cs
@@ -56,7 +56,7 @@
         /// <param name="dictionary">The parsed dictionary from the document.</param>
         internal TrailerDictionary(DictionaryToken dictionary)
         {
-            if (dictionary == null)
+            if (dictionary is null)
             {
                 throw new ArgumentNullException(nameof(dictionary));
             }

--- a/src/UglyToad.PdfPig/Encryption/CryptHandler.cs
+++ b/src/UglyToad.PdfPig/Encryption/CryptHandler.cs
@@ -15,12 +15,12 @@
         public CryptHandler(DictionaryToken cryptDictionary,
             NameToken streamName, NameToken stringName)
         {
-            if (streamName == null)
+            if (streamName is null)
             {
                 throw new ArgumentNullException(nameof(streamName));
             }
 
-            if (stringName == null)
+            if (stringName is null)
             {
                 throw new ArgumentNullException(nameof(stringName));
             }
@@ -32,7 +32,7 @@
 
         public CryptDictionary GetNamedCryptDictionary(NameToken name)
         {
-            if (name == null)
+            if (name is null)
             {
                 throw new ArgumentNullException(nameof(name));
             }

--- a/src/UglyToad.PdfPig/Encryption/EncryptionDictionaryFactory.cs
+++ b/src/UglyToad.PdfPig/Encryption/EncryptionDictionaryFactory.cs
@@ -11,7 +11,7 @@
     {
         public static EncryptionDictionary Read(DictionaryToken encryptionDictionary, IPdfTokenScanner tokenScanner)
         {
-            if (encryptionDictionary == null)
+            if (encryptionDictionary is null)
             {
                 throw new ArgumentNullException(nameof(encryptionDictionary));
             }

--- a/src/UglyToad.PdfPig/Encryption/EncryptionHandler.cs
+++ b/src/UglyToad.PdfPig/Encryption/EncryptionHandler.cs
@@ -70,7 +70,7 @@
                 documentIdBytes = [];
             }
 
-            if (encryptionDictionary == null)
+            if (encryptionDictionary is null)
             {
                 return;
             }
@@ -329,7 +329,7 @@
 
         public IToken Decrypt(IndirectReference reference, IToken token)
         {
-            if (token == null)
+            if (token is null)
             {
                 throw new ArgumentNullException(nameof(token));
             }
@@ -728,7 +728,7 @@
 
         private static byte[] GetPaddedPassword(byte[] password)
         {
-            if (password == null || password.Length == 0)
+            if (password is null || password.Length == 0)
             {
                 return PaddingBytes;
             }
@@ -771,7 +771,7 @@
         private static byte[] ComputeStupidIsoHash(byte[] password, byte[] salt, byte[] vector)
         {
             // There are some details here https://web.archive.org/web/20180311160224/esec-lab.sogeti.com/posts/2011/09/14/the-undocumented-password-validation-algorithm-of-adobe-reader-x.html
-            if (vector == null)
+            if (vector is null)
             {
                 vector = [];
             }

--- a/src/UglyToad.PdfPig/Filters/CcittFaxDecoderStream.cs
+++ b/src/UglyToad.PdfPig/Filters/CcittFaxDecoderStream.cs
@@ -115,7 +115,7 @@
                 {
                     node = node.Walk(ReadBit());
 
-                    if (node == null)
+                    if (node is null)
                     {
                         goto mode;
                     }
@@ -224,7 +224,7 @@
                 {
                     node = node.Walk(ReadBit());
 
-                    if (node == null)
+                    if (node is null)
                     {
                         goto eof;
                     }
@@ -347,7 +347,7 @@
                 var bit = ReadBit();
                 node = node.Walk(bit);
 
-                if (node == null)
+                if (node is null)
                 {
                     throw new InvalidOperationException("Unknown code in Huffman RLE stream");
                 }
@@ -495,7 +495,7 @@
                     var isSet = ((path >> bitPos) & 1) == 1;
                     var next = current.Walk(isSet);
 
-                    if (next == null)
+                    if (next is null)
                     {
                         next = new Node();
 
@@ -531,7 +531,7 @@
                     var isSet = ((path >> bitPos) & 1) == 1;
                     var next = current.Walk(isSet);
 
-                    if (next == null)
+                    if (next is null)
                     {
                         if (i == depth - 1)
                         {

--- a/src/UglyToad.PdfPig/Filters/DecodeParameterResolver.cs
+++ b/src/UglyToad.PdfPig/Filters/DecodeParameterResolver.cs
@@ -9,7 +9,7 @@
     {
         public static DictionaryToken GetFilterParameters(DictionaryToken streamDictionary, int index)
         {
-            if (streamDictionary == null)
+            if (streamDictionary is null)
             {
                 throw new ArgumentNullException(nameof(streamDictionary));
             }

--- a/src/UglyToad.PdfPig/Filters/DefaultFilterProvider.cs
+++ b/src/UglyToad.PdfPig/Filters/DefaultFilterProvider.cs
@@ -56,13 +56,13 @@
         /// <inheritdoc />
         public IReadOnlyList<IFilter> GetFilters(DictionaryToken dictionary)
         {
-            if (dictionary == null)
+            if (dictionary is null)
             {
                 throw new ArgumentNullException(nameof(dictionary));
             }
 
             var token = dictionary.GetObjectOrDefault(NameToken.Filter, NameToken.F);
-            if (token == null)
+            if (token is null)
             {
                 return Array.Empty<IFilter>();
             }
@@ -89,7 +89,7 @@
         /// <inheritdoc />
         public IReadOnlyList<IFilter> GetNamedFilters(IReadOnlyList<NameToken> names)
         {
-            if (names == null)
+            if (names is null)
             {
                 throw new ArgumentNullException(nameof(names));
             }

--- a/src/UglyToad.PdfPig/Filters/FilterProviderWithLookup.cs
+++ b/src/UglyToad.PdfPig/Filters/FilterProviderWithLookup.cs
@@ -29,13 +29,13 @@
 
         public IReadOnlyList<IFilter> GetFilters(DictionaryToken dictionary, IPdfTokenScanner scanner)
         {
-            if (dictionary == null)
+            if (dictionary is null)
             {
                 throw new ArgumentNullException(nameof(dictionary));
             }
 
             var token = dictionary.GetObjectOrDefault(NameToken.Filter, NameToken.F);
-            if (token == null)
+            if (token is null)
             {
                 return Array.Empty<IFilter>();
             }
@@ -57,7 +57,7 @@
                 case IndirectReferenceToken irt:
                     if (DirectObjectFinder.TryGet<NameToken>(irt, scanner, out var indirectName))
                     {
-                        return GetNamedFilters(new []{ indirectName });
+                        return GetNamedFilters(new[] { indirectName });
                     }
                     else if (DirectObjectFinder.TryGet<ArrayToken>(irt, scanner, out var indirectArray))
                     {

--- a/src/UglyToad.PdfPig/Filters/FlateFilter.cs
+++ b/src/UglyToad.PdfPig/Filters/FlateFilter.cs
@@ -36,7 +36,7 @@
         /// <inheritdoc />
         public byte[] Decode(IReadOnlyList<byte> input, DictionaryToken streamDictionary, int filterIndex)
         {
-            if (input == null)
+            if (input is null)
             {
                 throw new ArgumentNullException(nameof(input));
             }

--- a/src/UglyToad.PdfPig/Filters/PngPredictor.cs
+++ b/src/UglyToad.PdfPig/Filters/PngPredictor.cs
@@ -9,7 +9,7 @@
     {
         public static byte[] Decode(byte[] inputBytes, int predictor, int colors, int bitsPerComponent, int columns)
         {
-            if (inputBytes == null)
+            if (inputBytes is null)
             {
                 throw new ArgumentNullException(nameof(inputBytes));
             }
@@ -22,8 +22,8 @@
             int bitsPerPixel = colors * bitsPerComponent;
             int bytesPerPixel = (bitsPerPixel + 7) / 8;
             int rowlength = (columns * bitsPerPixel + 7) / 8;
-            byte[] actline = new byte[rowlength];
-            byte[] lastline = new byte[rowlength];
+            var actline = new byte[rowlength];
+            var lastline = new byte[rowlength];
 
             int linepredictor = predictor;
 

--- a/src/UglyToad.PdfPig/Functions/PdfFunction.cs
+++ b/src/UglyToad.PdfPig/Functions/PdfFunction.cs
@@ -84,7 +84,7 @@
             {
                 if (numberOfOutputValues == -1)
                 {
-                    if (RangeValues == null)
+                    if (RangeValues is null)
                     {
                         numberOfOutputValues = 0;
                     }

--- a/src/UglyToad.PdfPig/Functions/PdfFunctionType0.cs
+++ b/src/UglyToad.PdfPig/Functions/PdfFunctionType0.cs
@@ -254,7 +254,7 @@
         /// <returns>an array with all samples.</returns>
         private int[][] GetSamples()
         {
-            if (samples == null)
+            if (samples is null)
             {
                 int arraySize = 1;
                 int nIn = NumberOfInputParameters;

--- a/src/UglyToad.PdfPig/Functions/PdfFunctionType2.cs
+++ b/src/UglyToad.PdfPig/Functions/PdfFunctionType2.cs
@@ -40,7 +40,7 @@
             // exponential interpolation
             double xToN = Math.Pow(input[0], N); // x^exponent
 
-            double[] result = new double[Math.Min(C0.Length, C1.Length)];
+            var result = new double[Math.Min(C0.Length, C1.Length)];
             for (int j = 0; j < result.Length; j++)
             {
                 double c0j = ((NumericToken)C0[j]).Double;

--- a/src/UglyToad.PdfPig/Functions/PdfFunctionType3.cs
+++ b/src/UglyToad.PdfPig/Functions/PdfFunctionType3.cs
@@ -20,7 +20,7 @@
         internal PdfFunctionType3(DictionaryToken function, ArrayToken domain, ArrayToken range, IReadOnlyList<PdfFunction> functionsArray, ArrayToken bounds, ArrayToken encode)
             : base(function, domain, range)
         {
-            if (functionsArray == null || functionsArray.Count == 0)
+            if (functionsArray is null || functionsArray.Count == 0)
             {
                 throw new ArgumentNullException(nameof(functionsArray));
             }
@@ -36,7 +36,7 @@
         internal PdfFunctionType3(StreamToken function, ArrayToken domain, ArrayToken range, IReadOnlyList<PdfFunction> functionsArray, ArrayToken bounds, ArrayToken encode)
             : base(function, domain, range)
         {
-            if (functionsArray == null || functionsArray.Count == 0)
+            if (functionsArray is null || functionsArray.Count == 0)
             {
                 throw new ArgumentNullException(nameof(functionsArray));
             }
@@ -77,7 +77,7 @@
                 int boundsSize = boundsValues.Length;
                 // create a combined array containing the domain and the bounds values
                 // domain.min, bounds[0], bounds[1], ...., bounds[boundsSize-1], domain.max
-                double[] partitionValues = new double[boundsSize + 2];
+                var partitionValues = new double[boundsSize + 2];
                 int partitionValuesSize = partitionValues.Length;
                 partitionValues[0] = domain.Min;
                 partitionValues[partitionValuesSize - 1] = domain.Max;
@@ -95,11 +95,11 @@
                     }
                 }
             }
-            if (function == null)
+            if (function is null)
             {
                 throw new IOException("partition not found in type 3 function");
             }
-            double[] functionValues = new double[] { x };
+            var functionValues = new double[] { x };
             // calculate the output values using the chosen function
             double[] functionResult = function.Eval(functionValues);
             // clip to range if available

--- a/src/UglyToad.PdfPig/Geometry/ClippingExtensions.cs
+++ b/src/UglyToad.PdfPig/Geometry/ClippingExtensions.cs
@@ -24,9 +24,9 @@
         /// <summary>
         /// Generates the result of applying a clipping path to another path.
         /// </summary>
-        public static PdfPath Clip(this PdfPath clipping, PdfPath subject, ILog log = null)
+        public static PdfPath Clip(this PdfPath clipping, PdfPath subject, ILog? log = null)
         {
-            if (clipping == null)
+            if (clipping is null)
             {
                 throw new ArgumentNullException(nameof(clipping), $"{nameof(Clip)}: the clipping path cannot be null.");
             }
@@ -36,7 +36,7 @@
                 throw new ArgumentException($"{nameof(Clip)}: the clipping path does not have the IsClipping flag set to true.", nameof(clipping));
             }
 
-            if (subject == null)
+            if (subject is null)
             {
                 throw new ArgumentNullException(nameof(subject), $"{nameof(Clip)}: the subject path cannot be null.");
             }

--- a/src/UglyToad.PdfPig/Geometry/GeometryExtensions.cs
+++ b/src/UglyToad.PdfPig/Geometry/GeometryExtensions.cs
@@ -169,7 +169,7 @@
                     if (A < Amin)
                     {
                         Amin = A;
-                        MBR = new[] { R0X, R0Y, R1X, R1Y, R2X, R2Y, R3X, R3Y };
+                        MBR = [R0X, R0Y, R1X, R1Y, R2X, R2Y, R3X, R3Y];
                     }
                 }
 

--- a/src/UglyToad.PdfPig/Geometry/GeometryExtensions.cs
+++ b/src/UglyToad.PdfPig/Geometry/GeometryExtensions.cs
@@ -70,7 +70,7 @@
         /// </param>
         private static PdfRectangle ParametricPerpendicularProjection(IReadOnlyList<PdfPoint> polygon)
         {
-            if (polygon == null || polygon.Count == 0)
+            if (polygon is null || polygon.Count == 0)
             {
                 throw new ArgumentException("ParametricPerpendicularProjection(): polygon cannot be null and must contain at least one point.", nameof(polygon));
             }
@@ -208,7 +208,7 @@
         /// <param name="points">The points.</param>
         public static PdfRectangle OrientedBoundingBox(IReadOnlyList<PdfPoint> points)
         {
-            if (points == null || points.Count < 2)
+            if (points is null || points.Count < 2)
             {
                 throw new ArgumentException("OrientedBoundingBox(): points cannot be null and must contain at least two points.", nameof(points));
             }
@@ -881,7 +881,7 @@
         private static PdfPoint[] Intersect(BezierCurve bezierCurve, PdfPoint p1, PdfPoint p2)
         {
             var ts = IntersectT(bezierCurve, p1, p2);
-            if (ts == null || ts.Length == 0) return [];
+            if (ts is null || ts.Length == 0) return [];
 
             List<PdfPoint> points = new List<PdfPoint>();
             foreach (var t in ts)

--- a/src/UglyToad.PdfPig/Graphics/BaseStreamProcessor.cs
+++ b/src/UglyToad.PdfPig/Graphics/BaseStreamProcessor.cs
@@ -213,7 +213,7 @@
                 ? ActiveExtendedGraphicsStateFont
                 : ResourceStore.GetFont(currentState.FontState.FontName);
 
-            if (font == null)
+            if (font is null)
             {
                 if (ParsingOptions.SkipMissingFonts)
                 {
@@ -248,7 +248,7 @@
 
                 var foundUnicode = font.TryGetUnicode(code, out var unicode);
 
-                if (!foundUnicode || unicode == null)
+                if (!foundUnicode || unicode is null)
                 {
                     ParsingOptions.Logger.Warn(
                         $"We could not find the corresponding character with code {code} in font {font.Name}.");
@@ -342,7 +342,7 @@
             var horizontalScaling = textState.HorizontalScaling / 100.0;
             var font = ResourceStore.GetFont(textState.FontName);
 
-            if (font == null)
+            if (font is null)
             {
                 if (ParsingOptions.SkipMissingFonts)
                 {
@@ -766,7 +766,7 @@
         /// <inheritdoc/>
         public virtual void SetInlineImageProperties(IReadOnlyDictionary<NameToken, IToken> properties)
         {
-            if (InlineImageBuilder == null)
+            if (InlineImageBuilder is null)
             {
                 ParsingOptions.Logger.Error(
                     "Begin inline image data (ID) command encountered without a corresponding begin inline image (BI) command.");
@@ -779,7 +779,7 @@
         /// <inheritdoc/>
         public virtual void EndInlineImage(IReadOnlyList<byte> bytes)
         {
-            if (InlineImageBuilder == null)
+            if (InlineImageBuilder is null)
             {
                 ParsingOptions.Logger.Error(
                     "End inline image (EI) command encountered without a corresponding begin inline image (BI) command.");

--- a/src/UglyToad.PdfPig/Graphics/Colors/ColorSpaceDetails.cs
+++ b/src/UglyToad.PdfPig/Graphics/Colors/ColorSpaceDetails.cs
@@ -104,7 +104,7 @@
         /// <inheritdoc/>
         public override IColor GetColor(params double[] values)
         {
-            if (values == null || values.Length != NumberOfColorComponents)
+            if (values is null || values.Length != NumberOfColorComponents)
             {
                 throw new ArgumentException($"Invalid number of inputs, expecting {NumberOfColorComponents} but got {values.Length}", nameof(values));
             }
@@ -166,7 +166,7 @@
         /// <inheritdoc/>
         public override IColor GetColor(params double[] values)
         {
-            if (values == null || values.Length != NumberOfColorComponents)
+            if (values is null || values.Length != NumberOfColorComponents)
             {
                 throw new ArgumentException($"Invalid number of inputs, expecting {NumberOfColorComponents} but got {values.Length}", nameof(values));
             }
@@ -228,7 +228,7 @@
         /// <inheritdoc/>
         public override IColor GetColor(params double[] values)
         {
-            if (values == null || values.Length != NumberOfColorComponents)
+            if (values is null || values.Length != NumberOfColorComponents)
             {
                 throw new ArgumentException($"Invalid number of inputs, expecting {NumberOfColorComponents} but got {values.Length}", nameof(values));
             }
@@ -330,7 +330,7 @@
         /// <inheritdoc/>
         public override IColor GetColor(params double[] values)
         {
-            if (values == null || values.Length != NumberOfColorComponents)
+            if (values is null || values.Length != NumberOfColorComponents)
             {
                 throw new ArgumentException($"Invalid number of inputs, expecting {NumberOfColorComponents} but got {values.Length}", nameof(values));
             }
@@ -518,7 +518,7 @@
         /// <inheritdoc/>
         public override IColor GetColor(params double[] values)
         {
-            if (values == null || values.Length != NumberOfColorComponents)
+            if (values is null || values.Length != NumberOfColorComponents)
             {
                 throw new ArgumentException($"Invalid number of inputs, expecting {NumberOfColorComponents} but got {values.Length}", nameof(values));
             }
@@ -688,7 +688,7 @@
         /// <inheritdoc/>
         public override IColor GetColor(params double[] values)
         {
-            if (values == null || values.Length != NumberOfColorComponents)
+            if (values is null || values.Length != NumberOfColorComponents)
             {
                 throw new ArgumentException($"Invalid number of inputs, expecting {NumberOfColorComponents} but got {values.Length}", nameof(values));
             }
@@ -838,7 +838,7 @@
         /// <inheritdoc/>
         public override IColor GetColor(params double[] values)
         {
-            if (values == null || values.Length != NumberOfColorComponents)
+            if (values is null || values.Length != NumberOfColorComponents)
             {
                 throw new ArgumentException($"Invalid number of inputs, expecting {NumberOfColorComponents} but got {values.Length}", nameof(values));
             }
@@ -979,7 +979,7 @@
         /// <inheritdoc/>
         public override IColor GetColor(params double[] values)
         {
-            if (values == null || values.Length != NumberOfColorComponents)
+            if (values is null || values.Length != NumberOfColorComponents)
             {
                 throw new ArgumentException($"Invalid number of inputs, expecting {NumberOfColorComponents} but got {values.Length}", nameof(values));
             }
@@ -1120,7 +1120,7 @@
         /// <inheritdoc/>
         public override IColor GetColor(params double[] values)
         {
-            if (values == null || values.Length != NumberOfColorComponents)
+            if (values is null || values.Length != NumberOfColorComponents)
             {
                 throw new ArgumentException($"Invalid number of inputs, expecting {NumberOfColorComponents} but got {values.Length}", nameof(values));
             }
@@ -1232,7 +1232,7 @@
         /// <inheritdoc/>
         public override IColor GetColor(params double[] values)
         {
-            if (values == null || values.Length != NumberOfColorComponents)
+            if (values is null || values.Length != NumberOfColorComponents)
             {
                 throw new ArgumentException($"Invalid number of inputs, expecting {NumberOfColorComponents} but got {values.Length}", nameof(values));
             }

--- a/src/UglyToad.PdfPig/Graphics/Colors/ColorSpaceDetails.cs
+++ b/src/UglyToad.PdfPig/Graphics/Colors/ColorSpaceDetails.cs
@@ -538,7 +538,7 @@
             for (var i = 0; i < decoded.Count; i += NumberOfColorComponents)
             {
                 int key = 0;
-                double[] comps = new double[NumberOfColorComponents];
+                var comps = new double[NumberOfColorComponents];
                 for (int n = 0; n < NumberOfColorComponents; n++)
                 {
                     byte b = decoded[i + n];
@@ -832,7 +832,7 @@
         internal override double[] Process(params double[] values)
         {
             var (R, _, _) = colorSpaceTransformer.TransformToRGB((values[0], values[0], values[0]));
-            return new double[] { R };
+            return [R];
         }
 
         /// <inheritdoc/>
@@ -1114,7 +1114,7 @@
             double Z = WhitePoint[2] * g(N);
 
             var (R, G, B) = colorSpaceTransformer.TransformToRGB((X, Y, Z));
-            return new double[] { R, G, B };
+            return [R, G, B];
         }
 
         /// <inheritdoc/>

--- a/src/UglyToad.PdfPig/Graphics/Colors/ColorSpaceExtensions.cs
+++ b/src/UglyToad.PdfPig/Graphics/Colors/ColorSpaceExtensions.cs
@@ -99,33 +99,20 @@
         /// </summary>
         public static NameToken ToNameToken(this ColorSpace colorSpace)
         {
-            switch (colorSpace)
-            {
-                case ColorSpace.DeviceGray:
-                    return NameToken.Devicegray;
-                case ColorSpace.DeviceRGB:
-                    return NameToken.Devicergb;
-                case ColorSpace.DeviceCMYK:
-                    return NameToken.Devicecmyk;
-                case ColorSpace.CalGray:
-                    return NameToken.Calgray;
-                case ColorSpace.CalRGB:
-                    return NameToken.Calrgb;
-                case ColorSpace.Lab:
-                    return NameToken.Lab;
-                case ColorSpace.ICCBased:
-                    return NameToken.Iccbased;
-                case ColorSpace.Indexed:
-                    return NameToken.Indexed;
-                case ColorSpace.Pattern:
-                    return NameToken.Pattern;
-                case ColorSpace.Separation:
-                    return NameToken.Separation;
-                case ColorSpace.DeviceN:
-                    return NameToken.Devicen;
-                default:
-                    throw new ArgumentException($"Unrecognized colorspace: {colorSpace}.");
-            }
+            return colorSpace switch {
+                ColorSpace.DeviceGray => NameToken.Devicegray,
+                ColorSpace.DeviceRGB  => NameToken.Devicergb,
+                ColorSpace.DeviceCMYK => NameToken.Devicecmyk,
+                ColorSpace.CalGray    => NameToken.Calgray,
+                ColorSpace.CalRGB     => NameToken.Calrgb,
+                ColorSpace.Lab        => NameToken.Lab,
+                ColorSpace.ICCBased   => NameToken.Iccbased,
+                ColorSpace.Indexed    => NameToken.Indexed,
+                ColorSpace.Pattern    => NameToken.Pattern,
+                ColorSpace.Separation => NameToken.Separation,
+                ColorSpace.DeviceN    => NameToken.Devicen,
+                _ => throw new ArgumentException($"Unrecognized colorspace: {colorSpace}.")
+            };
         }
     }
 }

--- a/src/UglyToad.PdfPig/Graphics/Colors/Shading.cs
+++ b/src/UglyToad.PdfPig/Graphics/Colors/Shading.cs
@@ -82,7 +82,7 @@
         /// </summary>
         public double[] Eval(params double[] input)
         {
-            if (Functions == null || Functions.Length == 0)
+            if (Functions is null || Functions.Length == 0)
             {
                 return input;
             }

--- a/src/UglyToad.PdfPig/Graphics/ContentStreamProcessor.cs
+++ b/src/UglyToad.PdfPig/Graphics/ContentStreamProcessor.cs
@@ -136,7 +136,7 @@
             }
 
             // If we did not create a letter for a combined diacritic, create one here.
-            if (letter == null)
+            if (letter is null)
             {
                 letter = new Letter(
                     unicode,
@@ -167,7 +167,7 @@
 
         public override void BeginSubpath()
         {
-            if (CurrentPath == null)
+            if (CurrentPath is null)
             {
                 CurrentPath = new PdfPath();
             }
@@ -178,7 +178,7 @@
 
         public override PdfPoint? CloseSubpath()
         {
-            if (CurrentSubpath == null)
+            if (CurrentSubpath is null)
             {
                 return null;
             }
@@ -200,7 +200,7 @@
 
         public void AddCurrentSubpath() // Not an override
         {
-            if (CurrentSubpath == null)
+            if (CurrentSubpath is null)
             {
                 return;
             }
@@ -211,7 +211,7 @@
 
         public override void StrokePath(bool close)
         {
-            if (CurrentPath == null)
+            if (CurrentPath is null)
             {
                 return;
             }
@@ -228,7 +228,7 @@
 
         public override void FillPath(FillingRule fillingRule, bool close)
         {
-            if (CurrentPath == null)
+            if (CurrentPath is null)
             {
                 return;
             }
@@ -245,7 +245,7 @@
 
         public override void FillStrokePath(FillingRule fillingRule, bool close)
         {
-            if (CurrentPath == null)
+            if (CurrentPath is null)
             {
                 return;
             }
@@ -271,7 +271,7 @@
 
         public override void BezierCurveTo(double x2, double y2, double x3, double y3)
         {
-            if (CurrentSubpath == null)
+            if (CurrentSubpath is null)
             {
                 return;
             }
@@ -290,7 +290,7 @@
 
         public override void BezierCurveTo(double x1, double y1, double x2, double y2, double x3, double y3)
         {
-            if (CurrentSubpath == null)
+            if (CurrentSubpath is null)
             {
                 return;
             }
@@ -310,7 +310,7 @@
 
         public override void LineTo(double x, double y)
         {
-            if (CurrentSubpath == null)
+            if (CurrentSubpath is null)
             {
                 return;
             }
@@ -333,7 +333,7 @@
 
         public override void EndPath()
         {
-            if (CurrentPath == null)
+            if (CurrentPath is null)
             {
                 return;
             }
@@ -403,7 +403,7 @@
 
         public override void ModifyClippingIntersect(FillingRule clippingRule)
         {
-            if (CurrentPath == null)
+            if (CurrentPath is null)
             {
                 return;
             }
@@ -417,7 +417,7 @@
                 currentClipping.SetClipping(clippingRule);
 
                 var newClippings = CurrentPath.Clip(currentClipping, ParsingOptions.Logger);
-                if (newClippings == null)
+                if (newClippings is null)
                 {
                     ParsingOptions.Logger.Warn("Empty clipping path found. Clipping path not updated.");
                 }

--- a/src/UglyToad.PdfPig/Graphics/Core/RenderingIntent.cs
+++ b/src/UglyToad.PdfPig/Graphics/Core/RenderingIntent.cs
@@ -28,20 +28,15 @@
     {
         public static RenderingIntent ToRenderingIntent(this string s)
         {
-            switch (s)
-            {
-                case "AbsoluteColorimetric":
-                    return RenderingIntent.AbsoluteColorimetric;
-                   case "RelativeColorimetric":
-                    return RenderingIntent.RelativeColorimetric;
-                case "Saturation":
-                    return RenderingIntent.Saturation;
-                case "Perceptual":
-                    return RenderingIntent.Perceptual;
-                default:
-                    // If the application does not recognise the name it uses RelativeColorimetric by default.
-                    return RenderingIntent.RelativeColorimetric;
-            }
+            return s switch {
+                "AbsoluteColorimetric" => RenderingIntent.AbsoluteColorimetric,
+                "RelativeColorimetric" => RenderingIntent.RelativeColorimetric,
+                "Saturation"           => RenderingIntent.Saturation,
+                "Perceptual"           => RenderingIntent.Perceptual,
+
+                // If the application does not recognise the name it uses RelativeColorimetric by default.
+                _ => RenderingIntent.RelativeColorimetric
+            };
         }
     }
 }

--- a/src/UglyToad.PdfPig/Graphics/InlineImageBuilder.cs
+++ b/src/UglyToad.PdfPig/Graphics/InlineImageBuilder.cs
@@ -30,7 +30,7 @@
             RenderingIntent defaultRenderingIntent,
             IResourceStore resourceStore)
         {
-            if (Properties == null || Bytes == null)
+            if (Properties is null || Bytes is null)
             {
                 throw new InvalidOperationException($"Inline image builder not completely defined before calling {nameof(CreateInlineImage)}.");
             }
@@ -54,7 +54,7 @@
             {
                 colorSpaceName = GetByKeys<NameToken>(NameToken.ColorSpace, NameToken.Cs, false);
 
-                if (colorSpaceName == null)
+                if (colorSpaceName is null)
                 {
                     var colorSpaceArray = GetByKeys<ArrayToken>(NameToken.ColorSpace, NameToken.Cs, true);
 
@@ -82,7 +82,7 @@
 
             var filterName = GetByKeys<NameToken>(NameToken.Filter, NameToken.F, false);
 
-            if (filterName == null)
+            if (filterName is null)
             {
                 var filterArray = GetByKeys<ArrayToken>(NameToken.Filter, NameToken.F, false);
 

--- a/src/UglyToad.PdfPig/Graphics/Operations/SpecialGraphicsState/ModifyCurrentTransformationMatrix.cs
+++ b/src/UglyToad.PdfPig/Graphics/Operations/SpecialGraphicsState/ModifyCurrentTransformationMatrix.cs
@@ -28,7 +28,7 @@
         /// <param name="value">The 6 transformation matrix values.</param>
         public ModifyCurrentTransformationMatrix(double[] value)
         {
-            if (value == null)
+            if (value is null)
             {
                 throw new ArgumentNullException(nameof(value));
             }

--- a/src/UglyToad.PdfPig/Graphics/Operations/TextShowing/MoveToNextLineShowText.cs
+++ b/src/UglyToad.PdfPig/Graphics/Operations/TextShowing/MoveToNextLineShowText.cs
@@ -62,7 +62,7 @@
         /// <inheritdoc />
         public void Write(Stream stream)
         {
-            if (Bytes == null)
+            if (Bytes is null)
             {
                 stream.WriteText($"({Text}) {Symbol}");
                 stream.WriteNewLine();

--- a/src/UglyToad.PdfPig/Graphics/Operations/TextShowing/ShowTextsWithPositioning.cs
+++ b/src/UglyToad.PdfPig/Graphics/Operations/TextShowing/ShowTextsWithPositioning.cs
@@ -36,7 +36,7 @@
         /// <param name="array">The array elements.</param>
         public ShowTextsWithPositioning(IReadOnlyList<IToken> array)
         {
-            if (array == null)
+            if (array is null)
             {
                 throw new ArgumentNullException(nameof(array));
             }

--- a/src/UglyToad.PdfPig/Graphics/ReflectionGraphicsStateOperationFactory.cs
+++ b/src/UglyToad.PdfPig/Graphics/ReflectionGraphicsStateOperationFactory.cs
@@ -40,7 +40,7 @@ namespace UglyToad.PdfPig.Graphics
                 {
                     var symbol = assemblyType.GetField("Symbol");
 
-                    if (symbol == null)
+                    if (symbol is null)
                     {
                         throw new InvalidOperationException("An operation type was defined without the public const Symbol being declared. Type was: " + assemblyType.FullName);
                     }

--- a/src/UglyToad.PdfPig/IO/RandomAccessBuffer.cs
+++ b/src/UglyToad.PdfPig/IO/RandomAccessBuffer.cs
@@ -424,7 +424,7 @@
          */
         private void CheckClosed()
         {
-            if (currentBuffer == null)
+            if (currentBuffer is null)
             {
                 // consider that the rab is closed if there is no current buffer
                 throw new ObjectDisposedException("RandomAccessBuffer already closed");
@@ -438,7 +438,7 @@
 
         public bool IsClosed()
         {
-            return currentBuffer == null;
+            return currentBuffer is null;
         }
 
 /**

--- a/src/UglyToad.PdfPig/Images/ColorSpaceDetailsByteConverter.cs
+++ b/src/UglyToad.PdfPig/Images/ColorSpaceDetailsByteConverter.cs
@@ -19,12 +19,12 @@
         /// </summary>
         public static byte[] Convert(ColorSpaceDetails details, IReadOnlyList<byte> decoded, int bitsPerComponent, int imageWidth, int imageHeight)
         {
-            if (decoded == null)
+            if (decoded is null)
             {
                 return [];
             }
 
-            if (details == null)
+            if (details is null)
             {
                 return decoded.ToArray();
             }

--- a/src/UglyToad.PdfPig/Images/JpegHandler.cs
+++ b/src/UglyToad.PdfPig/Images/JpegHandler.cs
@@ -10,7 +10,7 @@
 
         public static JpegInformation GetInformation(Stream stream)
         {
-            if (stream == null)
+            if (stream is null)
             {
                 throw new ArgumentNullException(nameof(stream));
             }

--- a/src/UglyToad.PdfPig/Images/Png/Adam7.cs
+++ b/src/UglyToad.PdfPig/Images/Png/Adam7.cs
@@ -9,24 +9,24 @@
         /// </summary>
         private static readonly IReadOnlyDictionary<int, int[]> PassToScanlineGridIndex = new Dictionary<int, int[]>
         {
-            { 1, new []{ 0 } },
-            { 2, new []{ 0 } },
-            { 3, new []{ 4 } },
-            { 4, new []{ 0, 4 } },
-            { 5, new []{ 2, 6 } },
-            { 6, new[] { 0, 2, 4, 6 } },
-            { 7, new[] { 1, 3, 5, 7 } }
+            { 1, [0] },
+            { 2, [0] },
+            { 3, [4] },
+            { 4, [0, 4] },
+            { 5, [2, 6] },
+            { 6, [0, 2, 4, 6] },
+            { 7, [1, 3, 5, 7] }
         };
 
         private static readonly IReadOnlyDictionary<int, int[]> PassToScanlineColumnIndex = new Dictionary<int, int[]>
         {
-            { 1, new []{ 0 } },
-            { 2, new []{ 4 } },
-            { 3, new []{ 0, 4 } },
-            { 4, new []{ 2, 6 } },
-            { 5, new []{ 0, 2, 4, 6 } },
-            { 6, new []{ 1, 3, 5, 7 } },
-            { 7, new []{ 0, 1, 2, 3, 4, 5, 6, 7 } }
+            { 1, [0] },
+            { 2, [4] },
+            { 3, [0, 4] },
+            { 4, [2, 6] },
+            { 5, [0, 2, 4, 6] },
+            { 6, [1, 3, 5, 7] },
+            { 7, [0, 1, 2, 3, 4, 5, 6, 7] }
         };
 
         /*

--- a/src/UglyToad.PdfPig/Images/Png/Adler32Checksum.cs
+++ b/src/UglyToad.PdfPig/Images/Png/Adler32Checksum.cs
@@ -1,6 +1,6 @@
 ﻿namespace UglyToad.PdfPig.Images.Png
 {
-    using System.Collections.Generic;
+    using System;
 
     /// <summary>
     /// Used to calculate the Adler-32 checksum used for ZLIB data in accordance with 
@@ -14,7 +14,7 @@
         /// <summary>
         /// Calculate the Adler-32 checksum for some data.
         /// </summary>
-        public static int Calculate(IEnumerable<byte> data)
+        public static int Calculate(ReadOnlySpan<byte> data)
         {
             // s1 is the sum of all bytes.
             var s1 = 1;

--- a/src/UglyToad.PdfPig/Images/Png/Crc32.cs
+++ b/src/UglyToad.PdfPig/Images/Png/Crc32.cs
@@ -1,5 +1,6 @@
 ﻿namespace UglyToad.PdfPig.Images.Png
 {
+    using System;
     using System.Collections.Generic;
 
     /// <summary>
@@ -36,7 +37,7 @@
         /// <summary>
         /// Calculate the CRC32 for data.
         /// </summary>
-        public static uint Calculate(byte[] data)
+        public static uint Calculate(ReadOnlySpan<byte> data)
         {
             var crc32 = uint.MaxValue;
             for (var i = 0; i < data.Length; i++)

--- a/src/UglyToad.PdfPig/Images/Png/PngOpener.cs
+++ b/src/UglyToad.PdfPig/Images/Png/PngOpener.cs
@@ -15,7 +15,7 @@
 
         public static Png Open(Stream stream, PngOpenerSettings settings)
         {
-            if (stream == null)
+            if (stream is null)
             {
                 throw new ArgumentNullException(nameof(stream));
             }

--- a/src/UglyToad.PdfPig/Outline/BookmarksProvider.cs
+++ b/src/UglyToad.PdfPig/Outline/BookmarksProvider.cs
@@ -133,7 +133,7 @@
 
                 current = DirectObjectFinder.Get<DictionaryToken>(nextReference, pdfScanner);
 
-                if (current == null)
+                if (current is null)
                 {
                     break;
                 }

--- a/src/UglyToad.PdfPig/Outline/Destinations/NamedDestinationsProvider.cs
+++ b/src/UglyToad.PdfPig/Outline/Destinations/NamedDestinationsProvider.cs
@@ -77,7 +77,7 @@
         {
             destination = null;
 
-            if (explicitDestinationArray == null || explicitDestinationArray.Length == 0)
+            if (explicitDestinationArray is null || explicitDestinationArray.Length == 0)
             {
                 return false;
             }
@@ -111,7 +111,7 @@
                     return false;
                 }
                 var page = pages.GetPageByReference(pageIndirectReferenceToken.Data);
-                if (page?.PageNumber == null)
+                if (page?.PageNumber is null)
                 {
                     return false;
                 }
@@ -136,7 +136,7 @@
             {
                 destTypeToken = explicitDestinationArray[1] as NameToken;
             }
-            if (destTypeToken == null)
+            if (destTypeToken is null)
             {
                 var errorMessage = $"Missing name token as second argument to explicit destination: {explicitDestinationArray}.";
 

--- a/src/UglyToad.PdfPig/Parser/CatalogFactory.cs
+++ b/src/UglyToad.PdfPig/Parser/CatalogFactory.cs
@@ -14,7 +14,7 @@
         public static Catalog Create(IndirectReference rootReference, DictionaryToken dictionary,
             IPdfTokenScanner scanner, PageFactory pageFactory, ILog log, bool isLenientParsing)
         {
-            if (dictionary == null)
+            if (dictionary is null)
             {
                 throw new ArgumentNullException(nameof(dictionary));
             }

--- a/src/UglyToad.PdfPig/Parser/DocumentInformationFactory.cs
+++ b/src/UglyToad.PdfPig/Parser/DocumentInformationFactory.cs
@@ -65,7 +65,7 @@
 
         private static string GetEntryOrDefault(DictionaryToken infoDictionary, NameToken key, IPdfTokenScanner pdfTokenScanner)
         {
-            if (infoDictionary == null)
+            if (infoDictionary is null)
             {
                 return null;
             }

--- a/src/UglyToad.PdfPig/Parser/FileStructure/CrossReferenceObjectOffsetValidator.cs
+++ b/src/UglyToad.PdfPig/Parser/FileStructure/CrossReferenceObjectOffsetValidator.cs
@@ -54,7 +54,7 @@
         
         private static bool ValidateXrefOffsets(IInputBytes bytes, IReadOnlyDictionary<IndirectReference, long> objectOffsets, ILog log)
         {
-            if (objectOffsets == null)
+            if (objectOffsets is null)
             {
                 return true;
             }

--- a/src/UglyToad.PdfPig/Parser/FileStructure/CrossReferenceParser.cs
+++ b/src/UglyToad.PdfPig/Parser/FileStructure/CrossReferenceParser.cs
@@ -262,7 +262,7 @@
 
             var streamObjectToken = (ObjectToken)pdfScanner.CurrentToken;
 
-            if (streamObjectToken == null || !(streamObjectToken.Data is StreamToken objectStream))
+            if (streamObjectToken is null || !(streamObjectToken.Data is StreamToken objectStream))
             {
                 log.Error($"When reading a cross reference stream object found a non-stream object: {streamObjectToken?.Data}");
 

--- a/src/UglyToad.PdfPig/Parser/FileStructure/FileHeaderParser.cs
+++ b/src/UglyToad.PdfPig/Parser/FileStructure/FileHeaderParser.cs
@@ -31,7 +31,7 @@
         [NotNull]
         public static HeaderVersion Parse([NotNull] ISeekableTokenScanner scanner, IInputBytes inputBytes, bool isLenientParsing, ILog log)
         {
-            if (scanner == null)
+            if (scanner is null)
             {
                 throw new ArgumentNullException(nameof(scanner));
             }
@@ -57,7 +57,7 @@
                 comment = scanner.CurrentToken as CommentToken;
 
                 attempts++;
-            } while (comment == null);
+            } while (comment is null);
 
             return GetHeaderVersionAndResetScanner(comment, scanner, isLenientParsing, log);
         }

--- a/src/UglyToad.PdfPig/Parser/FileStructure/FileTrailerParser.cs
+++ b/src/UglyToad.PdfPig/Parser/FileStructure/FileTrailerParser.cs
@@ -30,12 +30,12 @@
 
         public static long GetFirstCrossReferenceOffset(IInputBytes bytes, ISeekableTokenScanner scanner, bool isLenientParsing)
         {
-            if (bytes == null)
+            if (bytes is null)
             {
                 throw new ArgumentNullException(nameof(bytes));
             }
 
-            if (scanner == null)
+            if (scanner is null)
             {
                 throw new ArgumentNullException(nameof(scanner));
             }
@@ -68,7 +68,7 @@
                 }
             }
 
-            if (numeric == null)
+            if (numeric is null)
             {
                 throw new PdfDocumentFormatException($"Could not find the numeric value following 'startxref'. Searching from position {startXrefPosition}.");
             }

--- a/src/UglyToad.PdfPig/Parser/PageContentParser.cs
+++ b/src/UglyToad.PdfPig/Parser/PageContentParser.cs
@@ -72,7 +72,7 @@
                             ? graphicsStateOperations[graphicsStateOperations.Count - 1]
                             : null;
 
-                        if (lastEndImageOffset == null || lastOperation == null || !(lastOperation is EndInlineImage lastEndImage))
+                        if (lastEndImageOffset is null || lastOperation is null || !(lastOperation is EndInlineImage lastEndImage))
                         {
                             throw new PdfDocumentFormatException("Encountered End Image token outside an inline image on " +
                                                                  $"page {pageNumber} at offset in content: {scanner.CurrentPosition}.");

--- a/src/UglyToad.PdfPig/Parser/PageFactory.cs
+++ b/src/UglyToad.PdfPig/Parser/PageFactory.cs
@@ -41,7 +41,7 @@
                 namedDestinations,
                 ParsingOptions.Logger);
 
-            if (operations == null || operations.Count == 0)
+            if (operations is null || operations.Count == 0)
             {
                 PageContent emptyContent = new PageContent(
                     Array.Empty<IGraphicsStateOperation>(),

--- a/src/UglyToad.PdfPig/Parser/Parts/BruteForceSearcher.cs
+++ b/src/UglyToad.PdfPig/Parser/Parts/BruteForceSearcher.cs
@@ -1,10 +1,10 @@
 ﻿namespace UglyToad.PdfPig.Parser.Parts
 {
+    using Core;
     using System;
     using System.Collections.Generic;
     using System.Globalization;
     using System.Text;
-    using Core;
     using Util.JetBrains.Annotations;
 
     /// <summary>
@@ -22,7 +22,7 @@
         [NotNull]
         public static IReadOnlyDictionary<IndirectReference, long> GetObjectLocations(IInputBytes bytes)
         {
-            if (bytes == null)
+            if (bytes is null)
             {
                 throw new ArgumentNullException(nameof(bytes));
             }
@@ -198,7 +198,7 @@
             return long.MaxValue;
         }
 
-        private static bool IsStartObjMarker(byte[] data)
+        private static bool IsStartObjMarker(ReadOnlySpan<byte> data)
         {
             if (!ReadHelper.IsWhitespace(data[0]))
             {

--- a/src/UglyToad.PdfPig/Parser/Parts/CrossReference/CrossReferenceStreamFieldSize.cs
+++ b/src/UglyToad.PdfPig/Parser/Parts/CrossReference/CrossReferenceStreamFieldSize.cs
@@ -32,7 +32,7 @@
 
         public CrossReferenceStreamFieldSize(DictionaryToken dictionary)
         {
-            if (dictionary == null)
+            if (dictionary is null)
             {
                 throw new ArgumentNullException(nameof(dictionary));
             }

--- a/src/UglyToad.PdfPig/Parser/PdfDocumentFactory.cs
+++ b/src/UglyToad.PdfPig/Parser/PdfDocumentFactory.cs
@@ -236,7 +236,7 @@
 
         private static EncryptionDictionary GetEncryptionDictionary(CrossReferenceTable crossReferenceTable, IPdfTokenScanner pdfTokenScanner)
         {
-            if (crossReferenceTable.Trailer.EncryptionToken == null)
+            if (crossReferenceTable.Trailer.EncryptionToken is null)
             {
                 return null;
             }

--- a/src/UglyToad.PdfPig/PdfFonts/CidFonts/PdfCidCompactFontFormatFont.cs
+++ b/src/UglyToad.PdfPig/PdfFonts/CidFonts/PdfCidCompactFontFormatFont.cs
@@ -25,21 +25,15 @@
                 return FontDetails.GetDefault();
             }
 
-            FontDetails WithWeightValues(bool isbold, int weight) => new FontDetails(null, isbold, weight, font.ItalicAngle != 0);
+            FontDetails WithWeightValues(bool isBold, int weight) => new FontDetails(null, isBold, weight, font.ItalicAngle != 0);
 
-            switch (font.Weight?.ToLowerInvariant())
-            {
-                case "light":
-                    return WithWeightValues(false, 300);
-                case "semibold":
-                    return WithWeightValues(true, 600);
-                case "bold":
-                    return WithWeightValues(true, FontDetails.BoldWeight);
-                case "black":
-                    return WithWeightValues(true, 900);
-                default:
-                    return WithWeightValues(false, FontDetails.DefaultWeight);
-            }
+            return (font.Weight?.ToLowerInvariant()) switch {
+                "light"    => WithWeightValues(false, 300),
+                "semibold" => WithWeightValues(true, 600),
+                "bold"     => WithWeightValues(true, FontDetails.BoldWeight),
+                "black"    => WithWeightValues(true, 900),
+                _          => WithWeightValues(false, FontDetails.DefaultWeight)
+            };
         }
 
         public TransformationMatrix GetFontTransformationMatrix() => fontCollection.GetFirstTransformationMatrix();

--- a/src/UglyToad.PdfPig/PdfFonts/CidFonts/PdfCidCompactFontFormatFont.cs
+++ b/src/UglyToad.PdfPig/PdfFonts/CidFonts/PdfCidCompactFontFormatFont.cs
@@ -20,7 +20,7 @@
 
         private static FontDetails GetDetails(CompactFontFormatFont font)
         {
-            if (font == null)
+            if (font is null)
             {
                 return FontDetails.GetDefault();
             }
@@ -82,7 +82,7 @@
         {
             var font = GetFont();
             var name = font.GetCharacterName(characterCode, true);
-            if (name == null)
+            if (name is null)
             {
                 matrix = null;
                 return false;

--- a/src/UglyToad.PdfPig/PdfFonts/CidFonts/Type0CidFont.cs
+++ b/src/UglyToad.PdfPig/PdfFonts/CidFonts/Type0CidFont.cs
@@ -85,7 +85,7 @@
                 return defaultWidth.Value;
             }
 
-            if (Descriptor == null)
+            if (Descriptor is null)
             {
                 return 1000;
             }
@@ -101,7 +101,7 @@
                 throw new ArgumentException($"The provided character identifier was negative: {characterIdentifier}.");
             }
 
-            if (fontProgram == null)
+            if (fontProgram is null)
             {
                 return Descriptor?.BoundingBox ?? new PdfRectangle(0, 0, 1000, 1.0 / scale);
             }
@@ -138,7 +138,7 @@
 
         public TransformationMatrix GetFontMatrix(int characterIdentifier)
         {
-            if (fontProgram == null)
+            if (fontProgram is null)
             {
                 return FontMatrix;
             }
@@ -149,7 +149,7 @@
         public bool TryGetPath(int characterCode, out IReadOnlyList<PdfSubpath> path)
         {
             path = null;
-            if (fontProgram == null)
+            if (fontProgram is null)
             {
                 return false;
             }
@@ -160,7 +160,7 @@
         public bool TryGetPath(int characterCode, Func<int, int?> characterCodeToGlyphId, out IReadOnlyList<PdfSubpath> path)
         {
             path = null;
-            if (fontProgram == null)
+            if (fontProgram is null)
             {
                 return false;
             }
@@ -171,7 +171,7 @@
         public bool TryGetNormalisedPath(int characterCode, out IReadOnlyList<PdfSubpath> path)
         {
             path = null;
-            if (fontProgram == null)
+            if (fontProgram is null)
             {
                 return false;
             }
@@ -188,7 +188,7 @@
         public bool TryGetNormalisedPath(int characterCode, Func<int, int?> characterCodeToGlyphId, out IReadOnlyList<PdfSubpath> path)
         {
             path = null;
-            if (fontProgram == null)
+            if (fontProgram is null)
             {
                 return false;
             }

--- a/src/UglyToad.PdfPig/PdfFonts/CidFonts/Type2CidFont.cs
+++ b/src/UglyToad.PdfPig/PdfFonts/CidFonts/Type2CidFont.cs
@@ -66,7 +66,7 @@
 
         public double GetWidthFromFont(int characterIdentifier)
         {
-            if (fontProgram == null)
+            if (fontProgram is null)
             {
                 return GetWidthFromDictionary(characterIdentifier);
             }
@@ -97,7 +97,7 @@
 
         public PdfRectangle GetBoundingBox(int characterIdentifier)
         {
-            if (fontProgram == null)
+            if (fontProgram is null)
             {
                 return Descriptor.BoundingBox;
             }
@@ -132,7 +132,7 @@
         public bool TryGetPath(int characterCode, Func<int, int?> characterCodeToGlyphId, out IReadOnlyList<PdfSubpath> path)
         {
             path = null;
-            if (fontProgram == null)
+            if (fontProgram is null)
             {
                 return false;
             }
@@ -148,7 +148,7 @@
         public bool TryGetNormalisedPath(int characterCode, Func<int, int?> characterCodeToGlyphId, out IReadOnlyList<PdfSubpath> path)
         {
             path = null;
-            if (fontProgram == null)
+            if (fontProgram is null)
             {
                 return false;
             }

--- a/src/UglyToad.PdfPig/PdfFonts/Cmap/CMap.cs
+++ b/src/UglyToad.PdfPig/PdfFonts/Cmap/CMap.cs
@@ -73,7 +73,7 @@
             IReadOnlyList<CidRange> cidRanges, 
             IReadOnlyList<CidCharacterMapping> cidCharacterMappings)
         {
-            if (cidCharacterMappings == null)
+            if (cidCharacterMappings is null)
             {
                 throw new ArgumentNullException(nameof(cidCharacterMappings));
             }

--- a/src/UglyToad.PdfPig/PdfFonts/Cmap/CMapCache.cs
+++ b/src/UglyToad.PdfPig/PdfFonts/Cmap/CMapCache.cs
@@ -37,7 +37,7 @@
 
         public static CMap Parse(IInputBytes bytes)
         {
-            if (bytes == null)
+            if (bytes is null)
             {
                 throw new ArgumentNullException(nameof(bytes));
             }

--- a/src/UglyToad.PdfPig/PdfFonts/Cmap/CharacterMapBuilder.cs
+++ b/src/UglyToad.PdfPig/PdfFonts/Cmap/CharacterMapBuilder.cs
@@ -115,17 +115,17 @@
 
         private static IReadOnlyList<T> Combine<T>(IReadOnlyList<T> a, IReadOnlyList<T> b)
         {
-            if (a == null && b == null)
+            if (a is null && b is null)
             {
                 return new T[0];
             }
 
-            if (a == null)
+            if (a is null)
             {
                 return b;
             }
 
-            if (b == null)
+            if (b is null)
             {
                 return a;
             }

--- a/src/UglyToad.PdfPig/PdfFonts/Cmap/CodespaceRange.cs
+++ b/src/UglyToad.PdfPig/PdfFonts/Cmap/CodespaceRange.cs
@@ -50,7 +50,7 @@
         /// </summary>
         public bool Matches(byte[] code)
         {
-            if (code == null)
+            if (code is null)
             {
                 throw new ArgumentNullException(nameof(code));
             }
@@ -63,7 +63,7 @@
         /// </summary>
         public bool IsFullMatch(byte[] code, int codeLength)
         {
-            if (code == null)
+            if (code is null)
             {
                 throw new ArgumentNullException(nameof(code));
             }

--- a/src/UglyToad.PdfPig/PdfFonts/FontStretchExtensions.cs
+++ b/src/UglyToad.PdfPig/PdfFonts/FontStretchExtensions.cs
@@ -6,27 +6,17 @@
     {
         public static FontStretch ConvertToFontStretch(this NameToken name)
         {
-            switch (name.Data)
-            {
-                case "UltraCondensed":
-                    return FontStretch.UltraCondensed;
-                case "ExtraCondensed":
-                    return FontStretch.ExtraCondensed;
-                case "Condensed":
-                    return FontStretch.Condensed;
-                case "Normal":
-                    return FontStretch.Normal;
-                case "SemiExpanded":
-                    return FontStretch.SemiExpanded;
-                case "Expanded":
-                    return FontStretch.Expanded;
-                case "ExtraExpanded":
-                    return FontStretch.ExtraExpanded;
-                case "UltraExpanded":
-                    return FontStretch.UltraExpanded;
-                default:
-                    return FontStretch.Unknown;
-            } 
+            return name.Data switch {
+                "UltraCondensed" => FontStretch.UltraCondensed,
+                "ExtraCondensed" => FontStretch.ExtraCondensed,
+                "Condensed"      => FontStretch.Condensed,
+                "Normal"         => FontStretch.Normal,
+                "SemiExpanded"   => FontStretch.SemiExpanded,
+                "Expanded"       => FontStretch.Expanded,
+                "ExtraExpanded"  => FontStretch.ExtraExpanded,
+                "UltraExpanded"  => FontStretch.UltraExpanded,
+                _                => FontStretch.Unknown
+            };
         }
     }
 }

--- a/src/UglyToad.PdfPig/PdfFonts/Parser/CMapParser.cs
+++ b/src/UglyToad.PdfPig/PdfFonts/Parser/CMapParser.cs
@@ -133,7 +133,7 @@
             var resource = resources.FirstOrDefault(x =>
                 x.EndsWith("CMap." + name, StringComparison.InvariantCultureIgnoreCase));
 
-            if (resource == null)
+            if (resource is null)
             {
                 return false;
             }
@@ -141,7 +141,7 @@
             byte[] bytes;
             using (var stream = typeof(CMapParser).Assembly.GetManifestResourceStream(resource))
             {
-                if (stream == null)
+                if (stream is null)
                 {
                     return false;
                 }

--- a/src/UglyToad.PdfPig/PdfFonts/Parser/EncodingReader.cs
+++ b/src/UglyToad.PdfPig/PdfFonts/Parser/EncodingReader.cs
@@ -57,7 +57,7 @@
 
         private Encoding ReadEncodingDictionary(DictionaryToken encodingDictionary, Encoding fontEncoding)
         {
-            if (encodingDictionary == null)
+            if (encodingDictionary is null)
             {
                 return null;
             }

--- a/src/UglyToad.PdfPig/PdfFonts/Parser/Handlers/TrueTypeFontHandler.cs
+++ b/src/UglyToad.PdfPig/PdfFonts/Parser/Handlers/TrueTypeFontHandler.cs
@@ -57,7 +57,7 @@
                 // Can use the AFM descriptor despite not being Type 1!
                 var standard14Font = Standard14.GetAdobeFontMetrics(baseFont.Data);
 
-                if (standard14Font == null)
+                if (standard14Font is null)
                 {
                     throw new InvalidFontFormatException($"The provided TrueType font dictionary did not have a /FirstChar and did not match a Standard 14 font: {dictionary}.");
                 }
@@ -66,7 +66,7 @@
 
                 var thisEncoding = encodingReader.Read(dictionary);
 
-                if (thisEncoding == null)
+                if (thisEncoding is null)
                 {
                     thisEncoding = new AdobeFontMetricsEncoding(standard14Font);
                 }
@@ -97,7 +97,7 @@
 
             var font = ParseTrueTypeFont(descriptor, out var actualHandler);
 
-            if (font == null && actualHandler != null)
+            if (font is null && actualHandler != null)
             {
                 return actualHandler.Generate(dictionary);
             }
@@ -126,7 +126,7 @@
 
             Encoding encoding = encodingReader.Read(dictionary, descriptor);
 
-            if (encoding == null && font?.TableRegister?.CMapTable != null
+            if (encoding is null && font?.TableRegister?.CMapTable != null
                                  && font.TableRegister.PostScriptTable?.GlyphNames != null)
             {
                 var postscript = font.TableRegister.PostScriptTable;
@@ -161,7 +161,7 @@
         {
             actualHandler = null;
 
-            if (descriptor.FontFile == null)
+            if (descriptor.FontFile is null)
             {
                 try
                 {

--- a/src/UglyToad.PdfPig/PdfFonts/Parser/Handlers/Type0FontHandler.cs
+++ b/src/UglyToad.PdfPig/PdfFonts/Parser/Handlers/Type0FontHandler.cs
@@ -193,7 +193,7 @@
 
             var encodingName = dictionary.GetNameOrDefault(NameToken.Encoding);
 
-            if (encodingName == null)
+            if (encodingName is null)
             {
                 return (null, false);
             }

--- a/src/UglyToad.PdfPig/PdfFonts/Parser/Handlers/Type1FontHandler.cs
+++ b/src/UglyToad.PdfPig/PdfFonts/Parser/Handlers/Type1FontHandler.cs
@@ -116,7 +116,7 @@
 
             var encoding = encodingReader.Read(dictionary, descriptor, fromFont);
 
-            if (encoding == null && font != null && font.TryGetFirst(out var t1FontReplacment))
+            if (encoding is null && font != null && font.TryGetFirst(out var t1FontReplacment))
             {
                 encoding = new BuiltInEncoding(t1FontReplacment.Encoding);
             }
@@ -126,7 +126,7 @@
 
         private Union<Type1Font, CompactFontFormatFontCollection> ParseFontProgram(FontDescriptor descriptor)
         {
-            if (descriptor?.FontFile == null)
+            if (descriptor?.FontFile is null)
             {
                 return null;
             }

--- a/src/UglyToad.PdfPig/PdfFonts/Parser/Parts/CidFontFactory.cs
+++ b/src/UglyToad.PdfPig/PdfFonts/Parser/Parts/CidFontFactory.cs
@@ -90,14 +90,14 @@
 
         private ICidFontProgram ReadDescriptorFile(FontDescriptor descriptor)
         {
-            if (descriptor?.FontFile == null)
+            if (descriptor?.FontFile is null)
             {
                 return null;
             }
 
             var fontFileStream = DirectObjectFinder.Get<StreamToken>(descriptor.FontFile.ObjectKey, pdfScanner);
 
-            if (fontFileStream == null)
+            if (fontFileStream is null)
             {
                 return null;
             }

--- a/src/UglyToad.PdfPig/PdfFonts/Parser/Parts/FontDescriptorFactory.cs
+++ b/src/UglyToad.PdfPig/PdfFonts/Parser/Parts/FontDescriptorFactory.cs
@@ -11,7 +11,7 @@
     {
         public static FontDescriptor Generate(DictionaryToken dictionary, IPdfTokenScanner pdfScanner)
         {
-            if (dictionary == null)
+            if (dictionary is null)
             {
                 throw new ArgumentNullException(nameof(dictionary));
             }

--- a/src/UglyToad.PdfPig/PdfFonts/Simple/TrueTypeSimpleFont.cs
+++ b/src/UglyToad.PdfPig/PdfFonts/Simple/TrueTypeSimpleFont.cs
@@ -87,7 +87,7 @@
                 return true;
             }
 
-            if (encoding == null)
+            if (encoding is null)
             {
                 return false;
             }
@@ -194,7 +194,7 @@
         {
             fromFont = true;
 
-            if (font == null)
+            if (font is null)
             {
                 return descriptor.BoundingBox;
             }
@@ -221,11 +221,11 @@
                 return (value & target) == target;
             }
 
-            if (descriptor == null || !unicodeValuesCache.TryGetValue(characterCode, out var unicode)
-                                   || font.TableRegister.CMapTable == null
-                                   || encoding == null
+            if (descriptor is null || !unicodeValuesCache.TryGetValue(characterCode, out var unicode)
+                                   || font.TableRegister.CMapTable is null
+                                   || encoding is null
                                    || !encoding.CodeToNameMap.TryGetValue(characterCode, out var name)
-                                   || name == null)
+                                   || name is null)
             {
                 return null;
             }
@@ -326,7 +326,7 @@
         /// <inheritdoc/>
         public bool TryGetPath(int characterCode, out IReadOnlyList<PdfSubpath> path)
         {
-            if (font == null)
+            if (font is null)
             {
                 path = null;
                 return false;

--- a/src/UglyToad.PdfPig/PdfFonts/Simple/TrueTypeStandard14FallbackSimpleFont.cs
+++ b/src/UglyToad.PdfPig/PdfFonts/Simple/TrueTypeStandard14FallbackSimpleFont.cs
@@ -37,7 +37,7 @@
             this.font = font;
             this.overrides = overrides;
             Name = name;
-            Details = fontMetrics == null ? FontDetails.GetDefault(Name?.Data) : new FontDetails(Name?.Data,
+            Details = fontMetrics is null ? FontDetails.GetDefault(Name?.Data) : new FontDetails(Name?.Data,
                 fontMetrics.Weight == "Bold",
                 fontMetrics.Weight == "Bold" ? 700 : FontDetails.DefaultWeight,
                 fontMetrics.ItalicAngle != 0);
@@ -137,7 +137,7 @@
         public bool TryGetPath(int characterCode, out IReadOnlyList<PdfSubpath> path)
         {
             path = null;
-            if (font == null)
+            if (font is null)
             {
                 return false;
             }

--- a/src/UglyToad.PdfPig/Tokenization/Scanner/ObjectLocationProvider.cs
+++ b/src/UglyToad.PdfPig/Tokenization/Scanner/ObjectLocationProvider.cs
@@ -55,7 +55,7 @@
                 return true;
             }
 
-            if (bruteForcedOffsets == null)
+            if (bruteForcedOffsets is null)
             {
                 bruteForcedOffsets = BruteForceSearcher.GetObjectLocations(bytes);
             }
@@ -75,7 +75,7 @@
 
         public void Cache(ObjectToken objectToken, bool force = false)
         {
-            if (objectToken == null)
+            if (objectToken is null)
             {
                 throw new ArgumentNullException();
             }

--- a/src/UglyToad.PdfPig/UglyToad.PdfPig.csproj
+++ b/src/UglyToad.PdfPig/UglyToad.PdfPig.csproj
@@ -7,6 +7,7 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\pdfpig.snk</AssemblyOriginatorKeyFile>
+    <Nullable>annotations</Nullable>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|netstandard2.0|AnyCPU'">
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/src/UglyToad.PdfPig/Util/Adler32Checksum.cs
+++ b/src/UglyToad.PdfPig/Util/Adler32Checksum.cs
@@ -1,6 +1,6 @@
 ﻿namespace UglyToad.PdfPig.Util
 {
-    using System.Collections.Generic;
+    using System;
 
     /// <summary>
     /// Used to calculate the Adler-32 checksum used for ZLIB data in accordance with 
@@ -14,7 +14,7 @@
         /// <summary>
         /// Calculate the Adler-32 checksum for some data.
         /// </summary>
-        public static int Calculate(IEnumerable<byte> data)
+        public static int Calculate(ReadOnlySpan<byte> data)
         {
             // s1 is the sum of all bytes.
             var s1 = 1;

--- a/src/UglyToad.PdfPig/Util/Annotations.cs
+++ b/src/UglyToad.PdfPig/Util/Annotations.cs
@@ -138,7 +138,7 @@ SOFTWARE. */
         /// </summary>
         /// <example><code>
         /// void Foo(string param) {
-        ///   if (param == null)
+        ///   if (param is null)
         ///     throw new ArgumentNullException("par"); // Warning: Cannot resolve symbol
         /// }
         /// </code></example>

--- a/src/UglyToad.PdfPig/Util/ArrayHelper.cs
+++ b/src/UglyToad.PdfPig/Util/ArrayHelper.cs
@@ -6,7 +6,7 @@
     {
         public static void Fill<T>(T[] array, int start, int end, T value)
         {
-            if (array == null)
+            if (array is null)
             {
                 throw new ArgumentNullException(nameof(array));
             }

--- a/src/UglyToad.PdfPig/Util/ColorSpaceDetailsParser.cs
+++ b/src/UglyToad.PdfPig/Util/ColorSpaceDetailsParser.cs
@@ -85,7 +85,7 @@
 
                         var first = colorSpaceArray[0] as NameToken;
 
-                        if (first == null || !ColorSpaceMapper.TryMap(first, resourceStore, out var innerColorSpace)
+                        if (first is null || !ColorSpaceMapper.TryMap(first, resourceStore, out var innerColorSpace)
                             || innerColorSpace != ColorSpace.CalGray)
                         {
                             return UnsupportedColorSpaceDetails.Instance;
@@ -128,7 +128,7 @@
 
                         var first = colorSpaceArray[0] as NameToken;
 
-                        if (first == null || !ColorSpaceMapper.TryMap(first, resourceStore, out var innerColorSpace)
+                        if (first is null || !ColorSpaceMapper.TryMap(first, resourceStore, out var innerColorSpace)
                             || innerColorSpace != ColorSpace.CalRGB)
                         {
                             return UnsupportedColorSpaceDetails.Instance;
@@ -178,7 +178,7 @@
 
                         var first = colorSpaceArray[0] as NameToken;
 
-                        if (first == null || !ColorSpaceMapper.TryMap(first, resourceStore, out var innerColorSpace)
+                        if (first is null || !ColorSpaceMapper.TryMap(first, resourceStore, out var innerColorSpace)
                             || innerColorSpace != ColorSpace.Lab)
                         {
                             return UnsupportedColorSpaceDetails.Instance;
@@ -221,7 +221,7 @@
 
                         var first = colorSpaceArray[0] as NameToken;
 
-                        if (first == null || !ColorSpaceMapper.TryMap(first, resourceStore, out var innerColorSpace)
+                        if (first is null || !ColorSpaceMapper.TryMap(first, resourceStore, out var innerColorSpace)
                             || innerColorSpace != ColorSpace.ICCBased)
                         {
                             return UnsupportedColorSpaceDetails.Instance;
@@ -277,7 +277,7 @@
 
                         var first = colorSpaceArray[0] as NameToken;
 
-                        if (first == null || !ColorSpaceMapper.TryMap(first, resourceStore, out var innerColorSpace)
+                        if (first is null || !ColorSpaceMapper.TryMap(first, resourceStore, out var innerColorSpace)
                             || innerColorSpace != ColorSpace.Indexed)
                         {
                             return UnsupportedColorSpaceDetails.Instance;

--- a/src/UglyToad.PdfPig/Util/DateFormatHelper.cs
+++ b/src/UglyToad.PdfPig/Util/DateFormatHelper.cs
@@ -35,7 +35,7 @@
                 return val >= min && val <= max;
             }
 
-            if (s == null || s.Length < 4)
+            if (s is null || s.Length < 4)
             {
                 return false;
             }

--- a/src/UglyToad.PdfPig/Util/DefaultWordExtractor.cs
+++ b/src/UglyToad.PdfPig/Util/DefaultWordExtractor.cs
@@ -38,7 +38,7 @@
                     lastX = letter.Location.X;
                 }
 
-                if (lastLetter == null)
+                if (lastLetter is null)
                 {
                     if (string.IsNullOrWhiteSpace(letter.Value))
                     {

--- a/src/UglyToad.PdfPig/Util/Diacritics.cs
+++ b/src/UglyToad.PdfPig/Util/Diacritics.cs
@@ -43,7 +43,7 @@
         {
             result = null;
 
-            if (previous == null)
+            if (previous is null)
             {
                 return false;
             }

--- a/src/UglyToad.PdfPig/Util/DictionaryTokenExtensions.cs
+++ b/src/UglyToad.PdfPig/Util/DictionaryTokenExtensions.cs
@@ -38,7 +38,7 @@
 
         public static int GetInt(this DictionaryToken token, NameToken name)
         {
-            if (token == null)
+            if (token is null)
             {
                 throw new ArgumentNullException(nameof(token));
             }
@@ -50,7 +50,7 @@
 
         public static int GetIntOrDefault(this DictionaryToken token, NameToken name, int defaultValue = 0)
         {
-            if (token == null)
+            if (token is null)
             {
                 throw new ArgumentNullException(nameof(token));
             }
@@ -62,7 +62,7 @@
 
         public static int GetIntOrDefault(this DictionaryToken token, NameToken first, NameToken second, int defaultValue = 0)
         {
-            if (token == null)
+            if (token is null)
             {
                 throw new ArgumentNullException(nameof(token));
             }
@@ -74,7 +74,7 @@
 
         public static long? GetLongOrDefault(this DictionaryToken token, NameToken name)
         {
-            if (token == null)
+            if (token is null)
             {
                 throw new ArgumentNullException(nameof(token));
             }
@@ -86,7 +86,7 @@
 
         public static bool GetBooleanOrDefault(this DictionaryToken token, NameToken name, bool defaultValue)
         {
-            if (token == null)
+            if (token is null)
             {
                 throw new ArgumentNullException(nameof(token));
             }
@@ -99,7 +99,7 @@
         [CanBeNull]
         public static NameToken GetNameOrDefault(this DictionaryToken token, NameToken name)
         {
-            if (token == null)
+            if (token is null)
             {
                 throw new ArgumentNullException(nameof(token));
             }
@@ -142,7 +142,7 @@
     {
         public static NumericToken GetNumeric(this ArrayToken array, int index)
         {
-            if (array == null)
+            if (array is null)
             {
                 throw new ArgumentNullException(nameof(array));
             }
@@ -162,7 +162,7 @@
 
         public static PdfRectangle ToRectangle(this ArrayToken array, IPdfTokenScanner tokenScanner)
         {
-            if (array == null)
+            if (array is null)
             {
                 throw new ArgumentNullException(nameof(array));
             }
@@ -180,7 +180,7 @@
 
         public static PdfRectangle ToIntRectangle(this ArrayToken array, IPdfTokenScanner tokenScanner)
         {
-            if (array == null)
+            if (array is null)
             {
                 throw new ArgumentNullException(nameof(array));
             }

--- a/src/UglyToad.PdfPig/Util/Hex.cs
+++ b/src/UglyToad.PdfPig/Util/Hex.cs
@@ -23,11 +23,6 @@
         /// </summary>
         public static string GetString(ReadOnlySpan<byte> bytes)
         {
-            if (bytes == null)
-            {
-                throw new ArgumentNullException(nameof(bytes));
-            }
-
             var stringBuilder = new StringBuilder(bytes.Length * 2);
 
             foreach (var b in bytes)

--- a/src/UglyToad.PdfPig/Util/InternalStringExtensions.cs
+++ b/src/UglyToad.PdfPig/Util/InternalStringExtensions.cs
@@ -11,9 +11,9 @@
                 throw new ArgumentOutOfRangeException(nameof(offset), $"Offset cannot be negative: {offset}");
             }
 
-            if (value == null)
+            if (value is null)
             {
-                if (start == null && offset == 0)
+                if (start is null && offset == 0)
                 {
                     return true;
                 }

--- a/src/UglyToad.PdfPig/Util/Matrix3x3.cs
+++ b/src/UglyToad.PdfPig/Util/Matrix3x3.cs
@@ -162,7 +162,7 @@ namespace UglyToad.PdfPig.Util
 
         public bool Equals(Matrix3x3 other)
         {
-            if (other == null)
+            if (other is null)
             { 
                 return false;
             }

--- a/src/UglyToad.PdfPig/Util/PatternParser.cs
+++ b/src/UglyToad.PdfPig/Util/PatternParser.cs
@@ -57,17 +57,13 @@
                 // optional
             }
 
-            switch (patternType)
-            {
-                case 1: // Tiling
-                    return CreateTilingPattern(patternStream, patternExtGState, matrix, scanner);
-
-                case 2: // Shading
-                    return CreateShadingPattern(patternDictionary, patternExtGState, matrix, scanner, resourceStore, filterProvider);
-
-                default:
-                    throw new PdfDocumentFormatException($"Invalid Pattern type encountered in page resource dictionary: {patternType}.");
-            }
+            return patternType switch {
+                // Tiling
+                1 => CreateTilingPattern(patternStream, patternExtGState, matrix, scanner),
+                // Shading
+                2 => CreateShadingPattern(patternDictionary, patternExtGState, matrix, scanner, resourceStore, filterProvider),
+                _ => throw new PdfDocumentFormatException($"Invalid Pattern type encountered in page resource dictionary: {patternType}.")
+            };
         }
 
         private static PatternColor CreateTilingPattern(StreamToken patternStream, DictionaryToken patternExtGState,

--- a/src/UglyToad.PdfPig/Util/PatternParser.cs
+++ b/src/UglyToad.PdfPig/Util/PatternParser.cs
@@ -47,7 +47,7 @@
             else
             {
                 // optional - Default value: the identity matrix [1 0 0 1 0 0]
-                matrix = TransformationMatrix.FromArray(new double[] { 1, 0, 0, 1, 0, 0 });
+                matrix = TransformationMatrix.FromArray([1, 0, 0, 1, 0, 0]);
             }
 
             DictionaryToken patternExtGState = null;

--- a/src/UglyToad.PdfPig/Util/PdfFunctionParser.cs
+++ b/src/UglyToad.PdfPig/Util/PdfFunctionParser.cs
@@ -42,7 +42,7 @@
             switch (functionType)
             {
                 case 0:
-                    if (functionStream == null)
+                    if (functionStream is null)
                     {
                         throw new NotImplementedException("PdfFunctionType0 not stream");
                     }
@@ -55,7 +55,7 @@
                     return CreatePdfFunctionType3(functionDictionary, domain, range, scanner, filterProvider);
 
                 case 4:
-                    if (functionStream == null)
+                    if (functionStream is null)
                     {
                         throw new NotImplementedException("PdfFunctionType4 not stream");
                     }
@@ -68,7 +68,7 @@
 
         private static PdfFunctionType0 CreatePdfFunctionType0(StreamToken functionStream, ArrayToken domain, ArrayToken range, IPdfTokenScanner scanner)
         {
-            if (range == null)
+            if (range is null)
             {
                 throw new ArgumentException("Could not retrieve Range in type 0 function.");
             }
@@ -89,7 +89,7 @@
                 order = orderToken.Int;
             }
 
-            if (!functionStream.StreamDictionary.TryGet<ArrayToken>(NameToken.Encode, scanner, out var encode) || encode == null)
+            if (!functionStream.StreamDictionary.TryGet<ArrayToken>(NameToken.Encode, scanner, out var encode) || encode is null)
             {
                 // The default value is [0 (size[0]-1) 0 (size[1]-1) ...]
                 var values = new List<NumericToken>();
@@ -102,7 +102,7 @@
                 encode = new ArrayToken(values);
             }
 
-            if (!functionStream.StreamDictionary.TryGet<ArrayToken>(NameToken.Decode, scanner, out var decode) || decode == null)
+            if (!functionStream.StreamDictionary.TryGet<ArrayToken>(NameToken.Decode, scanner, out var decode) || decode is null)
             {
                 // if decode is null, the default values are the range values
                 decode = range;
@@ -172,7 +172,7 @@
 
         private static PdfFunctionType4 CreatePdfFunctionType4(StreamToken functionStream, ArrayToken domain, ArrayToken range, IPdfTokenScanner scanner)
         {
-            if (range == null)
+            if (range is null)
             {
                 throw new ArgumentException("Could not retrieve Range in type 4 function.");
             }

--- a/src/UglyToad.PdfPig/Util/ShadingParser.cs
+++ b/src/UglyToad.PdfPig/Util/ShadingParser.cs
@@ -15,8 +15,8 @@
     {
         public static Shading Create(IToken shading, IPdfTokenScanner scanner, IResourceStore resourceStore, ILookupFilterProvider filterProvider)
         {
-            DictionaryToken shadingDictionary = null;
-            StreamToken shadingStream = null;
+            DictionaryToken? shadingDictionary = null;
+            StreamToken? shadingStream = null;
 
             if (shading is StreamToken fs)
             {
@@ -28,8 +28,7 @@
                 shadingDictionary = fd;
             }
 
-            ShadingType shadingType;
-            if (shadingDictionary.TryGet<NumericToken>(NameToken.ShadingType, scanner, out var shadingTypeToken))
+            if (shadingDictionary.TryGet<NumericToken>(NameToken.ShadingType, scanner, out ShadingType shadingTypeToken))
             {
                 // Shading types 4 to 7 shall be defined by a stream containing descriptive data characterizing
                 // the shading's gradient fill.
@@ -140,7 +139,7 @@
             else
             {
                 // Optional - Default value: [0.0 1.0 0.0 1.0].
-                domain = new double[] { 0.0, 1.0, 0.0, 1.0 };
+                domain = [0.0, 1.0, 0.0, 1.0];
             }
 
             TransformationMatrix matrix;
@@ -151,7 +150,7 @@
             else
             {
                 // Optional - Default value: the identity matrix [1 0 0 1 0 0]
-                matrix = TransformationMatrix.FromArray(new double[] { 1, 0, 0, 1, 0, 0 });
+                matrix = TransformationMatrix.FromArray([1, 0, 0, 1, 0, 0]);
             }
 
             if (!shadingDictionary.ContainsKey(NameToken.Function))
@@ -185,7 +184,7 @@
             else
             {
                 // set default values
-                domain = new double[] { 0, 1 };
+                domain = [0, 1];
             }
 
             if (!shadingDictionary.ContainsKey(NameToken.Function))
@@ -207,7 +206,7 @@
         private static RadialShading CreateRadialShading(DictionaryToken shadingDictionary, ColorSpaceDetails colorSpace,
             double[] background, PdfRectangle? bbox, bool antiAlias, IPdfTokenScanner scanner, ILookupFilterProvider filterProvider)
         {
-            double[] coords = null;
+            double[]? coords = null;
             if (shadingDictionary.TryGet<ArrayToken>(NameToken.Coords, scanner, out var coordsToken))
             {
                 coords = coordsToken.Data.OfType<NumericToken>().Select(v => v.Double).ToArray();
@@ -225,7 +224,7 @@
             else
             {
                 // set default values
-                domain = new double[] { 0, 1 };
+                domain = [0, 1];
             }
 
             if (!shadingDictionary.ContainsKey(NameToken.Function))
@@ -235,7 +234,7 @@
 
             PdfFunction[] functions = GetFunctions(shadingDictionary.Data[NameToken.Function], scanner, filterProvider);
 
-            bool[] extend = new bool[] { false, false }; // Default values
+            bool[] extend = [false, false]; // Default values
             if (shadingDictionary.TryGet<ArrayToken>(NameToken.Extend, scanner, out var extendToken))
             {
                 extend = extendToken.Data.OfType<BooleanToken>().Select(v => v.Data).ToArray();
@@ -287,7 +286,7 @@
                 throw new ArgumentNullException($"{NameToken.Decode} is required for shading type '{ShadingType.FreeFormGouraud}'.");
             }
 
-            PdfFunction[] functions = null; // Optional
+            PdfFunction[]? functions = null; // Optional
             if (shadingStream.StreamDictionary.ContainsKey(NameToken.Function))
             {
                 functions = GetFunctions(shadingStream.StreamDictionary.Data[NameToken.Function], scanner, filterProvider);

--- a/src/UglyToad.PdfPig/Util/ShadingParser.cs
+++ b/src/UglyToad.PdfPig/Util/ShadingParser.cs
@@ -28,11 +28,12 @@
                 shadingDictionary = fd;
             }
 
-            if (shadingDictionary.TryGet<NumericToken>(NameToken.ShadingType, scanner, out ShadingType shadingTypeToken))
+            ShadingType shadingType;
+            if (shadingDictionary.TryGet<NumericToken>(NameToken.ShadingType, scanner, out var shadingTypeToken))
             {
                 // Shading types 4 to 7 shall be defined by a stream containing descriptive data characterizing
                 // the shading's gradient fill.
-                if (shadingTypeToken.Int >= 4 && shadingStream == null)
+                if (shadingTypeToken.Int >= 4 && shadingStream is null)
                 {
                     throw new ArgumentNullException(nameof(shadingStream), $"Shading type '{(ShadingType)shadingTypeToken.Int}' is not properly defined. Shading types 4 to 7 shall be defined by a stream.");
                 }

--- a/src/UglyToad.PdfPig/Writer/Colors/ProfileStreamReader.cs
+++ b/src/UglyToad.PdfPig/Writer/Colors/ProfileStreamReader.cs
@@ -14,7 +14,7 @@
             var resource = resources.FirstOrDefault(x =>
                 x.EndsWith("sRGB2014.icc", StringComparison.InvariantCultureIgnoreCase));
 
-            if (resource == null)
+            if (resource is null)
             {
                 throw new InvalidOperationException("Could not find the sRGB ICC color profile stream.");
             }

--- a/src/UglyToad.PdfPig/Writer/Fonts/Standard14WritingFont.cs
+++ b/src/UglyToad.PdfPig/Writer/Fonts/Standard14WritingFont.cs
@@ -38,7 +38,7 @@
                                    .Where(v => v.Value.CharacterCode == code)
                                    .Select(v => v.Value)
                                    .FirstOrDefault();
-            if (characterMetric == null)
+            if (characterMetric is null)
             {
                 Debug.WriteLine($"Font '{metrics.FontName}' does NOT have character '{character}' (0x{(int)character:X}).");
                 return false;
@@ -106,7 +106,7 @@
                                     .Where(v => v.Value.CharacterCode == characterCode)
                                     .Select(v => v.Value)
                                     .FirstOrDefault();
-            if (characterMetric == null)
+            if (characterMetric is null)
             {
                 throw new NotSupportedException($"Font '{metrics.FontName}' does NOT have character '{character}' (0x{(int)character:X}).");
             }

--- a/src/UglyToad.PdfPig/Writer/Fonts/TrueTypeWritingFont.cs
+++ b/src/UglyToad.PdfPig/Writer/Fonts/TrueTypeWritingFont.cs
@@ -80,7 +80,7 @@
             };
 
             var os2 = font.TableRegister.Os2Table;
-            if (os2 == null)
+            if (os2 is null)
             {
                 throw new InvalidFontFormatException("Embedding TrueType font requires OS/2 table.");
             }

--- a/src/UglyToad.PdfPig/Writer/PdfDocumentBuilder.cs
+++ b/src/UglyToad.PdfPig/Writer/PdfDocumentBuilder.cs
@@ -133,7 +133,7 @@ namespace UglyToad.PdfPig.Writer
             reasons = reasonsMutable;
             try
             {
-                if (fontFileBytes == null)
+                if (fontFileBytes is null)
                 {
                     reasonsMutable.Add("Provided bytes were null.");
                     return false;
@@ -147,19 +147,19 @@ namespace UglyToad.PdfPig.Writer
 
                 var font = TrueTypeFontParser.Parse(new TrueTypeDataBytes(new ByteArrayInputBytes(fontFileBytes)));
 
-                if (font.TableRegister.CMapTable == null)
+                if (font.TableRegister.CMapTable is null)
                 {
                     reasonsMutable.Add("The provided font did not contain a cmap table, used to map character codes to glyph codes.");
                     return false;
                 }
 
-                if (font.TableRegister.Os2Table == null)
+                if (font.TableRegister.Os2Table is null)
                 {
                     reasonsMutable.Add("The provided font did not contain an OS/2 table, used to fill in the font descriptor dictionary.");
                     return false;
                 }
 
-                if (font.TableRegister.PostScriptTable == null)
+                if (font.TableRegister.PostScriptTable is null)
                 {
                     reasonsMutable.Add("The provided font did not contain a post PostScript table, used to map character codes to glyph codes.");
                     return false;
@@ -248,7 +248,7 @@ namespace UglyToad.PdfPig.Writer
                 }
             }
 
-            if (builder == null)
+            if (builder is null)
             {
                 builder = new PdfPageBuilder(pages.Count + 1, this);
             }
@@ -436,7 +436,7 @@ namespace UglyToad.PdfPig.Writer
                     if (kvp.Value is IndirectReferenceToken ir)
                     {
                         ObjectToken tk = document.Structure.TokenScanner.Get(ir.Data);
-                        if (tk == null)
+                        if (tk is null)
                         {
                             // malformed
                             continue;
@@ -455,7 +455,7 @@ namespace UglyToad.PdfPig.Writer
                     foreach (var annot in arr.Data)
                     {
                         DictionaryToken tk = GetRemoteDict(annot);
-                        if (tk == null)
+                        if (tk is null)
                         {
                             // malformed
                             continue;
@@ -463,21 +463,21 @@ namespace UglyToad.PdfPig.Writer
 
                         if (tk.TryGet(NameToken.Subtype, out var st) && st is NameToken nm && nm == NameToken.Link)
                         {
-                            if (copyLink == null)
+                            if (copyLink is null)
                             {
                                 // ingore link if don't know how to copy
                                 continue;
                             }
 
                             var link = page.annotationProvider.GetAction(tk);
-                            if (link == null)
+                            if (link is null)
                             {
                                 // ignore unknown link actions
                                 continue;
                             }
 
                             var copiedLink = copyLink(link);
-                            if (copiedLink == null)
+                            if (copiedLink is null)
                             {
                                 // ignore if caller wants to skip the link
                                 continue;
@@ -513,7 +513,7 @@ namespace UglyToad.PdfPig.Writer
             void CopyResourceDict(IToken token, Dictionary<NameToken, IToken> destinationDict)
             {
                 DictionaryToken dict = GetRemoteDict(token);
-                if (dict == null)
+                if (dict is null)
                 {
                     return;
                 }
@@ -545,7 +545,7 @@ namespace UglyToad.PdfPig.Writer
 
                     var subDict = GetRemoteDict(item.Value);
                     var destSubDict = destinationDict[NameToken.Create(item.Key)] as DictionaryToken;
-                    if (destSubDict == null || subDict == null)
+                    if (destSubDict is null || subDict is null)
                     {
                         // not a dict.. just overwrite with more important one? should maybe check arrays?
                         if (item.Value is IndirectReferenceToken ir)
@@ -1144,7 +1144,7 @@ namespace UglyToad.PdfPig.Writer
 
                 foreach (var pair in CustomMetadata)
                 {
-                    if (pair.Key == null || pair.Value == null)
+                    if (pair.Key is null || pair.Value is null)
                     {
                         continue;
                     }

--- a/src/UglyToad.PdfPig/Writer/PdfMerger.cs
+++ b/src/UglyToad.PdfPig/Writer/PdfMerger.cs
@@ -155,7 +155,7 @@
 
                     var basePageNumber = document.Pages.Count;
 
-                    if (pages == null)
+                    if (pages is null)
                     {
                         for (var i = 1; i <= existing.NumberOfPages; i++)
                         {
@@ -182,14 +182,14 @@
             PdfAction CopyLink(PdfAction action, Func<int, int?> getPageNumber)
             {
                 var link = action as AbstractGoToAction;
-                if (link == null)
+                if (link is null)
                 {
                     // copy the link if it is not a link to PDF documents
                     return action;
                 }
 
                 var newPageNumber = getPageNumber(link.Destination.PageNumber);
-                if (newPageNumber == null)
+                if (newPageNumber is null)
                 {
                     // ignore the link if the target page does not exist in the PDF document
                     return null;

--- a/src/UglyToad.PdfPig/Writer/PdfPageBuilder.cs
+++ b/src/UglyToad.PdfPig/Writer/PdfPageBuilder.cs
@@ -36,7 +36,7 @@
 
         private string ExtractPrefix(string name)
         {
-            if (name == null)
+            if (name is null)
                 return prefix;
             var i = 0;
             while (i < name.Length && (name[i] < '0' || name[i] > '9'))
@@ -431,12 +431,12 @@
         /// <returns>The letters from the input text with their corresponding size and position.</returns>
         public IReadOnlyList<Letter> MeasureText(string text, double fontSize, PdfPoint position, PdfDocumentBuilder.AddedFont font)
         {
-            if (font == null)
+            if (font is null)
             {
                 throw new ArgumentNullException(nameof(font));
             }
 
-            if (text == null)
+            if (text is null)
             {
                 throw new ArgumentNullException(nameof(text));
             }
@@ -476,12 +476,12 @@
         /// <returns>The letters from the input text with their corresponding size and position.</returns>
         public IReadOnlyList<Letter> AddText(string text, double fontSize, PdfPoint position, PdfDocumentBuilder.AddedFont font)
         {
-            if (font == null)
+            if (font is null)
             {
                 throw new ArgumentNullException(nameof(font));
             }
 
-            if (text == null)
+            if (text is null)
             {
                 throw new ArgumentNullException(nameof(text));
             }

--- a/src/UglyToad.PdfPig/Writer/PdfTextRemover.cs
+++ b/src/UglyToad.PdfPig/Writer/PdfTextRemover.cs
@@ -86,7 +86,7 @@ namespace UglyToad.PdfPig.Writer
             var tokenWriter = new NoTextTokenWriter();
             using (var document = new PdfDocumentBuilder(output, false, PdfWriterType.Default, file.Version, tokenWriter: tokenWriter))
             {
-                if (pagesBundle == null)
+                if (pagesBundle is null)
                 {
                     for (var i = 1; i <= file.NumberOfPages; i++)
                     {

--- a/src/UglyToad.PdfPig/Writer/TokenWriter.cs
+++ b/src/UglyToad.PdfPig/Writer/TokenWriter.cs
@@ -92,7 +92,7 @@
         /// <param name="outputStream">The stream to write the token to.</param>
         public void WriteToken(IToken token, Stream outputStream)
         {
-            if (token == null)
+            if (token is null)
             {
                 WriteNullToken(outputStream);
                 return;
@@ -378,7 +378,7 @@
                 WriteName(pair.Key, outputStream);
 
                 // handle scenario where PdfPig has a null value under some circumstances
-                if (pair.Value == null)
+                if (pair.Value is null)
                 {
                     WriteToken(NullToken.Instance, outputStream);
                 }

--- a/src/UglyToad.PdfPig/Writer/WriterUtil.cs
+++ b/src/UglyToad.PdfPig/Writer/WriterUtil.cs
@@ -74,7 +74,7 @@
         public static IToken CopyToken(IPdfStreamWriter writer, IToken tokenToCopy, IPdfTokenScanner tokenScanner,
             IDictionary<IndirectReference, IndirectReferenceToken> referencesFromDocument, Dictionary<IndirectReference, IndirectReferenceToken> callstack=null)
         {
-            if (callstack == null)
+            if (callstack is null)
             {
                 callstack = new Dictionary<IndirectReference, IndirectReferenceToken>();
             }
@@ -111,7 +111,7 @@
                             return newReferenceToken;
                         }
 
-                        if (callstack.ContainsKey(referenceToken.Data) && callstack[referenceToken.Data] == null)
+                        if (callstack.ContainsKey(referenceToken.Data) && callstack[referenceToken.Data] is null)
                         {
                             newReferenceToken = writer.ReserveObjectNumber();
                             callstack[referenceToken.Data] = newReferenceToken;
@@ -166,7 +166,7 @@
 
         internal static IEnumerable<(DictionaryToken, IReadOnlyList<DictionaryToken>)> WalkTree(PageTreeNode node, List<DictionaryToken> parents=null)
         {
-            if (parents == null)
+            if (parents is null)
             {
                 parents = new List<DictionaryToken>();
             }

--- a/src/UglyToad.PdfPig/Writer/Xmp/XmpWriter.cs
+++ b/src/UglyToad.PdfPig/Writer/Xmp/XmpWriter.cs
@@ -111,7 +111,7 @@ namespace UglyToad.PdfPig.Writer.Xmp
             {
                 var value = mapper.ValueFunc(builder);
 
-                if (value == null)
+                if (value is null)
                 {
                     continue;
                 }

--- a/src/UglyToad.PdfPig/XObjects/XObjectFactory.cs
+++ b/src/UglyToad.PdfPig/XObjects/XObjectFactory.cs
@@ -25,7 +25,7 @@
             ILookupFilterProvider filterProvider,
             IResourceStore resourceStore)
         {
-            if (xObject == null)
+            if (xObject is null)
             {
                 throw new ArgumentNullException(nameof(xObject));
             }

--- a/src/UglyToad.PdfPig/XObjects/XObjectImage.cs
+++ b/src/UglyToad.PdfPig/XObjects/XObjectImage.cs
@@ -99,7 +99,7 @@
         public bool TryGetBytes(out IReadOnlyList<byte> bytes)
         {
             bytes = null;
-            if (bytesFactory == null)
+            if (bytesFactory is null)
             {
                 return false;
             }


### PR DESCRIPTION
This PR:

- Spanifies internal Adler32Checksum and Crc32 methods
- Use switch expressions
- Enables nullable annotations (this just allows us to begin annotating, before turning on fully)
- Use collection expressions in more places where semantics don't change
- Prefer is null to == null (this ensures that we compare directly against null, and don't call an overloaded == operator)