### PR TITLE
Improve Tests

### DIFF
--- a/src/UglyToad.PdfPig.Tests/ContentStream/IndirectReferenceTests.cs
+++ b/src/UglyToad.PdfPig.Tests/ContentStream/IndirectReferenceTests.cs
@@ -1,7 +1,6 @@
 ﻿namespace UglyToad.PdfPig.Tests.ContentStream
 {
     using PdfPig.Core;
-    using Xunit;
 
     public class IndirectReferenceTests
     {

--- a/src/UglyToad.PdfPig.Tests/Core/PdfSubpathTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Core/PdfSubpathTests.cs
@@ -1,8 +1,6 @@
 ﻿namespace UglyToad.PdfPig.Tests.Core
 {
-    using System.Collections.Generic;
     using UglyToad.PdfPig.Core;
-    using Xunit;
 
     public class PdfSubpathTests
     {

--- a/src/UglyToad.PdfPig.Tests/Core/TransformationMatrixTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Core/TransformationMatrixTests.cs
@@ -1,8 +1,6 @@
 ﻿namespace UglyToad.PdfPig.Tests.Core
 {
-    using System.Collections.Generic;
     using PdfPig.Core;
-    using Xunit;
 
     public class TransformationMatrixTests
     {

--- a/src/UglyToad.PdfPig.Tests/Dla/ArraySegmentExtensionsTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Dla/ArraySegmentExtensionsTests.cs
@@ -1,10 +1,6 @@
 ﻿namespace UglyToad.PdfPig.Tests.Dla
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Linq;
     using UglyToad.PdfPig.DocumentLayoutAnalysis;
-    using Xunit;
 
     public class ArraySegmentExtensionsTests
     {

--- a/src/UglyToad.PdfPig.Tests/Dla/DistancesTest.cs
+++ b/src/UglyToad.PdfPig.Tests/Dla/DistancesTest.cs
@@ -1,9 +1,7 @@
 ﻿namespace UglyToad.PdfPig.Tests.Dla
 {
-    using System.Collections.Generic;
     using UglyToad.PdfPig.Core;
     using UglyToad.PdfPig.DocumentLayoutAnalysis;
-    using Xunit;
 
     public class DistancesTest
     {

--- a/src/UglyToad.PdfPig.Tests/Dla/DlaHelper.cs
+++ b/src/UglyToad.PdfPig.Tests/Dla/DlaHelper.cs
@@ -1,8 +1,5 @@
 ﻿namespace UglyToad.PdfPig.Tests.Dla
 {
-    using System;
-    using System.IO;
-
     internal static class DlaHelper
     {
         public static string GetDocumentPath(string name, bool isPdf = true)

--- a/src/UglyToad.PdfPig.Tests/Dla/DocstrumBoundingBoxesTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Dla/DocstrumBoundingBoxesTests.cs
@@ -1,11 +1,8 @@
 ﻿namespace UglyToad.PdfPig.Tests.Dla
 {
-    using System.Collections.Generic;
-    using System.Linq;
     using UglyToad.PdfPig.DocumentLayoutAnalysis.PageSegmenter;
     using UglyToad.PdfPig.DocumentLayoutAnalysis.WordExtractor;
     using UglyToad.PdfPig.Fonts.SystemFonts;
-    using Xunit;
 
     public class DocstrumBoundingBoxesTests
     {

--- a/src/UglyToad.PdfPig.Tests/Dla/KdTreeTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Dla/KdTreeTests.cs
@@ -1,9 +1,7 @@
 ﻿namespace UglyToad.PdfPig.Tests.Dla
 {
-    using System.Collections.Generic;
     using UglyToad.PdfPig.Core;
     using UglyToad.PdfPig.DocumentLayoutAnalysis;
-    using Xunit;
 
     public class KdTreeTests
     {

--- a/src/UglyToad.PdfPig.Tests/Dla/MathExtensionsTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Dla/MathExtensionsTests.cs
@@ -1,10 +1,7 @@
 ﻿namespace UglyToad.PdfPig.Tests.Dla
 {
-    using System.Collections.Generic;
-    using System.Linq;
     using UglyToad.PdfPig.DocumentLayoutAnalysis;
-    using Xunit;
-
+ 
     public class MathExtensionsTests
     {
         private static readonly DoubleComparer DoubleComparer = new DoubleComparer(3);

--- a/src/UglyToad.PdfPig.Tests/Dla/NearestNeighbourWordExtractorTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Dla/NearestNeighbourWordExtractorTests.cs
@@ -1,8 +1,6 @@
 ﻿namespace UglyToad.PdfPig.Tests.Dla
 {
-    using System.Linq;
     using UglyToad.PdfPig.DocumentLayoutAnalysis.WordExtractor;
-    using Xunit;
 
     public class NearestNeighbourWordExtractorTests
     {

--- a/src/UglyToad.PdfPig.Tests/Dla/RecursiveXYCutTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Dla/RecursiveXYCutTests.cs
@@ -1,11 +1,8 @@
 ﻿namespace UglyToad.PdfPig.Tests.Dla
 {
-    using System.Collections.Generic;
-    using System.Linq;
     using UglyToad.PdfPig.DocumentLayoutAnalysis.PageSegmenter;
     using UglyToad.PdfPig.DocumentLayoutAnalysis.WordExtractor;
-    using Xunit;
-
+ 
     public class RecursiveXYCutTests
     {
         public static IEnumerable<object[]> DataExtract => new[]

--- a/src/UglyToad.PdfPig.Tests/DoubleComparer.cs
+++ b/src/UglyToad.PdfPig.Tests/DoubleComparer.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-
-namespace UglyToad.PdfPig.Tests
+﻿namespace UglyToad.PdfPig.Tests
 {
     internal class DoubleComparer : IEqualityComparer<double>
     {

--- a/src/UglyToad.PdfPig.Tests/Encryption/AesEncryptionHelperTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Encryption/AesEncryptionHelperTests.cs
@@ -1,6 +1,4 @@
-﻿using Xunit;
-
-namespace UglyToad.PdfPig.Tests.Encryption
+﻿namespace UglyToad.PdfPig.Tests.Encryption
 {
     using PdfPig.Core;
     using PdfPig.Encryption;

--- a/src/UglyToad.PdfPig.Tests/Encryption/RC4Tests.cs
+++ b/src/UglyToad.PdfPig.Tests/Encryption/RC4Tests.cs
@@ -1,9 +1,7 @@
 ﻿namespace UglyToad.PdfPig.Tests.Encryption
 {
-    using System.Linq;
     using PdfPig.Encryption;
     using PdfPig.Tokens;
-    using Xunit;
 
     public class RC4Tests
     {

--- a/src/UglyToad.PdfPig.Tests/Filters/Ascii85FilterTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Filters/Ascii85FilterTests.cs
@@ -1,11 +1,8 @@
 ﻿namespace UglyToad.PdfPig.Tests.Filters
 {
-    using System;
-    using System.Collections.Generic;
     using System.Text;
     using PdfPig.Filters;
     using PdfPig.Tokens;
-    using Xunit;
 
     public class Ascii85FilterTests
     {

--- a/src/UglyToad.PdfPig.Tests/Filters/AsciiHexDecodeFilterTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Filters/AsciiHexDecodeFilterTests.cs
@@ -1,12 +1,9 @@
 ﻿namespace UglyToad.PdfPig.Tests.Filters
 {
-    using System;
-    using System.Collections.Generic;
     using System.Text;
     using PdfPig.Filters;
     using PdfPig.Tokens;
-    using Xunit;
-
+ 
     public class AsciiHexDecodeFilterTests
     {
         private readonly DictionaryToken dictionary = new DictionaryToken(new Dictionary<NameToken, IToken>());

--- a/src/UglyToad.PdfPig.Tests/Filters/BitStreamTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Filters/BitStreamTests.cs
@@ -1,7 +1,6 @@
 ﻿namespace UglyToad.PdfPig.Tests.Filters
 {
     using PdfPig.Filters;
-    using Xunit;
 
     public class BitStreamTests
     {

--- a/src/UglyToad.PdfPig.Tests/Filters/CcittFaxDecodeFilterTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Filters/CcittFaxDecodeFilterTests.cs
@@ -1,10 +1,8 @@
 ﻿namespace UglyToad.PdfPig.Tests.Filters
 {
-    using System.Collections.Generic;
     using UglyToad.PdfPig.Filters;
     using UglyToad.PdfPig.Tests.Images;
     using UglyToad.PdfPig.Tokens;
-    using Xunit;
 
     public class CcittFaxDecodeFilterTests
     {

--- a/src/UglyToad.PdfPig.Tests/Filters/DecodeParameterResolverTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Filters/DecodeParameterResolverTests.cs
@@ -1,10 +1,7 @@
 ﻿namespace UglyToad.PdfPig.Tests.Filters
 {
-    using System;
-    using System.Collections.Generic;
     using PdfPig.Tokens;
     using PdfPig.Filters;
-    using Xunit;
 
     public class DecodeParameterResolverTests
     {

--- a/src/UglyToad.PdfPig.Tests/Filters/FlateFilterTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Filters/FlateFilterTests.cs
@@ -1,10 +1,7 @@
 ﻿namespace UglyToad.PdfPig.Tests.Filters
 {
-    using System.Collections.Generic;
-    using System.IO;
     using PdfPig.Filters;
     using PdfPig.Tokens;
-    using Xunit;
 
     public class FlateFilterTests
     {

--- a/src/UglyToad.PdfPig.Tests/Filters/RunLengthFilterTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Filters/RunLengthFilterTests.cs
@@ -1,9 +1,7 @@
 ﻿namespace UglyToad.PdfPig.Tests.Filters
 {
-    using System.Collections.Generic;
     using PdfPig.Filters;
     using PdfPig.Tokens;
-    using Xunit;
 
     public class RunLengthFilterTests
     {

--- a/src/UglyToad.PdfPig.Tests/Fonts/CharacterPathTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Fonts/CharacterPathTests.cs
@@ -1,9 +1,7 @@
 ﻿namespace UglyToad.PdfPig.Tests.Fonts
 {
-    using System.Text;
     using PdfPig.Core;
-    using PdfPig.Geometry;
-    using Xunit;
+    using System.Text;
 
     public class CharacterPathTests
     {

--- a/src/UglyToad.PdfPig.Tests/Fonts/CidFonts/VerticalWritingMetricsTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Fonts/CidFonts/VerticalWritingMetricsTests.cs
@@ -1,9 +1,7 @@
 ﻿namespace UglyToad.PdfPig.Tests.Fonts.CidFonts
 {
-    using System.Collections.Generic;
     using PdfFonts.CidFonts;
     using PdfPig.Geometry;
-    using Xunit;
 
     public class VerticalWritingMetricsTests
     {

--- a/src/UglyToad.PdfPig.Tests/Fonts/Cmap/CidRangeTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Fonts/Cmap/CidRangeTests.cs
@@ -1,9 +1,7 @@
 ﻿// ReSharper disable ObjectCreationAsStatement
 namespace UglyToad.PdfPig.Tests.Fonts.Cmap
 {
-    using System;
     using PdfFonts.Cmap;
-    using Xunit;
 
     public class CidRangeTests
     {

--- a/src/UglyToad.PdfPig.Tests/Fonts/Cmap/CodespaceRangeTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Fonts/Cmap/CodespaceRangeTests.cs
@@ -1,13 +1,10 @@
 ﻿namespace UglyToad.PdfPig.Tests.Fonts.Cmap
 {
-    using System;
-    using System.Linq;
     using PdfFonts.Cmap;
     using PdfPig.Tokens;
     using UglyToad.PdfPig.Core;
     using UglyToad.PdfPig.PdfFonts.Parser.Parts;
     using UglyToad.PdfPig.Tokenization.Scanner;
-    using Xunit;
 
     public class CodespaceRangeTests
     {

--- a/src/UglyToad.PdfPig.Tests/Fonts/CompactFontFormat/CompactFontFormatParserTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Fonts/CompactFontFormat/CompactFontFormatParserTests.cs
@@ -1,10 +1,6 @@
 ﻿namespace UglyToad.PdfPig.Tests.Fonts.CompactFontFormat
 {
-    using System;
-    using System.IO;
-    using System.Linq;
     using PdfPig.Fonts.CompactFontFormat;
-    using Xunit;
 
     public class CompactFontFormatParserTests
     {

--- a/src/UglyToad.PdfPig.Tests/Fonts/CompactFontFormat/Type2CharStringParserTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Fonts/CompactFontFormat/Type2CharStringParserTests.cs
@@ -3,8 +3,6 @@
     using PdfPig.Fonts.CompactFontFormat;
     using PdfPig.Fonts.CompactFontFormat.Charsets;
     using PdfPig.Fonts.CompactFontFormat.CharStrings;
-    using System;
-    using Xunit;
 
     public class Type2CharStringParserTests
     {

--- a/src/UglyToad.PdfPig.Tests/Fonts/Encodings/GlyphListFactoryTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Fonts/Encodings/GlyphListFactoryTests.cs
@@ -1,9 +1,6 @@
 ﻿namespace UglyToad.PdfPig.Tests.Fonts.Encodings
 {
-    using System;
-    using System.IO;
     using PdfPig.Fonts;
-    using Xunit;
 
     public class GlyphListFactoryTests
     {

--- a/src/UglyToad.PdfPig.Tests/Fonts/Encodings/GlyphListTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Fonts/Encodings/GlyphListTests.cs
@@ -1,8 +1,6 @@
 ﻿namespace UglyToad.PdfPig.Tests.Fonts.Encodings
 {
-    using System.Collections.Generic;
     using PdfPig.Fonts;
-    using Xunit;
 
     public class GlyphListTests
     {

--- a/src/UglyToad.PdfPig.Tests/Fonts/Parser/AdobeFontMetricsParserTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Fonts/Parser/AdobeFontMetricsParserTests.cs
@@ -1,10 +1,7 @@
 ﻿namespace UglyToad.PdfPig.Tests.Fonts.Parser
 {
-    using System;
-    using System.IO;
     using PdfPig.Core;
     using PdfPig.Fonts.AdobeFontMetrics;
-    using Xunit;
 
     public class AdobeFontMetricsParserTests
     {

--- a/src/UglyToad.PdfPig.Tests/Fonts/Parser/CMapParserTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Fonts/Parser/CMapParserTests.cs
@@ -1,11 +1,8 @@
 ﻿namespace UglyToad.PdfPig.Tests.Fonts.Parser
 {
-    using System.Collections.Generic;
     using System.Diagnostics;
-    using System.IO;
     using PdfFonts.Parser;
     using PdfPig.Core;
-    using Xunit;
 
     public class CMapParserTests
     {

--- a/src/UglyToad.PdfPig.Tests/Fonts/Parser/Parts/BaseFontRangeParserTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Fonts/Parser/Parts/BaseFontRangeParserTests.cs
@@ -3,7 +3,6 @@
     using PdfFonts.Cmap;
     using PdfFonts.Parser.Parts;
     using PdfPig.Tokens;
-    using Xunit;
 
     public class BaseFontRangeParserTests
     {

--- a/src/UglyToad.PdfPig.Tests/Fonts/PointSizeTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Fonts/PointSizeTests.cs
@@ -1,7 +1,6 @@
 ﻿namespace UglyToad.PdfPig.Tests.Fonts
 {
     using UglyToad.PdfPig.Tests.Dla;
-    using Xunit;
 
     public class PointSizeTests
     {

--- a/src/UglyToad.PdfPig.Tests/Fonts/Standard14Tests.cs
+++ b/src/UglyToad.PdfPig.Tests/Fonts/Standard14Tests.cs
@@ -1,7 +1,6 @@
 ﻿namespace UglyToad.PdfPig.Tests.Fonts
 {
     using PdfPig.Fonts.Standard14Fonts;
-    using Xunit;
 
     public class Standard14Tests
     {

--- a/src/UglyToad.PdfPig.Tests/Fonts/SystemFonts/Linux.cs
+++ b/src/UglyToad.PdfPig.Tests/Fonts/SystemFonts/Linux.cs
@@ -1,7 +1,5 @@
-﻿using System.Collections.Generic;
-using UglyToad.PdfPig.Fonts.SystemFonts;
+﻿using UglyToad.PdfPig.Fonts.SystemFonts;
 using UglyToad.PdfPig.Tests.Dla;
-using Xunit;
 
 namespace UglyToad.PdfPig.Tests.Fonts.SystemFonts
 {

--- a/src/UglyToad.PdfPig.Tests/Fonts/TrueType/Parser/TrueTypeFontParserTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Fonts/TrueType/Parser/TrueTypeFontParserTests.cs
@@ -96,7 +96,7 @@ namespace UglyToad.PdfPig.Tests.Fonts.TrueType.Parser
 
             foreach (var s in data)
             {
-                var parts = s.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+                var parts = s.Split(' ').Where(x => x.Length > 0).ToArray();
 
                 var name = parts[0];
 

--- a/src/UglyToad.PdfPig.Tests/Fonts/TrueType/Parser/TrueTypeFontParserTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Fonts/TrueType/Parser/TrueTypeFontParserTests.cs
@@ -5,11 +5,9 @@ namespace UglyToad.PdfPig.Tests.Fonts.TrueType.Parser
     using PdfPig.Fonts.TrueType;
     using PdfPig.Fonts.TrueType.Parser;
     using PdfPig.Fonts.TrueType.Tables;
-    using System;
     using System.Globalization;
     using System.Text;
     using System.Text.RegularExpressions;
-    using Xunit;
 
     public class TrueTypeFontParserTests
     {

--- a/src/UglyToad.PdfPig.Tests/Fonts/TrueType/Tables/Os2TableTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Fonts/TrueType/Tables/Os2TableTests.cs
@@ -1,11 +1,8 @@
 ﻿namespace UglyToad.PdfPig.Tests.Fonts.TrueType.Tables
 {
-    using System.IO;
-    using System.Linq;
     using PdfPig.Core;
     using PdfPig.Fonts.TrueType;
     using PdfPig.Fonts.TrueType.Parser;
-    using Xunit;
 
     public class Os2TableTests
     {

--- a/src/UglyToad.PdfPig.Tests/Fonts/TrueType/TrueTypeChecksumCalculatorTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Fonts/TrueType/TrueTypeChecksumCalculatorTests.cs
@@ -1,12 +1,8 @@
 ﻿namespace UglyToad.PdfPig.Tests.Fonts.TrueType
 {
-    using System;
-    using System.IO;
-    using System.Linq;
     using PdfPig.Core;
     using PdfPig.Fonts.TrueType;
     using PdfPig.Fonts.TrueType.Parser;
-    using Xunit;
 
     public class TrueTypeChecksumCalculatorTests
     {

--- a/src/UglyToad.PdfPig.Tests/Fonts/TrueType/TrueTypeDataBytesTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Fonts/TrueType/TrueTypeDataBytesTests.cs
@@ -2,7 +2,6 @@
 {
     using PdfPig.Core;
     using PdfPig.Fonts.TrueType;
-    using Xunit;
 
     public class TrueTypeDataBytesTests
     {

--- a/src/UglyToad.PdfPig.Tests/Fonts/TrueType/TrueTypeTestHelper.cs
+++ b/src/UglyToad.PdfPig.Tests/Fonts/TrueType/TrueTypeTestHelper.cs
@@ -1,8 +1,5 @@
 ﻿namespace UglyToad.PdfPig.Tests.Fonts.TrueType
 {
-    using System;
-    using System.IO;
-
     internal static class TrueTypeTestHelper
     {
         public static byte[] GetFileBytes(string name)

--- a/src/UglyToad.PdfPig.Tests/Fonts/Type1/Type1CharStringParserTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Fonts/Type1/Type1CharStringParserTests.cs
@@ -1,7 +1,6 @@
 ﻿namespace UglyToad.PdfPig.Tests.Fonts.Type1
 {
     using UglyToad.PdfPig.Core;
-    using Xunit;
     using Integration;
 
     public class Type1CharStringParserTests

--- a/src/UglyToad.PdfPig.Tests/Fonts/Type1/Type1FontParserTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Fonts/Type1/Type1FontParserTests.cs
@@ -1,13 +1,8 @@
 ﻿namespace UglyToad.PdfPig.Tests.Fonts.Type1
 {
-    using System;
-    using System.IO;
-    using System.Linq;
     using System.Text;
     using PdfPig.Core;
     using PdfPig.Fonts.Type1.Parser;
-    using PdfPig.Geometry;
-    using Xunit;
 
     public class Type1FontParserTests
     {

--- a/src/UglyToad.PdfPig.Tests/Functions/PdfFunctionType0Tests.cs
+++ b/src/UglyToad.PdfPig.Tests/Functions/PdfFunctionType0Tests.cs
@@ -1,13 +1,9 @@
 ﻿namespace UglyToad.PdfPig.Tests.Functions
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Linq;
     using UglyToad.PdfPig.Functions;
     using UglyToad.PdfPig.Tests.Tokens;
     using UglyToad.PdfPig.Tokens;
     using UglyToad.PdfPig.Util;
-    using Xunit;
 
     public class PdfFunctionType0Tests
     {

--- a/src/UglyToad.PdfPig.Tests/Functions/PdfFunctionType2Tests.cs
+++ b/src/UglyToad.PdfPig.Tests/Functions/PdfFunctionType2Tests.cs
@@ -1,13 +1,10 @@
 ﻿namespace UglyToad.PdfPig.Tests.Functions
 {
-    using System.Collections.Generic;
-    using System.Linq;
     using UglyToad.PdfPig.Functions;
     using UglyToad.PdfPig.Tests.Tokens;
     using UglyToad.PdfPig.Tokens;
     using UglyToad.PdfPig.Util;
-    using Xunit;
-
+ 
     public class PdfFunctionType2Tests
     {
         private static PdfFunctionType2 CreateFunction(double[] domain, double[] range, double[] c0, double[] c1, double n)

--- a/src/UglyToad.PdfPig.Tests/Functions/PdfFunctionType3Tests.cs
+++ b/src/UglyToad.PdfPig.Tests/Functions/PdfFunctionType3Tests.cs
@@ -1,9 +1,5 @@
 ﻿namespace UglyToad.PdfPig.Tests.Functions
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Text;
-
     public class PdfFunctionType3Tests
     {
         // TODO

--- a/src/UglyToad.PdfPig.Tests/Functions/PdfFunctionType4Tests.cs
+++ b/src/UglyToad.PdfPig.Tests/Functions/PdfFunctionType4Tests.cs
@@ -1,14 +1,11 @@
 ﻿namespace UglyToad.PdfPig.Tests.Functions
 {
-    using System.Collections.Generic;
-    using System.Linq;
     using System.Text;
     using UglyToad.PdfPig.Functions;
     using UglyToad.PdfPig.Tests.Tokens;
     using UglyToad.PdfPig.Tokens;
     using UglyToad.PdfPig.Util;
-    using Xunit;
-
+ 
     public class PdfFunctionType4Tests
     {
         private static PdfFunctionType4 CreateFunction(string function, double[] domain, double[] range)

--- a/src/UglyToad.PdfPig.Tests/Functions/Type4/OperatorsTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Functions/Type4/OperatorsTests.cs
@@ -1,8 +1,6 @@
 ﻿namespace UglyToad.PdfPig.Tests.Functions.Type4
 {
-    using System;
     using UglyToad.PdfPig.Functions.Type4;
-    using Xunit;
 
     public class OperatorsTests
     {

--- a/src/UglyToad.PdfPig.Tests/Functions/Type4/ParserTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Functions/Type4/ParserTests.cs
@@ -1,7 +1,5 @@
 ﻿namespace UglyToad.PdfPig.Tests.Functions.Type4
 {
-    using Xunit;
-
     public class ParserTests
     {
         /// <summary>

--- a/src/UglyToad.PdfPig.Tests/Functions/Type4/Type4Tester.cs
+++ b/src/UglyToad.PdfPig.Tests/Functions/Type4/Type4Tester.cs
@@ -1,9 +1,7 @@
 ﻿namespace UglyToad.PdfPig.Tests.Functions.Type4
 {
-    using System;
     using System.Globalization;
     using UglyToad.PdfPig.Functions.Type4;
-    using Xunit;
 
     /// <summary>
     /// Testing helper class for testing type 4 functions from the PDF specification.

--- a/src/UglyToad.PdfPig.Tests/Geometry/BezierCurveTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Geometry/BezierCurveTests.cs
@@ -1,9 +1,7 @@
 ﻿namespace UglyToad.PdfPig.Tests.Geometry
 {
-    using System.Collections.Generic;
     using UglyToad.PdfPig.Core;
     using UglyToad.PdfPig.Geometry;
-    using Xunit;
     using static UglyToad.PdfPig.Core.PdfSubpath;
 
     public class BezierCurveTests

--- a/src/UglyToad.PdfPig.Tests/Geometry/ClippingTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Geometry/ClippingTests.cs
@@ -1,5 +1,4 @@
 ﻿using UglyToad.PdfPig.Tests.Integration;
-using Xunit;
 
 namespace UglyToad.PdfPig.Tests.Geometry
 {

--- a/src/UglyToad.PdfPig.Tests/Geometry/PdfLineTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Geometry/PdfLineTests.cs
@@ -2,8 +2,6 @@
 {
     using PdfPig.Core;
     using PdfPig.Geometry;
-    using System.Collections.Generic;
-    using Xunit;
 
     public class PdfLineTests
     {

--- a/src/UglyToad.PdfPig.Tests/Geometry/PdfPathExtensionsTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Geometry/PdfPathExtensionsTests.cs
@@ -1,10 +1,8 @@
 ﻿namespace UglyToad.PdfPig.Tests.Geometry
 {
-    using System.Linq;
     using UglyToad.PdfPig.Core;
     using UglyToad.PdfPig.Geometry;
     using UglyToad.PdfPig.Tests.Integration;
-    using Xunit;
 
     public class PdfPathExtensionsTests
     {

--- a/src/UglyToad.PdfPig.Tests/Geometry/PdfPathExtensionsTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Geometry/PdfPathExtensionsTests.cs
@@ -21,14 +21,14 @@
 
                     foreach (var c in words.Where(w => path.Contains(w.BoundingBox)).ToList())
                     {
-                        Assert.Equal("in", c.Text.Split("_").Last());
+                        Assert.Equal("in", c.Text.Split('_').Last());
                         words.Remove(c);
                     }
                 }
 
                 foreach (var w in words)
                 {
-                    Assert.NotEqual("in", w.Text.Split("_").Last());
+                    Assert.NotEqual("in", w.Text.Split('_').Last());
                 }
             }
         }

--- a/src/UglyToad.PdfPig.Tests/Geometry/PdfPointTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Geometry/PdfPointTests.cs
@@ -1,10 +1,7 @@
 ﻿namespace UglyToad.PdfPig.Tests.Geometry
 {
     using PdfPig.Core;
-    using System.Collections.Generic;
-    using System.Linq;
     using UglyToad.PdfPig.Geometry;
-    using Xunit;
 
     public class PdfPointTests
     {

--- a/src/UglyToad.PdfPig.Tests/Geometry/PdfRectangleTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Geometry/PdfRectangleTests.cs
@@ -3,8 +3,6 @@
     using Content;
     using PdfPig.Geometry;
     using PdfPig.Core;
-    using Xunit;
-    using System.Collections.Generic;
     using System.Drawing;
 
     public class PdfRectangleTests

--- a/src/UglyToad.PdfPig.Tests/Geometry/PdfSubpathLineTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Geometry/PdfSubpathLineTests.cs
@@ -1,9 +1,7 @@
 ﻿namespace UglyToad.PdfPig.Tests.Geometry
 {
-    using System.Collections.Generic;
     using UglyToad.PdfPig.Core;
     using UglyToad.PdfPig.Geometry;
-    using Xunit;
     using static UglyToad.PdfPig.Core.PdfSubpath;
 
     public class PdfSubpathLineTests

--- a/src/UglyToad.PdfPig.Tests/Geometry/PdfVectorTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Geometry/PdfVectorTests.cs
@@ -1,7 +1,6 @@
 ﻿namespace UglyToad.PdfPig.Tests.Geometry
 {
     using PdfPig.Geometry;
-    using Xunit;
 
     public class PdfVectorTests
     {

--- a/src/UglyToad.PdfPig.Tests/Graphics/ContentStreamProcessorTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Graphics/ContentStreamProcessorTests.cs
@@ -4,7 +4,6 @@
     using PdfPig.Core;
     using PdfPig.Geometry;
     using PdfPig.Graphics;
-    using Xunit;
 
     public class ContentStreamProcessorTests
     {

--- a/src/UglyToad.PdfPig.Tests/Graphics/Operations/General/SetMiterLimitTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Graphics/Operations/General/SetMiterLimitTests.cs
@@ -1,7 +1,6 @@
 ﻿namespace UglyToad.PdfPig.Tests.Graphics.Operations.General
 {
     using PdfPig.Graphics.Operations.General;
-    using Xunit;
 
     public class SetMiterLimitTests
     {

--- a/src/UglyToad.PdfPig.Tests/Graphics/Operations/GraphicsStateOperationTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Graphics/Operations/GraphicsStateOperationTests.cs
@@ -1,14 +1,9 @@
 ﻿namespace UglyToad.PdfPig.Tests.Graphics.Operations
 {
-    using System;
-    using System.Collections.Generic;
-    using System.IO;
-    using System.Linq;
     using System.Reflection;
     using PdfPig.Graphics.Operations;
     using PdfPig.Graphics.Operations.InlineImages;
     using PdfPig.Tokens;
-    using Xunit;
 
     public class GraphicsStateOperationTests
     {

--- a/src/UglyToad.PdfPig.Tests/Graphics/Operations/SpecialGraphicsState/PopTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Graphics/Operations/SpecialGraphicsState/PopTests.cs
@@ -1,9 +1,7 @@
 ﻿namespace UglyToad.PdfPig.Tests.Graphics.Operations.SpecialGraphicsState
 {
-    using System;
     using PdfPig.Graphics;
     using PdfPig.Graphics.Operations.SpecialGraphicsState;
-    using Xunit;
 
     public class PopTests
     {

--- a/src/UglyToad.PdfPig.Tests/Graphics/Operations/SpecialGraphicsState/PushTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Graphics/Operations/SpecialGraphicsState/PushTests.cs
@@ -1,7 +1,6 @@
 ﻿namespace UglyToad.PdfPig.Tests.Graphics.Operations.SpecialGraphicsState
 {
     using PdfPig.Graphics.Operations.SpecialGraphicsState;
-    using Xunit;
 
     public class PushTests
     {

--- a/src/UglyToad.PdfPig.Tests/Graphics/Operations/TextState/SetFontAndSizeTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Graphics/Operations/TextState/SetFontAndSizeTests.cs
@@ -1,9 +1,7 @@
 ﻿namespace UglyToad.PdfPig.Tests.Graphics.Operations.TextState
 {
-    using System;
     using PdfPig.Graphics.Operations.TextState;
     using PdfPig.Tokens;
-    using Xunit;
 
     public class SetFontAndSizeTests
     {

--- a/src/UglyToad.PdfPig.Tests/Graphics/TestOperationContext.cs
+++ b/src/UglyToad.PdfPig.Tests/Graphics/TestOperationContext.cs
@@ -1,13 +1,11 @@
 ﻿namespace UglyToad.PdfPig.Tests.Graphics
 {
-    using System.Collections.Generic;
     using Content;
     using Logging;
     using PdfFonts;
     using PdfPig.Graphics;
     using PdfPig.Tokens;
     using PdfPig.Core;
-    using System;
     using Tokens;
     using UglyToad.PdfPig.Graphics.Core;
     using UglyToad.PdfPig.Graphics.Operations.TextPositioning;

--- a/src/UglyToad.PdfPig.Tests/IO/InputBytesTests.cs
+++ b/src/UglyToad.PdfPig.Tests/IO/InputBytesTests.cs
@@ -1,10 +1,7 @@
 ﻿namespace UglyToad.PdfPig.Tests.IO
 {
-    using System.IO;
-    using System.Linq;
     using PdfPig.Core;
-    using Xunit;
-
+ 
     public class InputBytesTests
     {
         private const string TestData = @"123456789";

--- a/src/UglyToad.PdfPig.Tests/Images/ImageHelpers.cs
+++ b/src/UglyToad.PdfPig.Tests/Images/ImageHelpers.cs
@@ -1,6 +1,5 @@
 ﻿namespace UglyToad.PdfPig.Tests.Images
 {
-    using System;
     using System.IO;
     using System.IO.Compression;
     using UglyToad.PdfPig.Images.Png;

--- a/src/UglyToad.PdfPig.Tests/Images/JpegHandlerTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Images/JpegHandlerTests.cs
@@ -1,18 +1,12 @@
 ﻿namespace UglyToad.PdfPig.Tests.Images
 {
-    using System; 
-    using System.IO;    
-    using Xunit;
     using JpegHandler = UglyToad.PdfPig.Images.JpegHandler;
 
     public class JpegHandlerTests
-    { 
-         
-
+    {
         [Fact]
         public void CanGetJpegInformation()
         {
-
             var dataJpg = LoadJpg("218995467-ccb746b0-dc28-4616-bcb1-4ad685f81876.jpg");
 
             using (var ms = new MemoryStream(dataJpg))
@@ -23,9 +17,7 @@
                 Assert.Equal(2290, jpegInfo.Height);
                 Assert.Equal(1648, jpegInfo.Width);                
             }
-        }
-
-        
+        }        
 
         private static byte[] LoadJpg(string name)
         {

--- a/src/UglyToad.PdfPig.Tests/Images/PngFromPdfImageFactoryTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Images/PngFromPdfImageFactoryTests.cs
@@ -1,10 +1,7 @@
 ﻿namespace UglyToad.PdfPig.Tests.Images
 {
-    using System.Collections.Generic;
-    using System.Linq;
     using UglyToad.PdfPig.Graphics.Colors;
     using UglyToad.PdfPig.Images.Png;
-    using Xunit;
 
     public class PngFromPdfImageFactoryTests
     {

--- a/src/UglyToad.PdfPig.Tests/Integration/AccentedCharactersInBookmarksTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Integration/AccentedCharactersInBookmarksTests.cs
@@ -1,8 +1,5 @@
 ﻿namespace UglyToad.PdfPig.Tests.Integration;
 
-using System.Linq;
-using Xunit;
-
 public class AccentedCharactersInBookmarksTests
 {
     [Fact]

--- a/src/UglyToad.PdfPig.Tests/Integration/AcroFormsBasicFieldsTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Integration/AcroFormsBasicFieldsTests.cs
@@ -1,9 +1,6 @@
 ﻿namespace UglyToad.PdfPig.Tests.Integration
 {
-    using System;
-    using System.Linq;
     using AcroForms.Fields;
-    using Xunit;
 
     public class AcroFormsBasicFieldsTests
     {

--- a/src/UglyToad.PdfPig.Tests/Integration/AdvancedPdfDocumentAccessTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Integration/AdvancedPdfDocumentAccessTests.cs
@@ -1,8 +1,6 @@
 ﻿namespace UglyToad.PdfPig.Tests.Integration
 {
     using PdfPig.Tokens;
-    using System.Collections.Generic;
-    using Xunit;
 
     public class AdvancedPdfDocumentAccessTests
     {

--- a/src/UglyToad.PdfPig.Tests/Integration/AltoXmlTextExporterTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Integration/AltoXmlTextExporterTests.cs
@@ -1,14 +1,10 @@
 ﻿namespace UglyToad.PdfPig.Tests.Integration
 {
-    using System;
-    using System.IO;
-    using System.Linq;
     using System.Text;
     using System.Xml;
     using UglyToad.PdfPig.DocumentLayoutAnalysis.Export;
     using UglyToad.PdfPig.DocumentLayoutAnalysis.PageSegmenter;
     using UglyToad.PdfPig.Util;
-    using Xunit;
 
     public class AltoXmlTextExporterTests
     {

--- a/src/UglyToad.PdfPig.Tests/Integration/AnnotationReplyToTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Integration/AnnotationReplyToTests.cs
@@ -1,8 +1,6 @@
 ﻿namespace UglyToad.PdfPig.Tests.Integration;
 
 using Annotations;
-using System.Linq;
-using Xunit;
 
 public class AnnotationReplyToTests
 {

--- a/src/UglyToad.PdfPig.Tests/Integration/AnnotationsTest.cs
+++ b/src/UglyToad.PdfPig.Tests/Integration/AnnotationsTest.cs
@@ -1,8 +1,6 @@
 ﻿namespace UglyToad.PdfPig.Tests.Integration
 {
     using Actions;
-    using System.Linq;
-    using Xunit;
 
     public class AnnotationsTest
     {

--- a/src/UglyToad.PdfPig.Tests/Integration/AssertablePositionData.cs
+++ b/src/UglyToad.PdfPig.Tests/Integration/AssertablePositionData.cs
@@ -1,9 +1,7 @@
 ﻿namespace UglyToad.PdfPig.Tests.Integration
 {
-    using System;
     using System.Globalization;
     using Content;
-    using Xunit;
 
     public class AssertablePositionData
     {

--- a/src/UglyToad.PdfPig.Tests/Integration/CatGeneticsTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Integration/CatGeneticsTests.cs
@@ -1,8 +1,6 @@
 ﻿namespace UglyToad.PdfPig.Tests.Integration
 {
-    using System.Linq;
     using Annotations;
-    using Xunit;
 
     public class CatGeneticsTests
     {

--- a/src/UglyToad.PdfPig.Tests/Integration/ColorSpaceTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Integration/ColorSpaceTests.cs
@@ -1,12 +1,8 @@
 ﻿namespace UglyToad.PdfPig.Tests.Integration
 {
-    using System;
-    using System.IO;
-    using System.Linq;
     using UglyToad.PdfPig.Content;
     using UglyToad.PdfPig.DocumentLayoutAnalysis.WordExtractor;
     using UglyToad.PdfPig.Graphics.Colors;
-    using Xunit;
 
     public class ColorSpaceTests
     {

--- a/src/UglyToad.PdfPig.Tests/Integration/DocumentInformationTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Integration/DocumentInformationTests.cs
@@ -2,7 +2,6 @@
 {
     using PdfPig.Core;
     using PdfPig.Tokens;
-    using Xunit;
 
     public class DocumentInformationTests
     {

--- a/src/UglyToad.PdfPig.Tests/Integration/EmbeddedFileAttachmentTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Integration/EmbeddedFileAttachmentTests.cs
@@ -1,7 +1,5 @@
 ﻿namespace UglyToad.PdfPig.Tests.Integration
 {
-    using Xunit;
-
     public class EmbeddedFileAttachmentTests
     {
         [Fact]

--- a/src/UglyToad.PdfPig.Tests/Integration/EncodingsTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Integration/EncodingsTests.cs
@@ -2,8 +2,6 @@
 {
     using PdfPig.Core;
     using PdfPig.Geometry;
-    using System.Linq;
-    using Xunit;
 
     public class EncodingsTests
     {

--- a/src/UglyToad.PdfPig.Tests/Integration/EncryptedDocumentTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Integration/EncryptedDocumentTests.cs
@@ -1,9 +1,6 @@
 ﻿namespace UglyToad.PdfPig.Tests.Integration
 {
-    using System;
-    using System.Collections.Generic;
     using Exceptions;
-    using Xunit;
 
     public class EncryptedDocumentTests
     {

--- a/src/UglyToad.PdfPig.Tests/Integration/FarmerMacTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Integration/FarmerMacTests.cs
@@ -1,8 +1,5 @@
 ﻿namespace UglyToad.PdfPig.Tests.Integration
 {
-    using System.Linq;
-    using Xunit;
-
     public class FarmerMacTests
     {
         private static string GetFilename()

--- a/src/UglyToad.PdfPig.Tests/Integration/FontDescriptorTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Integration/FontDescriptorTests.cs
@@ -1,12 +1,7 @@
 ﻿namespace UglyToad.PdfPig.Tests.Integration
 {
-    using System;
-    using System.Collections.Generic;
-    using System.IO;
-    using System.Linq;
     using System.Text;
     using UglyToad.PdfPig.Content;
-    using Xunit;
 
     public class FontDescriptorTests
     {

--- a/src/UglyToad.PdfPig.Tests/Integration/FontSizeTestFromGoogleChromeTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Integration/FontSizeTestFromGoogleChromeTests.cs
@@ -1,10 +1,6 @@
 ﻿namespace UglyToad.PdfPig.Tests.Integration
 {
-    using System;
-    using System.IO;
-    using System.Linq;
     using Content;
-    using Xunit;
 
     public class FontSizeTestFromGoogleChromeTests
     {

--- a/src/UglyToad.PdfPig.Tests/Integration/FontSizeTestFromLibreOfficeTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Integration/FontSizeTestFromLibreOfficeTests.cs
@@ -1,10 +1,6 @@
 ﻿namespace UglyToad.PdfPig.Tests.Integration
 {
-    using System;
-    using System.IO;
-    using System.Linq;
     using Content;
-    using Xunit;
 
     public class FontSizeTestFromLibreOfficeTests
     {

--- a/src/UglyToad.PdfPig.Tests/Integration/GamebookTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Integration/GamebookTests.cs
@@ -1,7 +1,5 @@
 ﻿namespace UglyToad.PdfPig.Tests.Integration
 {
-    using Xunit;
-
     public class GamebookTests
     {
         [Fact]

--- a/src/UglyToad.PdfPig.Tests/Integration/HOcrTextExporterTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Integration/HOcrTextExporterTests.cs
@@ -1,13 +1,10 @@
 ﻿namespace UglyToad.PdfPig.Tests.Integration
 {
-    using System;
-    using System.IO;
     using System.Text;
     using System.Xml;
     using UglyToad.PdfPig.DocumentLayoutAnalysis.Export;
     using UglyToad.PdfPig.DocumentLayoutAnalysis.PageSegmenter;
     using UglyToad.PdfPig.Util;
-    using Xunit;
 
     public class HOcrTextExporterTests
     {

--- a/src/UglyToad.PdfPig.Tests/Integration/IndexedPageSummaryFileTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Integration/IndexedPageSummaryFileTests.cs
@@ -1,8 +1,5 @@
 namespace UglyToad.PdfPig.Tests.Integration;
 
-using System.Linq;
-using Xunit;
-
 public class IndexedPageSummaryFileTests
 {
     private static string GetFilename()

--- a/src/UglyToad.PdfPig.Tests/Integration/IntegrationDocumentTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Integration/IntegrationDocumentTests.cs
@@ -1,11 +1,5 @@
 ﻿namespace UglyToad.PdfPig.Tests.Integration
 {
-    using System;
-    using System.Collections.Generic;
-    using System.IO;
-    using System.Linq;
-    using Xunit;
-
     public class IntegrationDocumentTests
     {
         private static readonly Lazy<string> DocumentFolder = new Lazy<string>(() => Path.GetFullPath(Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "..", "..", "..", "Integration", "Documents")));

--- a/src/UglyToad.PdfPig.Tests/Integration/IntegrationHelpers.cs
+++ b/src/UglyToad.PdfPig.Tests/Integration/IntegrationHelpers.cs
@@ -1,8 +1,5 @@
 ﻿namespace UglyToad.PdfPig.Tests.Integration
 {
-    using System;
-    using System.IO;
-
     internal static class IntegrationHelpers
     {
         public static string GetDocumentPath(string name, bool isPdf = true)

--- a/src/UglyToad.PdfPig.Tests/Integration/InvalidObjectLoopTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Integration/InvalidObjectLoopTests.cs
@@ -1,7 +1,5 @@
 ﻿namespace UglyToad.PdfPig.Tests.Integration
 {
-    using Xunit;
-
     public class InvalidObjectLoopTests
     {
         [Fact]

--- a/src/UglyToad.PdfPig.Tests/Integration/InvalidOperator.cs
+++ b/src/UglyToad.PdfPig.Tests/Integration/InvalidOperator.cs
@@ -1,8 +1,5 @@
 ﻿namespace UglyToad.PdfPig.Tests.Integration
 {
-    using System;
-    using Xunit;
-
     public class InvalidOperatorTests
     {
         [Fact]

--- a/src/UglyToad.PdfPig.Tests/Integration/JudgementDocumentTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Integration/JudgementDocumentTests.cs
@@ -1,9 +1,6 @@
 ﻿namespace UglyToad.PdfPig.Tests.Integration
 {
-    using System.IO;
-    using System.Linq;
     using Content;
-    using Xunit;
 
     public class JudgementDocumentTests
     {

--- a/src/UglyToad.PdfPig.Tests/Integration/LaTexTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Integration/LaTexTests.cs
@@ -2,13 +2,8 @@
 
 namespace UglyToad.PdfPig.Tests.Integration
 {
-    using System;
-    using System.Collections.Generic;
-    using System.IO;
-    using System.Linq;
     using PdfPig.Core;
     using DocumentLayoutAnalysis.Export;
-    using Xunit;
 
     public class LaTexTests
     {

--- a/src/UglyToad.PdfPig.Tests/Integration/LittlePigInArmenianTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Integration/LittlePigInArmenianTests.cs
@@ -1,8 +1,5 @@
 ﻿namespace UglyToad.PdfPig.Tests.Integration;
 
-using System.Linq;
-using Xunit;
-
 public class LittlePigInArmenianTests
 {
     [Fact]

--- a/src/UglyToad.PdfPig.Tests/Integration/LocalTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Integration/LocalTests.cs
@@ -1,9 +1,6 @@
 ﻿namespace UglyToad.PdfPig.Tests.Integration
 {
-    //using System;
     //using System.Diagnostics;
-    //using System.IO;
-    //using Xunit;
 
     /// <summary>
     /// A class for testing files which are not checked in to source control.

--- a/src/UglyToad.PdfPig.Tests/Integration/MarkedContentExtractionTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Integration/MarkedContentExtractionTests.cs
@@ -1,5 +1,4 @@
 ﻿using UglyToad.PdfPig.Content;
-using Xunit;
 
 namespace UglyToad.PdfPig.Tests.Integration
 {

--- a/src/UglyToad.PdfPig.Tests/Integration/Math119FakingDataTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Integration/Math119FakingDataTests.cs
@@ -1,7 +1,5 @@
 ﻿namespace UglyToad.PdfPig.Tests.Integration;
 
-using Xunit;
-
 public class Math119FakingDataTests
 {
     [Fact]
@@ -12,7 +10,6 @@ public class Math119FakingDataTests
         var lastPage = document.GetPage(8);
 
         var words = lastPage.GetWords();
-
 
     }
 }

--- a/src/UglyToad.PdfPig.Tests/Integration/MultiplePageMortalityStatisticsTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Integration/MultiplePageMortalityStatisticsTests.cs
@@ -1,11 +1,6 @@
 ﻿namespace UglyToad.PdfPig.Tests.Integration
 {
-    using System;
-    using System.Collections.Generic;
-    using System.IO;
-    using System.Linq;
     using Content;
-    using Xunit;
 
     public class MultiplePageMortalityStatisticsTests
     {

--- a/src/UglyToad.PdfPig.Tests/Integration/NonAsciiCharactersBookmarksTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Integration/NonAsciiCharactersBookmarksTests.cs
@@ -16,7 +16,7 @@
             builder.AddPage(PageSize.A4);
 
             // Set bookmark items.
-            var inputs = words.Split(" ", StringSplitOptions.RemoveEmptyEntries);
+            var inputs = words.Split(' ').Where(x => x.Length > 0).ToArray();
             builder.Bookmarks = new Bookmarks(inputs.Select(x => new DocumentBookmarkNode(x,
                 0,
                 new ExplicitDestination(1,

--- a/src/UglyToad.PdfPig.Tests/Integration/NonAsciiCharactersBookmarksTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Integration/NonAsciiCharactersBookmarksTests.cs
@@ -1,13 +1,9 @@
 ﻿namespace UglyToad.PdfPig.Tests.Integration
 {
-    using System;
-    using System.IO;
-    using System.Linq;
     using UglyToad.PdfPig.Content;
     using UglyToad.PdfPig.Outline;
     using UglyToad.PdfPig.Outline.Destinations;
     using UglyToad.PdfPig.Writer;
-    using Xunit;
 
     public class NonAsciiCharactersBookmarksTests
     {

--- a/src/UglyToad.PdfPig.Tests/Integration/OldGutnishTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Integration/OldGutnishTests.cs
@@ -1,8 +1,5 @@
 ﻿namespace UglyToad.PdfPig.Tests.Integration
 {
-    using System.Linq;
-    using Xunit;
-
     public class OldGutnishTests
     {
         private static string GetFilename()

--- a/src/UglyToad.PdfPig.Tests/Integration/OpenTypeFontTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Integration/OpenTypeFontTests.cs
@@ -1,7 +1,5 @@
-﻿using System.Linq;
-using UglyToad.PdfPig.DocumentLayoutAnalysis.PageSegmenter;
+﻿using UglyToad.PdfPig.DocumentLayoutAnalysis.PageSegmenter;
 using UglyToad.PdfPig.DocumentLayoutAnalysis.WordExtractor;
-using Xunit;
 
 namespace UglyToad.PdfPig.Tests.Integration
 {

--- a/src/UglyToad.PdfPig.Tests/Integration/OptionalContentTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Integration/OptionalContentTests.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using UglyToad.PdfPig.Tokens;
-using Xunit;
-
-namespace UglyToad.PdfPig.Tests.Integration
+﻿namespace UglyToad.PdfPig.Tests.Integration
 {
     public class OptionalContentTests
     {

--- a/src/UglyToad.PdfPig.Tests/Integration/PageContentTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Integration/PageContentTests.cs
@@ -1,7 +1,6 @@
 ﻿namespace UglyToad.PdfPig.Tests.Integration
 {
     using PdfPig.Core;
-    using Xunit;
 
     public class PageContentTests
     {

--- a/src/UglyToad.PdfPig.Tests/Integration/PageFactoryTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Integration/PageFactoryTests.cs
@@ -9,9 +9,6 @@
     using PdfPig.Parser;
     using PdfPig.Tokenization.Scanner;
     using PdfPig.Tokens;
-    using System;
-    using System.Collections.Generic;
-    using Xunit;
 
     public class PageFactoryTests
     {

--- a/src/UglyToad.PdfPig.Tests/Integration/PageXmlTextExporterTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Integration/PageXmlTextExporterTests.cs
@@ -5,14 +5,10 @@
     using DocumentLayoutAnalysis.ReadingOrderDetector;
     using PdfPig.Core;
     using PdfPig.Util;
-    using System;
-    using System.IO;
-    using System.Linq;
     using System.Text;
     using System.Text.RegularExpressions;
     using System.Xml;
     using UglyToad.PdfPig.DocumentLayoutAnalysis.Export.PAGE;
-    using Xunit;
 
     public class PageXmlTextExporterTests
     {

--- a/src/UglyToad.PdfPig.Tests/Integration/PatternColorTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Integration/PatternColorTests.cs
@@ -1,9 +1,7 @@
 ﻿namespace UglyToad.PdfPig.Tests.Integration
 {
-    using System.Linq;
     using UglyToad.PdfPig.Core;
     using UglyToad.PdfPig.Graphics.Colors;
-    using Xunit;
 
     public class PatternColorTests
     {

--- a/src/UglyToad.PdfPig.Tests/Integration/PdfParserTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Integration/PdfParserTests.cs
@@ -1,14 +1,9 @@
 ﻿namespace UglyToad.PdfPig.Tests.Integration
 {
-    using System;
-    using System.Collections.Generic;
-    using System.IO;
     using System.IO.Compression;
-    using System.Linq;
     using System.Text;
     using PdfPig.Filters;
     using PdfPig.Tokens;
-    using Xunit;
 
     /*
      * catalog

--- a/src/UglyToad.PdfPig.Tests/Integration/PigProductionHandbookTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Integration/PigProductionHandbookTests.cs
@@ -1,11 +1,5 @@
 ﻿namespace UglyToad.PdfPig.Tests.Integration
 {
-    using System;
-    using System.Collections.Generic;
-    using System.IO;
-    using System.Linq;
-    using Xunit;
-
     public class PigProductionHandbookTests
     {
         private static string GetFilename()

--- a/src/UglyToad.PdfPig.Tests/Integration/PigReproductionPowerpointTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Integration/PigReproductionPowerpointTests.cs
@@ -1,8 +1,5 @@
 ﻿namespace UglyToad.PdfPig.Tests.Integration
 {
-    using System.Linq;
-    using Xunit;
-
     public class PigReproductionPowerpointTests
     {
         private static string GetFilename()

--- a/src/UglyToad.PdfPig.Tests/Integration/PlosOneTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Integration/PlosOneTests.cs
@@ -1,7 +1,5 @@
 ﻿namespace UglyToad.PdfPig.Tests.Integration
 {
-    using Xunit;
-
     public class PlosOneTests
     {
         private static string GetFilename()

--- a/src/UglyToad.PdfPig.Tests/Integration/PopBugzilla37292Tests.cs
+++ b/src/UglyToad.PdfPig.Tests/Integration/PopBugzilla37292Tests.cs
@@ -1,7 +1,5 @@
 ﻿namespace UglyToad.PdfPig.Tests.Integration
 {
-    using Xunit;
-
     public class PopBugzilla37292Tests
     {
         private static string GetFilename()

--- a/src/UglyToad.PdfPig.Tests/Integration/RotationAndCroppingTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Integration/RotationAndCroppingTests.cs
@@ -1,8 +1,5 @@
 ﻿namespace UglyToad.PdfPig.Tests.Integration
 {
-    using System.Linq;
-    using Xunit;
-
     public class RotationAndCroppingTests
     {
         [Fact]

--- a/src/UglyToad.PdfPig.Tests/Integration/ShadingTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Integration/ShadingTests.cs
@@ -1,7 +1,5 @@
 ﻿namespace UglyToad.PdfPig.Tests.Integration
 {
-    using Xunit;
-
     public class ShadingTests
     {
         [Fact]

--- a/src/UglyToad.PdfPig.Tests/Integration/ShowTextEscapeText.cs
+++ b/src/UglyToad.PdfPig.Tests/Integration/ShowTextEscapeText.cs
@@ -1,9 +1,7 @@
 namespace UglyToad.PdfPig.Tests.Integration
 {
-    using System.Linq;
     using UglyToad.PdfPig;
     using UglyToad.PdfPig.Writer;
-    using Xunit;
 
     public class ShowTextEscapeText
     {

--- a/src/UglyToad.PdfPig.Tests/Integration/SinglePageFormContentIText1Tests.cs
+++ b/src/UglyToad.PdfPig.Tests/Integration/SinglePageFormContentIText1Tests.cs
@@ -1,11 +1,8 @@
 ﻿namespace UglyToad.PdfPig.Tests.Integration
 {
-    using System;
     using System.Globalization;
     using System.IO;
-    using System.Linq;
     using Content;
-    using Xunit;
 
     public class SinglePageFormContentIText1Tests
     {

--- a/src/UglyToad.PdfPig.Tests/Integration/SinglePageHyperlinksOpenOffice.cs
+++ b/src/UglyToad.PdfPig.Tests/Integration/SinglePageHyperlinksOpenOffice.cs
@@ -1,7 +1,5 @@
 ﻿namespace UglyToad.PdfPig.Tests.Integration
 {
-    using Xunit;
-
     public class SinglePageHyperlinksOpenOffice
     {
         private static string GetFilename()

--- a/src/UglyToad.PdfPig.Tests/Integration/SinglePageInkscapeTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Integration/SinglePageInkscapeTests.cs
@@ -1,10 +1,5 @@
 ﻿namespace UglyToad.PdfPig.Tests.Integration
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Linq;
-    using Xunit;
-
     public class SinglePageInkscapeTests
     {
         private static string GetFilename()

--- a/src/UglyToad.PdfPig.Tests/Integration/SinglePageLibreOfficeImages.cs
+++ b/src/UglyToad.PdfPig.Tests/Integration/SinglePageLibreOfficeImages.cs
@@ -1,8 +1,5 @@
 ﻿namespace UglyToad.PdfPig.Tests.Integration
 {
-    using System.Linq;
-    using Xunit;
-
     public class SinglePageLibreOfficeImages
     {
         private static string GetFilePath() => IntegrationHelpers.GetDocumentPath(@"Single Page Images - from libre office.pdf");

--- a/src/UglyToad.PdfPig.Tests/Integration/SinglePageNonLatinAcrobatDistillerTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Integration/SinglePageNonLatinAcrobatDistillerTests.cs
@@ -1,11 +1,6 @@
 ﻿namespace UglyToad.PdfPig.Tests.Integration
 {
-    using System;
-    using System.Collections.Generic;
-    using System.IO;
-    using System.Linq;
     using Content;
-    using Xunit;
 
     public class SinglePageNonLatinAcrobatDistillerTests
     {

--- a/src/UglyToad.PdfPig.Tests/Integration/SinglePageSimpleGoogleChromeTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Integration/SinglePageSimpleGoogleChromeTests.cs
@@ -1,12 +1,7 @@
 ﻿// ReSharper disable AccessToDisposedClosure
 namespace UglyToad.PdfPig.Tests.Integration
 {
-    using System;
-    using System.Collections.Generic;
-    using System.IO;
-    using System.Linq;
     using Content;
-    using Xunit;
 
     public class SinglePageSimpleGoogleChromeTests
     {

--- a/src/UglyToad.PdfPig.Tests/Integration/SinglePageSimpleOpenOfficeTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Integration/SinglePageSimpleOpenOfficeTests.cs
@@ -1,9 +1,6 @@
 ﻿namespace UglyToad.PdfPig.Tests.Integration
 {
-    using System.IO;
-    using System.Linq;
     using Content;
-    using Xunit;
 
     public class SinglePageSimpleOpenOfficeTests
     {

--- a/src/UglyToad.PdfPig.Tests/Integration/SinglePageType1FontTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Integration/SinglePageType1FontTests.cs
@@ -1,7 +1,6 @@
 ﻿namespace UglyToad.PdfPig.Tests.Integration
 {
     using Content;
-    using Xunit;
 
     public class SinglePageType1FontTests
     {

--- a/src/UglyToad.PdfPig.Tests/Integration/StreamProcessorTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Integration/StreamProcessorTests.cs
@@ -12,9 +12,6 @@
     using PdfPig.Parser;
     using PdfPig.Tokenization.Scanner;
     using PdfPig.Tokens;
-    using System.Collections.Generic;
-    using System.Linq;
-    using Xunit;
 
     public class StreamProcessorTests
     {

--- a/src/UglyToad.PdfPig.Tests/Integration/SvgTextExporterTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Integration/SvgTextExporterTests.cs
@@ -1,11 +1,8 @@
 ﻿namespace UglyToad.PdfPig.Tests.Integration
 {
-    using System;
-    using System.IO;
     using System.Text;
     using System.Xml;
     using UglyToad.PdfPig.DocumentLayoutAnalysis.Export;
-    using Xunit;
 
     public class SvgTextExporterTests
     {

--- a/src/UglyToad.PdfPig.Tests/Integration/SwedishTouringCarChampionshipTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Integration/SwedishTouringCarChampionshipTests.cs
@@ -2,7 +2,6 @@
 {
     using Content;
     using UglyToad.PdfPig.Images.Png;
-    using Xunit;
 
     public class SwedishTouringCarChampionshipTests
     {

--- a/src/UglyToad.PdfPig.Tests/Integration/TwoPageTextOnlyLibreOfficeTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Integration/TwoPageTextOnlyLibreOfficeTests.cs
@@ -1,8 +1,6 @@
 ﻿namespace UglyToad.PdfPig.Tests.Integration
 {
-    using System.IO;
     using Content;
-    using Xunit;
 
     public class TwoPageTextOnlyLibreOfficeTests
     {

--- a/src/UglyToad.PdfPig.Tests/Integration/Type0FontTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Integration/Type0FontTests.cs
@@ -1,9 +1,6 @@
 namespace UglyToad.PdfPig.Tests.Integration
 {
-    using System.IO;
-    using System.Linq;
     using Content;
-    using Xunit;
 
     public class Type0FontTests
     {

--- a/src/UglyToad.PdfPig.Tests/Integration/Type0_CJK_FontTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Integration/Type0_CJK_FontTests.cs
@@ -1,10 +1,5 @@
 ﻿namespace UglyToad.PdfPig.Tests.Integration
 {
-    using System.IO;
-    using System.Linq;
-    using Content;
-    using Xunit;
-
     public class Type0_CJK_FontTests
     {
         private static string GetFilename()
@@ -21,8 +16,7 @@
             {
                 Assert.Equal(95, document.NumberOfPages);
             }
-        }
- 
+        } 
 
         [Fact]
         public void HasCorrectChineseCharacters()

--- a/src/UglyToad.PdfPig.Tests/Integration/Type3FontTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Integration/Type3FontTests.cs
@@ -1,7 +1,5 @@
 namespace UglyToad.PdfPig.Tests.Integration
 {
-    using Xunit;
-
     public class Type3FontTests
     {
         private static string GetFilename()

--- a/src/UglyToad.PdfPig.Tests/Integration/VisualVerification/GenerateLetterBoundingBoxImages.cs
+++ b/src/UglyToad.PdfPig.Tests/Integration/VisualVerification/GenerateLetterBoundingBoxImages.cs
@@ -2,9 +2,6 @@
 {
     using PdfPig.Core;
     using SkiaSharp;
-    using System;
-    using System.IO;
-    using Xunit;
 
     public class GenerateLetterBoundingBoxImages
     {

--- a/src/UglyToad.PdfPig.Tests/Integration/VisualVerification/GenerateLetterGlyphImages.cs
+++ b/src/UglyToad.PdfPig.Tests/Integration/VisualVerification/GenerateLetterGlyphImages.cs
@@ -2,11 +2,8 @@
 {
     using PdfPig.Core;
     using SkiaSharp;
-    using System;
     using System.IO;
-    using System.Linq;
     using UglyToad.PdfPig.Tests.Integration.VisualVerification.SkiaHelpers;
-    using Xunit;
 
     public class GenerateLetterGlyphImages
     {

--- a/src/UglyToad.PdfPig.Tests/Integration/VisualVerification/SkiaHelpers/SkiaExtensions.cs
+++ b/src/UglyToad.PdfPig.Tests/Integration/VisualVerification/SkiaHelpers/SkiaExtensions.cs
@@ -3,8 +3,6 @@
     using PdfPig.Core;
     using PdfPig.Graphics.Colors;
     using SkiaSharp;
-    using System;
-    using System.Collections.Generic;
 
     internal static class SkiaExtensions
     {

--- a/src/UglyToad.PdfPig.Tests/Integration/VisualVerification/SkiaHelpers/SkiaGlyphPageFactory.cs
+++ b/src/UglyToad.PdfPig.Tests/Integration/VisualVerification/SkiaHelpers/SkiaGlyphPageFactory.cs
@@ -10,7 +10,6 @@
     using PdfPig.Tokenization.Scanner;
     using PdfPig.Tokens;
     using SkiaSharp;
-    using System.Collections.Generic;
 
     internal sealed class SkiaGlyphPageFactory : BasePageFactory<SKPicture>
     {

--- a/src/UglyToad.PdfPig.Tests/Integration/VisualVerification/SkiaHelpers/SkiaGlyphStreamProcessor.cs
+++ b/src/UglyToad.PdfPig.Tests/Integration/VisualVerification/SkiaHelpers/SkiaGlyphStreamProcessor.cs
@@ -12,7 +12,6 @@
     using PdfPig.Tokenization.Scanner;
     using PdfPig.Tokens;
     using SkiaSharp;
-    using System.Collections.Generic;
 
     internal sealed class SkiaGlyphStreamProcessor : BaseStreamProcessor<SKPicture>
     {

--- a/src/UglyToad.PdfPig.Tests/Integration/XObjectFormTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Integration/XObjectFormTests.cs
@@ -1,7 +1,6 @@
 ﻿namespace UglyToad.PdfPig.Tests.Integration
 {
     using UglyToad.PdfPig.Core;
-    using Xunit;
 
     public class XObjectFormTests
     {

--- a/src/UglyToad.PdfPig.Tests/Parser/PageContentParserTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Parser/PageContentParserTests.cs
@@ -1,7 +1,5 @@
 ﻿namespace UglyToad.PdfPig.Tests.Parser
 {
-    using System;
-    using System.IO;
     using System.Text.RegularExpressions;
     using Logging;
     using PdfPig.Core;
@@ -14,7 +12,6 @@
     using PdfPig.Graphics.Operations.TextState;
     using PdfPig.Parser;
     using PdfPig.Tokens;
-    using Xunit;
 
     public class PageContentParserTests
     {

--- a/src/UglyToad.PdfPig.Tests/Parser/Parts/BruteForceSearcherTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Parser/Parts/BruteForceSearcherTests.cs
@@ -1,12 +1,9 @@
 ﻿// ReSharper disable ObjectCreationAsStatement
 namespace UglyToad.PdfPig.Tests.Parser.Parts
 {
-    using System;
-    using System.IO;
     using Integration;
     using PdfPig.Core;
     using PdfPig.Parser.Parts;
-    using Xunit;
 
     public class BruteForceSearcherTests
     {

--- a/src/UglyToad.PdfPig.Tests/Parser/Parts/CrossReference/TableSubsectionDefinitionTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Parser/Parts/CrossReference/TableSubsectionDefinitionTests.cs
@@ -1,8 +1,6 @@
 ﻿namespace UglyToad.PdfPig.Tests.Parser.Parts.CrossReference
 {
-    using System;
     using PdfPig.Parser.Parts.CrossReference;
-    using Xunit;
 
     public class TableSubsectionDefinitionTests
     {

--- a/src/UglyToad.PdfPig.Tests/Parser/Parts/DirectObjectFinderTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Parser/Parts/DirectObjectFinderTests.cs
@@ -1,11 +1,9 @@
 ﻿namespace UglyToad.PdfPig.Tests.Parser.Parts
 {
-    using System;
     using PdfPig.Core;
     using PdfPig.Parser.Parts;
     using PdfPig.Tokens;
     using Tokens;
-    using Xunit;
 
     public class DirectObjectFinderTests
     {

--- a/src/UglyToad.PdfPig.Tests/Parser/Parts/FileHeaderParserTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Parser/Parts/FileHeaderParserTests.cs
@@ -1,13 +1,10 @@
 ﻿namespace UglyToad.PdfPig.Tests.Parser.Parts
 {
-    using System;
     using Logging;
     using PdfPig.Core;
     using PdfPig.Parser.FileStructure;
     using PdfPig.Tokenization.Scanner;
     using PdfPig.Tokens;
-    using System.Linq;
-    using Xunit;
 
     public class FileHeaderParserTests
     {

--- a/src/UglyToad.PdfPig.Tests/Parser/Parts/FileHeaderParserTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Parser/Parts/FileHeaderParserTests.cs
@@ -162,7 +162,7 @@ three %PDF-1.6";
             const string hex =
                 @"00 0F 4A 43 42 31 33 36 36 31 32 32 37 2E 70 64 66 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 50 44 46 20 43 41 52 4F 01 00 FF FF FF FF 00 00 00 00 00 04 DF 28 00 00 00 00 AF 51 7E 82 AF 52 D7 09 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 81 81 03 0D 00 00 25 50 44 46 2D 31 2E 31 0A 25 E2 E3 CF D3 0D 0A 31 20 30 20 6F 62 6A";
 
-            var bytes = hex.Split(' ', StringSplitOptions.RemoveEmptyEntries).Select(x => HexToken.Convert(x[0], x[1]));
+            var bytes = hex.Split(' ').Where(x => x.Length > 0).Select(x => HexToken.Convert(x[0], x[1]));
 
             var str = OtherEncodings.BytesAsLatin1String(bytes.ToArray());
 

--- a/src/UglyToad.PdfPig.Tests/Parser/Parts/FileStructure/CrossReferenceTableParserTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Parser/Parts/FileStructure/CrossReferenceTableParserTests.cs
@@ -1,12 +1,9 @@
 ﻿namespace UglyToad.PdfPig.Tests.Parser.Parts.FileStructure
 {
-    using System;
-    using System.Linq;
     using PdfPig.Core;
     using PdfPig.CrossReference;
     using PdfPig.Parser.FileStructure;
     using PdfPig.Tokenization.Scanner;
-    using Xunit;
 
     public class CrossReferenceTableParserTests
     {

--- a/src/UglyToad.PdfPig.Tests/Parser/Parts/FileTrailerParserTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Parser/Parts/FileTrailerParserTests.cs
@@ -1,10 +1,8 @@
 ﻿namespace UglyToad.PdfPig.Tests.Parser.Parts
 {
-    using System;
     using PdfPig.Core;
     using PdfPig.Parser.FileStructure;
     using PdfPig.Tokenization.Scanner;
-    using Xunit;
 
     public class FileTrailerFileTrailerParserTests
     {

--- a/src/UglyToad.PdfPig.Tests/Parser/Parts/ReadHelperTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Parser/Parts/ReadHelperTests.cs
@@ -1,7 +1,6 @@
 ﻿namespace UglyToad.PdfPig.Tests.Parser.Parts
 {
     using PdfPig.Core;
-    using Xunit;
 
     public class ReadHelperTests
     {

--- a/src/UglyToad.PdfPig.Tests/PointComparer.cs
+++ b/src/UglyToad.PdfPig.Tests/PointComparer.cs
@@ -1,7 +1,5 @@
 ﻿namespace UglyToad.PdfPig.Tests
 {
-    using System;
-    using System.Collections.Generic;
     using PdfPig.Core;
 
     internal class PointComparer : IEqualityComparer<PdfPoint>

--- a/src/UglyToad.PdfPig.Tests/PublicApiScannerTests.cs
+++ b/src/UglyToad.PdfPig.Tests/PublicApiScannerTests.cs
@@ -1,11 +1,7 @@
 ﻿namespace UglyToad.PdfPig.Tests
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Linq;
     using System.Reflection;
     using PdfPig.Graphics.Operations;
-    using Xunit;
 
     public class PublicApiScannerTests
     {

--- a/src/UglyToad.PdfPig.Tests/TestEnvironment.cs
+++ b/src/UglyToad.PdfPig.Tests/TestEnvironment.cs
@@ -1,10 +1,7 @@
 ﻿namespace UglyToad.PdfPig.Tests
 {
-    using System;
-
     public static class TestEnvironment
     {
-        public static bool IsSingleByteNewLine(string s) => s.IndexOf('\r') < 0;
-            
+        public static bool IsSingleByteNewLine(string s) => s.IndexOf('\r') < 0;           
     }
 }

--- a/src/UglyToad.PdfPig.Tests/TestFilterProvider.cs
+++ b/src/UglyToad.PdfPig.Tests/TestFilterProvider.cs
@@ -1,6 +1,5 @@
 ﻿namespace UglyToad.PdfPig.Tests
 {
-    using System.Collections.Generic;
     using PdfPig.Filters;
     using PdfPig.Tokenization.Scanner;
     using PdfPig.Tokens;

--- a/src/UglyToad.PdfPig.Tests/TestObjectLocationProvider.cs
+++ b/src/UglyToad.PdfPig.Tests/TestObjectLocationProvider.cs
@@ -1,6 +1,5 @@
 ﻿namespace UglyToad.PdfPig.Tests
 {
-    using System.Collections.Generic;
     using PdfPig.Core;
     using PdfPig.Tokenization.Scanner;
     using PdfPig.Tokens;

--- a/src/UglyToad.PdfPig.Tests/TestPdfImage.cs
+++ b/src/UglyToad.PdfPig.Tests/TestPdfImage.cs
@@ -1,6 +1,5 @@
 ﻿namespace UglyToad.PdfPig.Tests
 {
-    using System.Collections.Generic;
     using UglyToad.PdfPig.Content;
     using UglyToad.PdfPig.Core;
     using UglyToad.PdfPig.Graphics.Colors;

--- a/src/UglyToad.PdfPig.Tests/TestingLog.cs
+++ b/src/UglyToad.PdfPig.Tests/TestingLog.cs
@@ -1,6 +1,5 @@
 ﻿namespace UglyToad.PdfPig.Tests
 {
-    using System;
     using Logging;
 
     public class TestingLog : ILog

--- a/src/UglyToad.PdfPig.Tests/Tokenization/ArrayTokenizerTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Tokenization/ArrayTokenizerTests.cs
@@ -1,9 +1,7 @@
 ﻿namespace UglyToad.PdfPig.Tests.Tokenization
 {
-    using System.Collections.Generic;
     using PdfPig.Tokenization;
     using PdfPig.Tokens;
-    using Xunit;
 
     public class ArrayTokenizerTests
     {

--- a/src/UglyToad.PdfPig.Tests/Tokenization/CommentTokenizerTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Tokenization/CommentTokenizerTests.cs
@@ -2,7 +2,6 @@
 {
     using PdfPig.Tokenization;
     using PdfPig.Tokens;
-    using Xunit;
 
     public class CommentTokenizerTests
     {

--- a/src/UglyToad.PdfPig.Tests/Tokenization/DictionaryTokenizerTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Tokenization/DictionaryTokenizerTests.cs
@@ -1,12 +1,9 @@
 ﻿// ReSharper disable ParameterOnlyUsedForPreconditionCheck.Local
 namespace UglyToad.PdfPig.Tests.Tokenization
 {
-    using System;
-    using System.Collections.Generic;
     using PdfPig.Core;
     using PdfPig.Tokenization;
     using PdfPig.Tokens;
-    using Xunit;
 
     public class DictionaryTokenizerTests
     {

--- a/src/UglyToad.PdfPig.Tests/Tokenization/EndOfLineTokenizerTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Tokenization/EndOfLineTokenizerTests.cs
@@ -2,7 +2,6 @@
 {
     using PdfPig.Tokenization;
     using PdfPig.Tokens;
-    using Xunit;
 
     public class EndOfLineTokenizerTests
     {

--- a/src/UglyToad.PdfPig.Tests/Tokenization/HexTokenizerTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Tokenization/HexTokenizerTests.cs
@@ -2,7 +2,6 @@
 {
     using PdfPig.Tokenization;
     using PdfPig.Tokens;
-    using Xunit;
 
     public class HexTokenizerTests
     {

--- a/src/UglyToad.PdfPig.Tests/Tokenization/NameTokenizerTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Tokenization/NameTokenizerTests.cs
@@ -2,7 +2,6 @@
 {
     using PdfPig.Tokenization;
     using PdfPig.Tokens;
-    using Xunit;
 
     public class NameTokenizerTests
     {

--- a/src/UglyToad.PdfPig.Tests/Tokenization/NumericTokenizerTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Tokenization/NumericTokenizerTests.cs
@@ -1,9 +1,7 @@
 ﻿namespace UglyToad.PdfPig.Tests.Tokenization
 {
-    using System.Collections.Generic;
     using PdfPig.Tokenization;
     using PdfPig.Tokens;
-    using Xunit;
 
     public class NumericTokenizerTests
     {

--- a/src/UglyToad.PdfPig.Tests/Tokenization/PlainTokenizerTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Tokenization/PlainTokenizerTests.cs
@@ -2,7 +2,6 @@
 {
     using PdfPig.Tokenization;
     using PdfPig.Tokens;
-    using Xunit;
 
     public class PlainTokenizerTests
     {

--- a/src/UglyToad.PdfPig.Tests/Tokenization/Scanner/CoreTokenScannerTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Tokenization/Scanner/CoreTokenScannerTests.cs
@@ -1,12 +1,9 @@
 ﻿// ReSharper disable ParameterOnlyUsedForPreconditionCheck.Local
 namespace UglyToad.PdfPig.Tests.Tokenization.Scanner
 {
-    using System;
-    using System.Collections.Generic;
     using PdfPig.Core;
     using PdfPig.Tokenization.Scanner;
     using PdfPig.Tokens;
-    using Xunit;
 
     public class CoreTokenScannerTests
     {

--- a/src/UglyToad.PdfPig.Tests/Tokenization/Scanner/PdfTokenScannerTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Tokenization/Scanner/PdfTokenScannerTests.cs
@@ -1,14 +1,10 @@
 ﻿namespace UglyToad.PdfPig.Tests.Tokenization.Scanner
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Linq;
     using System.Text;
     using PdfPig.Core;
     using PdfPig.Encryption;
     using PdfPig.Tokenization.Scanner;
     using PdfPig.Tokens;
-    using Xunit;
 
     public class PdfTokenScannerTests
     {

--- a/src/UglyToad.PdfPig.Tests/Tokenization/StringTokenizerTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Tokenization/StringTokenizerTests.cs
@@ -3,7 +3,6 @@
     using PdfPig.Core;
     using PdfPig.Tokenization;
     using PdfPig.Tokens;
-    using Xunit;
 
     public class StringTokenizerTests
     {

--- a/src/UglyToad.PdfPig.Tests/Tokens/ArrayTokenTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Tokens/ArrayTokenTests.cs
@@ -1,8 +1,6 @@
 ﻿namespace UglyToad.PdfPig.Tests.Tokens
 {
-    using System;
     using PdfPig.Tokens;
-    using Xunit;
 
     public class ArrayTokenTests
     {

--- a/src/UglyToad.PdfPig.Tests/Tokens/BooleanTokenTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Tokens/BooleanTokenTests.cs
@@ -1,7 +1,6 @@
 ﻿namespace UglyToad.PdfPig.Tests.Tokens
 {
     using PdfPig.Tokens;
-    using Xunit;
 
     public class BooleanTokenTests
     {

--- a/src/UglyToad.PdfPig.Tests/Tokens/DictionaryTokenTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Tokens/DictionaryTokenTests.cs
@@ -1,12 +1,9 @@
 ﻿// ReSharper disable ObjectCreationAsStatement
 namespace UglyToad.PdfPig.Tests.Tokens
 {
-    using System;
-    using System.Collections.Generic;
     using PdfPig.Core;
     using PdfPig.Tokens;
-    using Xunit;
-
+ 
     public class DictionaryTokenTests
     {
         [Fact]

--- a/src/UglyToad.PdfPig.Tests/Tokens/HexTokenTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Tokens/HexTokenTests.cs
@@ -1,7 +1,6 @@
 ﻿namespace UglyToad.PdfPig.Tests.Tokens
 {
     using PdfPig.Tokens;
-    using Xunit;
 
     public class HexTokenTests
     {

--- a/src/UglyToad.PdfPig.Tests/Tokens/TestPdfTokenScanner.cs
+++ b/src/UglyToad.PdfPig.Tests/Tokens/TestPdfTokenScanner.cs
@@ -1,8 +1,6 @@
 ﻿// ReSharper disable ObjectCreationAsStatement
 namespace UglyToad.PdfPig.Tests.Tokens
 {
-    using System;
-    using System.Collections.Generic;
     using PdfPig.Core;
     using PdfPig.Tokenization;
     using PdfPig.Tokenization.Scanner;

--- a/src/UglyToad.PdfPig.Tests/UglyToad.PdfPig.Tests.csproj
+++ b/src/UglyToad.PdfPig.Tests/UglyToad.PdfPig.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;net8.0</TargetFrameworks>
+    <TargetFrameworks>net471;net8.0</TargetFrameworks>
     <IsTestProject>true</IsTestProject>
     <IsPackable>false</IsPackable>
     <DebugType>full</DebugType>

--- a/src/UglyToad.PdfPig.Tests/UglyToad.PdfPig.Tests.csproj
+++ b/src/UglyToad.PdfPig.Tests/UglyToad.PdfPig.Tests.csproj
@@ -5,7 +5,7 @@
     <IsTestProject>true</IsTestProject>
     <IsPackable>false</IsPackable>
     <DebugType>full</DebugType>
-    <LangVersion>latest</LangVersion>
+    <LangVersion>12</LangVersion>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\pdfpig.snk</AssemblyOriginatorKeyFile>
     <RuntimeFrameworkVersion Condition="'$(TargetFramework)'=='netcoreapp2.1'">2.1.30</RuntimeFrameworkVersion>
@@ -89,11 +89,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.3" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
     <PackageReference Include="SkiaSharp" Version="2.88.7" />
-    <PackageReference Include="xunit" Version="2.6.6" />
-    <PackageReference Include="xunit.extensibility.execution" Version="2.6.6" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+    <PackageReference Include="xunit" Version="2.7.0" />
+    <PackageReference Include="xunit.extensibility.execution" Version="2.7.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.7">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/src/UglyToad.PdfPig.Tests/UglyToad.PdfPig.Tests.csproj
+++ b/src/UglyToad.PdfPig.Tests/UglyToad.PdfPig.Tests.csproj
@@ -9,6 +9,7 @@
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\pdfpig.snk</AssemblyOriginatorKeyFile>
     <RuntimeFrameworkVersion Condition="'$(TargetFramework)'=='netcoreapp2.1'">2.1.30</RuntimeFrameworkVersion>
+    <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 
   <ItemGroup>
@@ -131,5 +132,8 @@
     <None Update="Dla\Documents\Random 2 Columns Lists Hyph - Justified.pdf">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+  </ItemGroup>
+  <ItemGroup>
+    <Using Include="Xunit" />
   </ItemGroup>
 </Project>

--- a/src/UglyToad.PdfPig.Tests/Util/DateFormatHelperTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Util/DateFormatHelperTests.cs
@@ -1,14 +1,11 @@
 ﻿namespace UglyToad.PdfPig.Tests.Util
 {
-    using System;
-    using System.Collections.Generic;
     using PdfPig.Util;
-    using Xunit;
-
+ 
     public class DateFormatHelperTests
     {
-        public static IEnumerable<object[]> PositiveDateData = new[]
-        {
+        public static IEnumerable<object[]> PositiveDateData =
+        [
             new object[] {"D:20190710205447+01'00'", new DateTimeOffset(2019, 7, 10, 20, 54, 47, TimeSpan.FromHours(1))},
             new object[] {"D:2017", new DateTimeOffset(2017, 1, 1, 0, 0, 0, TimeSpan.Zero)},
             new object[] {"2017", new DateTimeOffset(2017, 1, 1, 0, 0, 0, TimeSpan.Zero)},
@@ -24,7 +21,7 @@
             new object[] {"D:19970915110347-07'30'", new DateTimeOffset(1997, 9, 15, 11, 3, 47, new TimeSpan(-7, -30, 0))},
             new object[] {"D:19990209153925+11'", new DateTimeOffset(1999, 2, 9, 15, 39, 25, TimeSpan.FromHours(11))},
             new object[] {"D:19990209153925-03'", new DateTimeOffset(1999, 2, 9, 15, 39, 25, TimeSpan.FromHours(-3))},
-        };
+        ];
 
         [Theory]
         [InlineData(default(string))]

--- a/src/UglyToad.PdfPig.Tests/Util/DefaultWordExtractorTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Util/DefaultWordExtractorTests.cs
@@ -1,8 +1,6 @@
 ﻿namespace UglyToad.PdfPig.Tests.Util
 {
     using Integration;
-    using System.Linq;
-    using Xunit;
 
     public class DefaultWordExtractorTests
     {

--- a/src/UglyToad.PdfPig.Tests/Util/HexTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Util/HexTests.cs
@@ -1,8 +1,6 @@
 ﻿namespace UglyToad.PdfPig.Tests.Util
 {
-    using System.Collections.Generic;
     using PdfPig.Util;
-    using Xunit;
 
     public class HexTests
     {

--- a/src/UglyToad.PdfPig.Tests/Util/InternalStringExtensionsTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Util/InternalStringExtensionsTests.cs
@@ -1,8 +1,6 @@
 namespace UglyToad.PdfPig.Tests.Util
 {
-    using System;
     using PdfPig.Util;
-    using Xunit;
 
     public class InternalStringExtensionsTests
     {

--- a/src/UglyToad.PdfPig.Tests/Util/Matrix3x3Tests.cs
+++ b/src/UglyToad.PdfPig.Tests/Util/Matrix3x3Tests.cs
@@ -1,6 +1,5 @@
 ﻿namespace UglyToad.PdfPig.Tests.Util
 {
-    using Xunit;
     using PdfPig.Util;
 
     public class Matrix3x3Tests

--- a/src/UglyToad.PdfPig.Tests/Util/OctalHelpersTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Util/OctalHelpersTests.cs
@@ -1,7 +1,6 @@
 ﻿namespace UglyToad.PdfPig.Tests.Util
 {
     using PdfPig.Core;
-    using Xunit;
 
     public class OctalHelpersTests
     {

--- a/src/UglyToad.PdfPig.Tests/Util/OtherEncodingsTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Util/OtherEncodingsTests.cs
@@ -1,7 +1,6 @@
 ﻿namespace UglyToad.PdfPig.Tests.Util
 {
     using PdfPig.Core;
-    using Xunit;
 
     public class OtherEncodingsTests
     {

--- a/src/UglyToad.PdfPig.Tests/Writer/Fonts/Standard14WritingFontTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Writer/Fonts/Standard14WritingFontTests.cs
@@ -1,21 +1,14 @@
 ﻿namespace UglyToad.PdfPig.Tests.Writer.Fonts
 {
-    using System;
-
-    using System.Linq;
     using PdfPig.Fonts;
     using PdfPig.Content;
     using UglyToad.PdfPig.Core;
     using UglyToad.PdfPig.Fonts.Standard14Fonts;
     using UglyToad.PdfPig.Writer;
 
-    using Xunit;
     using System.Reflection;
-    using System.Collections.Generic;
     using UglyToad.PdfPig.Fonts.AdobeFontMetrics;
-    using System.IO;
     using System.Diagnostics;
-
 
     public class Standard14WritingFontTests
     {

--- a/src/UglyToad.PdfPig.Tests/Writer/Fonts/ToUnicodeCMapBuilderTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Writer/Fonts/ToUnicodeCMapBuilderTests.cs
@@ -1,10 +1,8 @@
 ﻿namespace UglyToad.PdfPig.Tests.Writer.Fonts
 {
-    using System.Collections.Generic;
     using PdfFonts.Parser;
     using PdfPig.Core;
     using PdfPig.Writer.Fonts;
-    using Xunit;
 
     public class ToUnicodeCMapBuilderTests
     {

--- a/src/UglyToad.PdfPig.Tests/Writer/PdfDocumentBuilderTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Writer/PdfDocumentBuilderTests.cs
@@ -1,17 +1,12 @@
 ﻿namespace UglyToad.PdfPig.Tests.Writer
 {
-    using System.IO;
-    using System.Linq;
     using Content;
     using Integration;
     using PdfPig.Core;
     using PdfPig.Fonts.Standard14Fonts;
     using PdfPig.Tokens;
     using PdfPig.Writer;
-    using System.Collections.Generic;
     using Tests.Fonts.TrueType;
-    using Xunit;
-    using System;
     using UglyToad.PdfPig.Graphics.Operations.InlineImages;
     using UglyToad.PdfPig.Outline;
     using UglyToad.PdfPig.Outline.Destinations;

--- a/src/UglyToad.PdfPig.Tests/Writer/PdfMergerTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Writer/PdfMergerTests.cs
@@ -2,11 +2,6 @@
 {
     using Integration;
     using PdfPig.Writer;
-    using System;
-    using System.Collections.Generic;
-    using System.IO;
-    using System.Linq;
-    using Xunit;
 
     public class PdfMergerTests
     {

--- a/src/UglyToad.PdfPig.Tests/Writer/PdfPageBuilderTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Writer/PdfPageBuilderTests.cs
@@ -1,19 +1,12 @@
 ﻿namespace UglyToad.PdfPig.Tests.Images
 {
-    using System;
-    using System.IO;
-    using System.Linq;
     using UglyToad.PdfPig;
-    using UglyToad.PdfPig.Content;
     using UglyToad.PdfPig.Core;
     using UglyToad.PdfPig.Fonts.Standard14Fonts;
     using UglyToad.PdfPig.Writer;
-    using Xunit;
-
+ 
     public class PdfPageBuilderTests
     {
-
-
         [Fact]
         public void CanAddPng()
         {
@@ -44,7 +37,6 @@
                 }
                 pdfBytes = pdfBuilder.Build();
             }
-
 
             File.WriteAllBytes(@"PdfPageBuilderTests_CanAddPng.pdf", pdfBytes);
 

--- a/src/UglyToad.PdfPig.Tests/Writer/PdfTextRemoverTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Writer/PdfTextRemoverTests.cs
@@ -1,7 +1,5 @@
-﻿using System.IO;
-using UglyToad.PdfPig.Tests.Integration;
+﻿using UglyToad.PdfPig.Tests.Integration;
 using UglyToad.PdfPig.Writer;
-using Xunit;
 
 namespace UglyToad.PdfPig.Tests.Writer
 {

--- a/src/UglyToad.PdfPig.Tests/Writer/TokenWriterTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Writer/TokenWriterTests.cs
@@ -1,14 +1,10 @@
 ﻿namespace UglyToad.PdfPig.Tests.Writer
 {
-    using Integration;
     using PdfPig.Writer;
-    using System.IO;
     using UglyToad.PdfPig.Tokens;
-    using Xunit;
 
     public class TokenWriterTests
     {
-
         [Fact]
         public void EscapeSpecialCharacter()
         {

--- a/src/UglyToad.PdfPig.Tests/Writer/XmpTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Writer/XmpTests.cs
@@ -3,9 +3,7 @@
     using Integration;
     using PdfPig.Content;
     using PdfPig.Writer;
-    using System.Linq;
     using System.Xml.Linq;
-    using Xunit;
 
     public class XmpTests
     {


### PR DESCRIPTION
- Update xunit to 2.7.0
- Updates Microsoft.NET.Test.Sdk to 17.9.0
- Enables implicit usings
- Replace netcoreapp2.1 test target (obsolete, and no longer compatible with xunit) with net471