### PR TITLE
Spanify work, 1 of x

### DIFF
--- a/src/UglyToad.PdfPig.Core/ArrayPoolBufferWriter.cs
+++ b/src/UglyToad.PdfPig.Core/ArrayPoolBufferWriter.cs
@@ -1,0 +1,148 @@
+﻿using System;
+using System.Buffers;
+
+namespace UglyToad.PdfPig.Core;
+
+/// <summary>
+/// Pooled Buffer Writer
+/// </summary>
+public sealed class ArrayPoolBufferWriter<T> : IBufferWriter<T>, IDisposable
+{
+    private const int DefaultBufferSize = 256;
+
+    private T[] buffer;
+    private int position;
+
+    /// <summary>
+    /// PooledBufferWriter constructor
+    /// </summary>
+    public ArrayPoolBufferWriter()
+    {
+        buffer = ArrayPool<T>.Shared.Rent(DefaultBufferSize);
+        position = 0;
+    }
+
+    /// <summary>
+    /// Constructs a PooledBufferWriter
+    /// </summary>
+    /// <param name="size">The size of the initial buffer</param>
+    public ArrayPoolBufferWriter(int size)
+    {
+        buffer = ArrayPool<T>.Shared.Rent(size);
+        position = 0;
+    }
+
+    /// <summary>
+    /// Advanced the current position
+    /// </summary>
+    /// <param name="count"></param>
+    public void Advance(int count)
+    {
+        position += count;
+    }
+
+    /// <summary>
+    /// Writes the provided value
+    /// </summary>
+    public void Write(T value)
+    {
+        GetSpan(1)[0] = value;
+
+        position += 1;
+    }
+
+    /// <summary>
+    /// Writes the provided values
+    /// </summary>
+    /// <param name="values"></param>
+    public void Write(ReadOnlySpan<T> values)
+    {
+        values.CopyTo(GetSpan(values.Length));
+
+        position += values.Length;
+    }
+
+    /// <summary>
+    /// Returns a writeable block of memory that can be written to
+    /// </summary>
+    public Memory<T> GetMemory(int sizeHint = 0)
+    {
+        EnsureCapacity(sizeHint);
+
+        return buffer.AsMemory(position);
+    }
+
+    /// <summary>
+    /// Returns a span that can be written to
+    /// </summary>
+    public Span<T> GetSpan(int sizeHint = 0)
+    {
+        EnsureCapacity(sizeHint);
+
+        return buffer.AsSpan(position);
+    }
+
+    /// <summary>
+    /// Returns the number of bytes written to the buffer
+    /// </summary>
+    public int WrittenCount => position;
+
+    /// <summary>
+    /// Returns the committed data as Memory
+    /// </summary>
+    public ReadOnlyMemory<T> WrittenMemory => buffer.AsMemory(0, position);
+
+    /// <summary>
+    /// Returns the committed data as a Span
+    /// </summary>
+    public ReadOnlySpan<T> WrittenSpan => buffer.AsSpan(0, position);
+
+    private void EnsureCapacity(int sizeHint)
+    {
+        if (sizeHint is 0)
+        {
+            sizeHint = 1;
+        }
+
+        if (sizeHint > RemainingBytes)
+        {
+            var newBuffer = ArrayPool<T>.Shared.Rent(Math.Max(position + sizeHint, 512));
+
+            if (buffer.Length != 0)
+            {
+                Array.Copy(buffer, 0, newBuffer, 0, position);
+                ArrayPool<T>.Shared.Return(buffer);
+            }
+
+            buffer = newBuffer;
+        }
+    }
+
+    private int RemainingBytes => buffer.Length - position;
+
+    /// <summary>
+    /// Resets the internal state so the instance can be reused before disposal
+    /// </summary>
+    /// <param name="clearArray"></param>
+    public void Reset(bool clearArray = false)
+    {
+        position = 0;
+
+        if (clearArray)
+        {
+            buffer.AsSpan().Clear();
+        }
+    }
+
+    /// <summary>
+    /// Disposes the buffer and returns any rented memory to the pool
+    /// </summary>
+    public void Dispose()
+    {
+        if (buffer.Length != 0)
+        {
+            ArrayPool<T>.Shared.Return(buffer);
+            buffer = [];
+        }
+    }
+}

--- a/src/UglyToad.PdfPig.Core/OctalHelpers.cs
+++ b/src/UglyToad.PdfPig.Core/OctalHelpers.cs
@@ -42,7 +42,7 @@
         /// <summary>
         /// Read an integer from octal digits.
         /// </summary>
-        public static int FromOctalDigits(short[] octal)
+        public static int FromOctalDigits(ReadOnlySpan<short> octal)
         {
             int sum = 0;
             for (int i = octal.Length - 1; i >= 0; i--)

--- a/src/UglyToad.PdfPig.Core/OtherEncodings.cs
+++ b/src/UglyToad.PdfPig.Core/OtherEncodings.cs
@@ -1,7 +1,6 @@
 ﻿namespace UglyToad.PdfPig.Core
 {
-    using System.Collections.Generic;
-    using System.Linq;
+    using System;
     using System.Text;
 
     /// <summary>
@@ -30,31 +29,8 @@
         /// <summary>
         /// Convert the bytes to string using the ISO 8859-1 encoding.
         /// </summary>
-        public static string BytesAsLatin1String(IReadOnlyList<byte> bytes)
+        public static string BytesAsLatin1String(ReadOnlySpan<byte> bytes)
         {
-            if (bytes == null)
-            {
-                return null;
-            }
-
-            if (bytes is byte[] arr)
-            {
-                return BytesAsLatin1String(arr);
-            }
-
-            return BytesAsLatin1String(bytes.ToArray());
-        }
-
-        /// <summary>
-        /// Convert the bytes to string using the ISO 8859-1 encoding.
-        /// </summary>
-        public static string BytesAsLatin1String(byte[] bytes)
-        {
-            if (bytes == null)
-            {
-                return null;
-            }
-
             return Iso88591.GetString(bytes);
         }
     }

--- a/src/UglyToad.PdfPig.Core/PdfDocEncoding.cs
+++ b/src/UglyToad.PdfPig.Core/PdfDocEncoding.cs
@@ -1,5 +1,6 @@
 ﻿namespace UglyToad.PdfPig.Core
 {
+    using System;
     using System.Collections.Generic;
 
     /// <summary>
@@ -263,7 +264,7 @@
         /// Try to convert raw bytes to a PdfDocEncoding encoded string. If unsupported characters are encountered
         /// meaning we cannot safely round-trip the value to bytes this will instead return false.
         /// </summary>
-        public static bool TryConvertBytesToString(byte[] bytes, out string result)
+        public static bool TryConvertBytesToString(ReadOnlySpan<byte> bytes, out string result)
         {
             result = null;
             if (bytes.Length == 0)

--- a/src/UglyToad.PdfPig.Core/Polyfills/EncodingExtensions.cs
+++ b/src/UglyToad.PdfPig.Core/Polyfills/EncodingExtensions.cs
@@ -1,0 +1,16 @@
+﻿#if NETFRAMEWORK || NETSTANDARD2_0
+
+namespace System.Text;
+
+internal static class EncodingExtensions
+{
+    public unsafe static string GetString(this Encoding encoding, ReadOnlySpan<byte> bytes)
+    {
+        fixed (byte* pBytes = bytes)
+        {
+            return encoding.GetString(pBytes, bytes.Length);
+        }
+    }
+}
+
+#endif

--- a/src/UglyToad.PdfPig.Core/Polyfills/EncodingExtensions.cs
+++ b/src/UglyToad.PdfPig.Core/Polyfills/EncodingExtensions.cs
@@ -6,9 +6,13 @@ internal static class EncodingExtensions
 {
     public static string GetString(this Encoding encoding, ReadOnlySpan<byte> bytes)
     {
+        if (bytes.IsEmpty)
+        {
+            return string.Empty;
+        }
+
         // NOTE: this can be made allocation free by introducing unsafe
         return encoding.GetString(bytes.ToArray());
-        
     }
 }
 

--- a/src/UglyToad.PdfPig.Core/Polyfills/EncodingExtensions.cs
+++ b/src/UglyToad.PdfPig.Core/Polyfills/EncodingExtensions.cs
@@ -4,12 +4,11 @@ namespace System.Text;
 
 internal static class EncodingExtensions
 {
-    public unsafe static string GetString(this Encoding encoding, ReadOnlySpan<byte> bytes)
+    public static string GetString(this Encoding encoding, ReadOnlySpan<byte> bytes)
     {
-        fixed (byte* pBytes = bytes)
-        {
-            return encoding.GetString(pBytes, bytes.Length);
-        }
+        // NOTE: this can be made allocation free by introducing unsafe
+        return encoding.GetString(bytes.ToArray());
+        
     }
 }
 

--- a/src/UglyToad.PdfPig.Core/ReadHelper.cs
+++ b/src/UglyToad.PdfPig.Core/ReadHelper.cs
@@ -5,6 +5,10 @@
     using System.Globalization;
     using System.Text;
 
+#if NET8_0_OR_GREATER
+    using System.Text.Unicode;
+#endif
+
     /// <summary>
     /// Helper methods for reading from PDF files.
     /// </summary>
@@ -20,8 +24,8 @@
         /// </summary>
         public const byte AsciiCarriageReturn = 13;
 
-        private static readonly HashSet<int> EndOfNameCharacters = new HashSet<int>
-        {
+        private static readonly HashSet<int> EndOfNameCharacters =
+        [
             ' ',
             AsciiCarriageReturn,
             AsciiLineFeed,
@@ -35,7 +39,7 @@
             '(',
             0,
             '\f'
-        };
+        ];
 
         private static readonly int MaximumNumberStringLength = long.MaxValue.ToString("D").Length;
 
@@ -269,7 +273,11 @@
         /// </summary>
         public static bool IsHex(char ch)
         {
+#if NET8_0_OR_GREATER
+            return char.IsAsciiHexDigit(ch);
+#else
             return char.IsDigit(ch) || (ch >= 'a' && ch <= 'f') || (ch >= 'A' && ch <= 'F');
+#endif
         }
 
         /// <summary>
@@ -277,6 +285,9 @@
         /// </summary>
         public static bool IsValidUtf8(byte[] input)
         {
+#if NET8_0_OR_GREATER
+            return Utf8.IsValid(input);
+#else
             try
             {
                 var d = Encoding.UTF8.GetDecoder();
@@ -290,6 +301,7 @@
             {
                 return false;
             }
+#endif
         }
 
         private static StringBuilder ReadStringNumber(IInputBytes reader)

--- a/src/UglyToad.PdfPig.Core/UglyToad.PdfPig.Core.csproj
+++ b/src/UglyToad.PdfPig.Core/UglyToad.PdfPig.Core.csproj
@@ -7,7 +7,6 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\pdfpig.snk</AssemblyOriginatorKeyFile>
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|netstandard2.0|AnyCPU'">
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/src/UglyToad.PdfPig.Core/UglyToad.PdfPig.Core.csproj
+++ b/src/UglyToad.PdfPig.Core/UglyToad.PdfPig.Core.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net462;net471;net6.0;net8.0</TargetFrameworks>
     <LangVersion>12</LangVersion>
@@ -7,6 +7,7 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\pdfpig.snk</AssemblyOriginatorKeyFile>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|netstandard2.0|AnyCPU'">
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
@@ -17,7 +18,10 @@
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)'=='netstandard2.0' or '$(TargetFramework)'=='net462' OR '$(TargetFramework)'=='net471'">
     <PackageReference Include="Microsoft.Bcl.HashCode" Version="1.1.1" />
-  </ItemGroup>	
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)'=='netstandard2.0' or '$(TargetFramework)'=='net462' or '$(TargetFramework)'=='net471'">
+    <PackageReference Include="System.Memory" Version="4.5.5" />
+  </ItemGroup>
   <ItemGroup>
     <None Include="..\pdfpig.snk" Link="pdfpig.snk" />
   </ItemGroup>

--- a/src/UglyToad.PdfPig.DocumentLayoutAnalysis/TextEdgesExtractor.cs
+++ b/src/UglyToad.PdfPig.DocumentLayoutAnalysis/TextEdgesExtractor.cs
@@ -17,12 +17,12 @@
         /// <summary>
         /// Functions used to define left, middle and right edges.
         /// </summary>
-        private static readonly Tuple<EdgeType, Func<PdfRectangle, double>>[] edgesFuncs = new Tuple<EdgeType, Func<PdfRectangle, double>>[]
-        {
+        private static readonly Tuple<EdgeType, Func<PdfRectangle, double>>[] edgesFuncs =
+        [
             Tuple.Create<EdgeType, Func<PdfRectangle, double>>(EdgeType.Left,   x => Math.Round(x.Left, 0)),                // use BoundingBox's left coordinate
             Tuple.Create<EdgeType, Func<PdfRectangle, double>>(EdgeType.Mid, x => Math.Round(x.Left + x.Width / 2, 0)),     // use BoundingBox's mid coordinate
             Tuple.Create<EdgeType, Func<PdfRectangle, double>>(EdgeType.Right,  x => Math.Round(x.Right, 0))                // use BoundingBox's right coordinate
-        };
+        ];
 
         /// <summary>
         /// Get the text edges.

--- a/src/UglyToad.PdfPig.Fonts/Type1/CharStrings/Type1CharStringParser.cs
+++ b/src/UglyToad.PdfPig.Fonts/Type1/CharStrings/Type1CharStringParser.cs
@@ -1,13 +1,13 @@
 ﻿namespace UglyToad.PdfPig.Fonts.Type1.CharStrings
 {
+    using System;
+    using System.Collections.Generic;
     using Commands;
     using Commands.Arithmetic;
     using Commands.Hint;
     using Commands.PathConstruction;
     using Commands.StartFinishOutline;
     using Core;
-    using System;
-    using System.Collections.Generic;
 
     /// <summary>
     /// Decodes a set of CharStrings to their corresponding Type 1 BuildChar operations.
@@ -73,11 +73,11 @@
             return new Type1CharStrings(charStringResults, charStringIndexToName, subroutineResults);
         }
 
-        private static IReadOnlyList<Union<double, LazyType1Command>> ParseSingle(IReadOnlyList<byte> charStringBytes)
+        private static IReadOnlyList<Union<double, LazyType1Command>> ParseSingle(ReadOnlySpan<byte> charStringBytes)
         {
             var interpreted = new List<Union<double, LazyType1Command>>();
 
-            for (var i = 0; i < charStringBytes.Count; i++)
+            for (var i = 0; i < charStringBytes.Length; i++)
             {
                 var b = charStringBytes[i];
 
@@ -104,7 +104,7 @@
             return interpreted;
         }
 
-        private static int InterpretNumber(byte b, IReadOnlyList<byte> bytes, ref int i)
+        private static int InterpretNumber(byte b, ReadOnlySpan<byte> bytes, ref int i)
         {
             if (b >= 32 && b <= 246)
             {
@@ -128,7 +128,7 @@
             return result;
         }
 
-        public static LazyType1Command GetCommand(byte v, IReadOnlyList<byte> bytes, ref int i)
+        public static LazyType1Command GetCommand(byte v, ReadOnlySpan<byte> bytes, ref int i)
         {
             switch (v)
             {

--- a/src/UglyToad.PdfPig.Fonts/Type1/CharStrings/Type1CharstringDecryptedBytes.cs
+++ b/src/UglyToad.PdfPig.Fonts/Type1/CharStrings/Type1CharstringDecryptedBytes.cs
@@ -5,9 +5,9 @@
 
     internal sealed class Type1CharstringDecryptedBytes
     {
-        private readonly byte[] _bytes;
+        private readonly byte[] bytes;
 
-        public ReadOnlySpan<byte> Bytes => _bytes;
+        public ReadOnlySpan<byte> Bytes => bytes;
 
         public int Index { get; }
 
@@ -17,7 +17,7 @@
 
         public Type1CharstringDecryptedBytes(byte[] bytes, int index)
         {
-            _bytes = bytes;
+            this.bytes = bytes ?? throw new ArgumentNullException(nameof(bytes));
             Index = index;
             Name = GlyphList.NotDefined;
             Source = SourceType.Subroutine;
@@ -25,7 +25,7 @@
 
         public Type1CharstringDecryptedBytes(string name, byte[] bytes, int index)
         {
-            _bytes = bytes;
+            this.bytes = bytes ?? throw new ArgumentNullException(nameof(bytes));
             Index = index;
             Name = name ?? index.ToString(CultureInfo.InvariantCulture);
             Source = SourceType.Charstring;

--- a/src/UglyToad.PdfPig.Fonts/Type1/CharStrings/Type1CharstringDecryptedBytes.cs
+++ b/src/UglyToad.PdfPig.Fonts/Type1/CharStrings/Type1CharstringDecryptedBytes.cs
@@ -1,12 +1,13 @@
 ﻿namespace UglyToad.PdfPig.Fonts.Type1.CharStrings
 {
     using System;
-    using System.Collections.Generic;
     using System.Globalization;
 
     internal sealed class Type1CharstringDecryptedBytes
     {
-        public IReadOnlyList<byte> Bytes { get; }
+        private readonly byte[] _bytes;
+
+        public ReadOnlySpan<byte> Bytes => _bytes;
 
         public int Index { get; }
 
@@ -14,17 +15,17 @@
 
         public SourceType Source { get; }
 
-        public Type1CharstringDecryptedBytes(IReadOnlyList<byte> bytes, int index)
+        public Type1CharstringDecryptedBytes(byte[] bytes, int index)
         {
-            Bytes = bytes ?? throw new ArgumentNullException(nameof(bytes));
+            _bytes = bytes;
             Index = index;
             Name = GlyphList.NotDefined;
             Source = SourceType.Subroutine;
         }
 
-        public Type1CharstringDecryptedBytes(string name, IReadOnlyList<byte> bytes, int index)
+        public Type1CharstringDecryptedBytes(string name, byte[] bytes, int index)
         {
-            Bytes = bytes ?? throw new ArgumentNullException(nameof(bytes));
+            _bytes = bytes;
             Index = index;
             Name = name ?? index.ToString(CultureInfo.InvariantCulture);
             Source = SourceType.Charstring;
@@ -38,7 +39,7 @@
 
         public override string ToString()
         {
-            return $"{Name} {Source} {Index} {Bytes.Count} bytes";
+            return $"{Name} {Source} {Index} {Bytes.Length} bytes";
         }
     }
 }

--- a/src/UglyToad.PdfPig.Fonts/Type1/Parser/Type1FontParser.cs
+++ b/src/UglyToad.PdfPig.Fonts/Type1/Parser/Type1FontParser.cs
@@ -32,7 +32,7 @@
             // Sometimes the entire PFB file including the header bytes can be included which prevents parsing in the normal way.
             var isEntirePfbFile = inputBytes.Peek() == PfbFileIndicator;
 
-            IReadOnlyList<byte> eexecPortion = new byte[0];
+            ReadOnlySpan<byte> eexecPortion = [];
 
             if (isEntirePfbFile)
             {
@@ -77,7 +77,7 @@
             
             try
             {
-                var tempEexecPortion = new List<byte>();
+                using var tempEexecPortion = new ArrayPoolBufferWriter<byte>();
                 var tokenSet = new PreviousTokenSet();
                 tokenSet.Add(scanner.CurrentToken);
                 while (scanner.MoveNext())
@@ -100,7 +100,7 @@
                                     {
                                         for (int i = 0; i < offset; i++)
                                         {
-                                            tempEexecPortion.Add((byte)ClearToMark[i]);
+                                            tempEexecPortion.Write((byte)ClearToMark[i]);
                                         }
                                     }
 
@@ -117,7 +117,7 @@
                                     continue;
                                 }
 
-                                tempEexecPortion.Add(inputBytes.CurrentByte);
+                                tempEexecPortion.Write(inputBytes.CurrentByte);
                             }
                         }
                         else
@@ -131,7 +131,7 @@
 
                 if (!isEntirePfbFile)
                 {
-                    eexecPortion = tempEexecPortion;
+                    eexecPortion = tempEexecPortion.WrittenSpan.ToArray();
                 }
             }
             finally

--- a/src/UglyToad.PdfPig.Fonts/Type1/Parser/Type1Token.cs
+++ b/src/UglyToad.PdfPig.Fonts/Type1/Parser/Type1Token.cs
@@ -1,16 +1,15 @@
 ﻿namespace UglyToad.PdfPig.Fonts.Type1.Parser
 {
     using System;
-    using System.Collections.Generic;
     using System.Globalization;
 
-    internal class Type1DataToken : Type1Token
+    internal sealed class Type1DataToken : Type1Token
     {
-        public IReadOnlyList<byte> Data { get; }
+        public ReadOnlyMemory<byte> Data { get; }
 
         public override bool IsPrivateDictionary { get; } = false;
 
-        public Type1DataToken(TokenType type, IReadOnlyList<byte> data) : base(string.Empty, type)
+        public Type1DataToken(TokenType type, ReadOnlyMemory<byte> data) : base(string.Empty, type)
         {
             if (type != TokenType.Charstring)
             {
@@ -22,7 +21,7 @@
 
         public override string ToString()
         {
-            return $"Token[type = {Type}, data = {Data.Count} bytes]";
+            return $"Token[type = {Type}, data = {Data.Length} bytes]";
         }
     }
 

--- a/src/UglyToad.PdfPig.Tests/Encryption/RC4Tests.cs
+++ b/src/UglyToad.PdfPig.Tests/Encryption/RC4Tests.cs
@@ -35,7 +35,7 @@
             var result = new byte[hex.Length / 2];
             for (var i = 0; i < hex.Length; i += 2)
             {
-                result[i / 2] = HexToken.Convert(hex[i], hex[i + 1]);
+                result[i / 2] = HexToken.ConvertPair(hex[i], hex[i + 1]);
             }
 
             return result;

--- a/src/UglyToad.PdfPig.Tests/Parser/Parts/FileHeaderParserTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Parser/Parts/FileHeaderParserTests.cs
@@ -162,7 +162,7 @@ three %PDF-1.6";
             const string hex =
                 @"00 0F 4A 43 42 31 33 36 36 31 32 32 37 2E 70 64 66 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 50 44 46 20 43 41 52 4F 01 00 FF FF FF FF 00 00 00 00 00 04 DF 28 00 00 00 00 AF 51 7E 82 AF 52 D7 09 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 81 81 03 0D 00 00 25 50 44 46 2D 31 2E 31 0A 25 E2 E3 CF D3 0D 0A 31 20 30 20 6F 62 6A";
 
-            var bytes = hex.Split(' ').Where(x => x.Length > 0).Select(x => HexToken.Convert(x[0], x[1]));
+            var bytes = hex.Split(' ').Where(x => x.Length > 0).Select(x => HexToken.ConvertPair(x[0], x[1]));
 
             var str = OtherEncodings.BytesAsLatin1String(bytes.ToArray());
 

--- a/src/UglyToad.PdfPig.Tests/Util/OtherEncodingsTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Util/OtherEncodingsTests.cs
@@ -5,17 +5,9 @@
     public class OtherEncodingsTests
     {
         [Fact]
-        public void BytesNullReturnsNullString()
-        {
-            var result = OtherEncodings.BytesAsLatin1String(null);
-
-            Assert.Null(result);
-        }
-
-        [Fact]
         public void BytesEmptyReturnsEmptyString()
         {
-            var result = OtherEncodings.BytesAsLatin1String(new byte[0]);
+            var result = OtherEncodings.BytesAsLatin1String([]);
 
             Assert.Equal(string.Empty, result);
         }

--- a/src/UglyToad.PdfPig.Tokenization/HexTokenizer.cs
+++ b/src/UglyToad.PdfPig.Tokenization/HexTokenizer.cs
@@ -1,10 +1,9 @@
 ﻿namespace UglyToad.PdfPig.Tokenization
 {
-    using System.Collections.Generic;
     using Core;
     using Tokens;
 
-    internal class HexTokenizer : ITokenizer
+    internal sealed class HexTokenizer : ITokenizer
     {
         public bool ReadsNextByte { get; } = false;
 
@@ -16,8 +15,8 @@
             {
                 return false;
             }
-            
-            var characters = new List<char>();
+
+            using var charBuffer = new ArrayPoolBufferWriter<char>();
 
             while (inputBytes.MoveNext())
             {
@@ -38,10 +37,10 @@
                     return false;
                 }
 
-                characters.Add((char)current);
+                charBuffer.Write((char)current);
             }
 
-            token = new HexToken(characters);
+            token = new HexToken(charBuffer.WrittenSpan);
 
             return true;
         }

--- a/src/UglyToad.PdfPig.Tokenization/NameTokenizer.cs
+++ b/src/UglyToad.PdfPig.Tokenization/NameTokenizer.cs
@@ -1,7 +1,6 @@
 ﻿namespace UglyToad.PdfPig.Tokenization
 {
     using System;
-    using System.Collections.Generic;
     using System.Text;
     using Core;
     using Tokens;

--- a/src/UglyToad.PdfPig.Tokens/ArrayToken.cs
+++ b/src/UglyToad.PdfPig.Tokens/ArrayToken.cs
@@ -10,7 +10,7 @@
     /// PDF arrays may be heterogeneous; that is, an array's elements may be any combination of numbers, strings,
     /// dictionaries, or any other objects, including other arrays.
     /// </summary>
-    public class ArrayToken : IDataToken<IReadOnlyList<IToken>>
+    public sealed class ArrayToken : IDataToken<IReadOnlyList<IToken>>
     {
         /// <summary>
         /// The tokens contained in this array.

--- a/src/UglyToad.PdfPig.Tokens/HexToken.cs
+++ b/src/UglyToad.PdfPig.Tokens/HexToken.cs
@@ -2,13 +2,12 @@ namespace UglyToad.PdfPig.Tokens
 {
     using System;
     using System.Collections.Generic;
-    using System.Linq;
     using System.Text;
 
     /// <summary>
     /// A token containing string data where the string is encoded as hexadecimal.
     /// </summary>
-    public class HexToken : IDataToken<string>
+    public sealed class HexToken : IDataToken<string>
     {
         private static readonly Dictionary<char, byte> HexMap = new() {
             {'0', 0x00 },

--- a/src/UglyToad.PdfPig.Tokens/UglyToad.PdfPig.Tokens.csproj
+++ b/src/UglyToad.PdfPig.Tokens/UglyToad.PdfPig.Tokens.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net462;net471;net6.0;net8.0</TargetFrameworks>
     <LangVersion>12</LangVersion>
@@ -14,6 +14,9 @@
   </PropertyGroup>
   <ItemGroup Condition="'$(TargetFramework)'=='net462'">
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)'=='netstandard2.0' or '$(TargetFramework)'=='net462' or '$(TargetFramework)'=='net471'">
+    <PackageReference Include="System.Memory" Version="4.5.5" />
   </ItemGroup>
   <ItemGroup>
     <None Include="..\pdfpig.snk" Link="pdfpig.snk" />

--- a/src/UglyToad.PdfPig/Content/Word.cs
+++ b/src/UglyToad.PdfPig/Content/Word.cs
@@ -362,7 +362,10 @@
         private static double BoundAngle180(double angle)
         {
             angle = (angle + 180) % 360;
-            if (angle < 0) angle += 360;
+            if (angle < 0)
+            {
+                angle += 360;
+            }
             return angle - 180;
         }
 

--- a/src/UglyToad.PdfPig/Content/Word.cs
+++ b/src/UglyToad.PdfPig/Content/Word.cs
@@ -67,30 +67,13 @@
                 }
             }
 
-            Tuple<string, PdfRectangle> data;
-            switch (tempTextOrientation)
-            {
-                case TextOrientation.Horizontal:
-                    data = GetBoundingBoxH(letters);
-                    break;
-
-                case TextOrientation.Rotate180:
-                    data = GetBoundingBox180(letters);
-                    break;
-
-                case TextOrientation.Rotate90:
-                    data = GetBoundingBox90(letters);
-                    break;
-
-                case TextOrientation.Rotate270:
-                    data = GetBoundingBox270(letters);
-                    break;
-
-                case TextOrientation.Other:
-                default:
-                    data = GetBoundingBoxOther(letters);
-                    break;
-            }
+            var data = tempTextOrientation switch {
+                TextOrientation.Horizontal => GetBoundingBoxH(letters),
+                TextOrientation.Rotate180  => GetBoundingBox180(letters),
+                TextOrientation.Rotate90   => GetBoundingBox90(letters),
+                TextOrientation.Rotate270  => GetBoundingBox270(letters),
+                _ => GetBoundingBoxOther(letters),
+            };
 
             Text = data.Item1;
             BoundingBox = data.Item2;
@@ -100,7 +83,7 @@
         }
 
         #region Bounding box
-        private Tuple<string, PdfRectangle> GetBoundingBoxH(IReadOnlyList<Letter> letters)
+        private (string, PdfRectangle) GetBoundingBoxH(IReadOnlyList<Letter> letters)
         {
             var builder = new StringBuilder();
 
@@ -136,10 +119,10 @@
                 }
             }
 
-            return new Tuple<string, PdfRectangle>(builder.ToString(), new PdfRectangle(blX, blY, trX, trY));
+            return new(builder.ToString(), new PdfRectangle(blX, blY, trX, trY));
         }
 
-        private Tuple<string, PdfRectangle> GetBoundingBox180(IReadOnlyList<Letter> letters)
+        private (string, PdfRectangle) GetBoundingBox180(IReadOnlyList<Letter> letters)
         {
             var builder = new StringBuilder();
 
@@ -175,10 +158,10 @@
                 }
             }
 
-            return new Tuple<string, PdfRectangle>(builder.ToString(), new PdfRectangle(blX, blY, trX, trY));
+            return (builder.ToString(), new PdfRectangle(blX, blY, trX, trY));
         }
 
-        private Tuple<string, PdfRectangle> GetBoundingBox90(IReadOnlyList<Letter> letters)
+        private (string, PdfRectangle) GetBoundingBox90(IReadOnlyList<Letter> letters)
         {
             var builder = new StringBuilder();
 
@@ -214,12 +197,12 @@
                 }
             }
 
-            return new Tuple<string, PdfRectangle>(builder.ToString(), new PdfRectangle(
+            return new (builder.ToString(), new PdfRectangle(
                 new PdfPoint(t, l), new PdfPoint(t, r),
                 new PdfPoint(b, l), new PdfPoint(b, r)));
         }
 
-        private Tuple<string, PdfRectangle> GetBoundingBox270(IReadOnlyList<Letter> letters)
+        private (string, PdfRectangle) GetBoundingBox270(IReadOnlyList<Letter> letters)
         {
             var builder = new StringBuilder();
 
@@ -255,12 +238,12 @@
                 }
             }
 
-            return new Tuple<string, PdfRectangle>(builder.ToString(), new PdfRectangle(
+            return new(builder.ToString(), new PdfRectangle(
                 new PdfPoint(t, l), new PdfPoint(t, r),
                 new PdfPoint(b, l), new PdfPoint(b, r)));
         }
 
-        private Tuple<string, PdfRectangle> GetBoundingBoxOther(IReadOnlyList<Letter> letters)
+        private (string, PdfRectangle) GetBoundingBoxOther(IReadOnlyList<Letter> letters)
         {
             var builder = new StringBuilder();
             for (var i = 0; i < letters.Count; i++)
@@ -270,7 +253,7 @@
 
             if (letters.Count == 1)
             {
-                return new Tuple<string, PdfRectangle>(builder.ToString(), letters[0].GlyphRectangle);
+                return new(builder.ToString(), letters[0].GlyphRectangle);
             }
             else
             {
@@ -367,7 +350,7 @@
                     obb = obb3;
                 }
 
-                return new Tuple<string, PdfRectangle>(builder.ToString(), obb);
+                return new(builder.ToString(), obb);
             }
         }
         #endregion

--- a/src/UglyToad.PdfPig/Encryption/EncryptionHandler.cs
+++ b/src/UglyToad.PdfPig/Encryption/EncryptionHandler.cs
@@ -402,7 +402,7 @@ namespace UglyToad.PdfPig.Encryption
 
                         var decrypted = DecryptData(data, reference);
 
-                        token = new HexToken(Hex.GetString(decrypted).ToCharArray());
+                        token = new HexToken(Hex.GetString(decrypted).AsSpan());
 
                         break;
                     }

--- a/src/UglyToad.PdfPig/Graphics/BaseStreamProcessor.cs
+++ b/src/UglyToad.PdfPig/Graphics/BaseStreamProcessor.cs
@@ -382,10 +382,10 @@
                 }
                 else
                 {
-                    IReadOnlyList<byte> bytes;
+                    byte[] bytes;
                     if (token is HexToken hex)
                     {
-                        bytes = hex.Bytes;
+                        bytes = [.. hex.Bytes];
                     }
                     else
                     {

--- a/src/UglyToad.PdfPig/Images/Png/Palette.cs
+++ b/src/UglyToad.PdfPig/Images/Png/Palette.cs
@@ -1,6 +1,8 @@
 ﻿namespace UglyToad.PdfPig.Images.Png
 {
-    internal class Palette
+    using System;
+
+    internal sealed class Palette
     {
         public bool HasAlphaValues { get; private set; }
 
@@ -9,7 +11,7 @@
         /// <summary>
         /// Creates a palette object. Input palette data length from PLTE chunk must be a multiple of 3.
         /// </summary>
-        public Palette(byte[] data)
+        public Palette(ReadOnlySpan<byte> data)
         {
             Data = new byte[data.Length * 4 / 3];
             var dataIndex = 0;

--- a/src/UglyToad.PdfPig/Outline/BookmarkNode.cs
+++ b/src/UglyToad.PdfPig/Outline/BookmarkNode.cs
@@ -1,6 +1,5 @@
 ﻿namespace UglyToad.PdfPig.Outline
 {
-    using Destinations;
     using System;
     using System.Collections.Generic;
 

--- a/src/UglyToad.PdfPig/Parser/Parts/ObjectHelper.cs
+++ b/src/UglyToad.PdfPig/Parser/Parts/ObjectHelper.cs
@@ -24,7 +24,7 @@
             int result = ReadHelper.ReadInt(bytes);
             if (result < 0 || result > GenerationNumberThreshold)
             {
-                throw new FormatException("Generation Number '" + result + "' has more than 5 digits");
+                throw new FormatException($"Generation Number '{result}' has more than 5 digits");
             }
 
             return result;

--- a/src/UglyToad.PdfPig/PdfFonts/Cmap/CMap.cs
+++ b/src/UglyToad.PdfPig/PdfFonts/Cmap/CMap.cs
@@ -152,7 +152,7 @@
             {
                 var data = new byte[minCodeLength];
                 bytes.Read(data);
-                return data.ToInt(minCodeLength);
+                return ((ReadOnlySpan<byte>)data).Slice(0, minCodeLength).ToInt();
             }
 
             byte[] result = new byte[maxCodeLength];

--- a/src/UglyToad.PdfPig/PdfFonts/Cmap/CMapUtils.cs
+++ b/src/UglyToad.PdfPig/PdfFonts/Cmap/CMapUtils.cs
@@ -1,13 +1,14 @@
 ﻿namespace UglyToad.PdfPig.PdfFonts.Cmap
 {
+    using System;
     using System.Collections.Generic;
 
     internal static class CMapUtils
     {
-        public static int ToInt(this IReadOnlyList<byte> data, int length)
+        public static int ToInt(this ReadOnlySpan<byte> data)
         {
             int code = 0;
-            for (int i = 0; i < length; ++i)
+            for (int i = 0; i < data.Length; ++i)
             {
                 code <<= 8;
                 code |= (data[i] & 0xFF);
@@ -15,8 +16,7 @@
             return code;
         }
 
-        public static void PutAll<TKey, TValue>(this Dictionary<TKey, TValue> target,
-            IReadOnlyDictionary<TKey, TValue> source)
+        public static void PutAll<TKey, TValue>(this Dictionary<TKey, TValue> target, IReadOnlyDictionary<TKey, TValue> source)
         {
             foreach (var pair in source)
             {

--- a/src/UglyToad.PdfPig/PdfFonts/Cmap/CharacterMapBuilder.cs
+++ b/src/UglyToad.PdfPig/PdfFonts/Cmap/CharacterMapBuilder.cs
@@ -3,6 +3,7 @@
 namespace UglyToad.PdfPig.PdfFonts.Cmap
 {
     using Core;
+    using System;
     using System.Collections.Generic;
     using System.Linq;
     using System.Text;
@@ -66,14 +67,14 @@ namespace UglyToad.PdfPig.PdfFonts.Cmap
 
         public Dictionary<int, string> BaseFontCharacterMap { get; } = new Dictionary<int, string>();
 
-        public void AddBaseFontCharacter(IReadOnlyList<byte> bytes, IReadOnlyList<byte> value)
+        public void AddBaseFontCharacter(ReadOnlySpan<byte> bytes, ReadOnlySpan<byte> value)
         {
-            AddBaseFontCharacter(bytes, CreateStringFromBytes(value.ToArray()));
+            AddBaseFontCharacter(bytes, CreateStringFromBytes(value));
         }
 
-        public void AddBaseFontCharacter(IReadOnlyList<byte> bytes, string value)
+        public void AddBaseFontCharacter(ReadOnlySpan<byte> bytes, string value)
         {
-            var code = GetCodeFromArray(bytes, bytes.Count);
+            var code = GetCodeFromArray(bytes);
 
             BaseFontCharacterMap[code] = value;
         }
@@ -134,17 +135,13 @@ namespace UglyToad.PdfPig.PdfFonts.Cmap
                 return a;
             }
 
-            var result = new List<T>(a);
-
-            result.AddRange(b);
-
-            return result;
+            return [.. a, .. b];
         }
 
-        private int GetCodeFromArray(IReadOnlyList<byte> data, int length)
+        private int GetCodeFromArray(ReadOnlySpan<byte> data)
         {
             int code = 0;
-            for (int i = 0; i < length; i++)
+            for (int i = 0; i < data.Length; i++)
             {
                 code <<= 8;
                 code |= (data[i] + 256) % 256;
@@ -152,7 +149,7 @@ namespace UglyToad.PdfPig.PdfFonts.Cmap
             return code;
         }
 
-        private static string CreateStringFromBytes(byte[] bytes)
+        private static string CreateStringFromBytes(ReadOnlySpan<byte> bytes)
         {
             return bytes.Length == 1
                 ? OtherEncodings.BytesAsLatin1String(bytes)

--- a/src/UglyToad.PdfPig/PdfFonts/Cmap/CodespaceRange.cs
+++ b/src/UglyToad.PdfPig/PdfFonts/Cmap/CodespaceRange.cs
@@ -1,7 +1,6 @@
 ﻿namespace UglyToad.PdfPig.PdfFonts.Cmap
 {
     using System;
-    using System.Collections.Generic;
 
     /// <summary>
     ///  A codespace range is specified by a pair of codes of some particular length giving the lower and upper bounds of that range.
@@ -11,12 +10,12 @@
         /// <summary>
         /// The lower-bound of this range.
         /// </summary>
-        public IReadOnlyList<byte> Start { get; }
+        public ReadOnlyMemory<byte> Start { get; }
 
         /// <summary>
         /// The upper-bound of this range.
         /// </summary>
-        public IReadOnlyList<byte> End { get; }
+        public ReadOnlyMemory<byte> End { get; }
 
         /// <summary>
         /// The lower-bound of this range as an integer.
@@ -36,13 +35,13 @@
         /// <summary>
         /// Creates a new instance of <see cref="CodespaceRange"/>.
         /// </summary>
-        public CodespaceRange(IReadOnlyList<byte> start, IReadOnlyList<byte> end)
+        public CodespaceRange(ReadOnlyMemory<byte> start, ReadOnlyMemory<byte> end)
         {
             Start = start;
             End = end;
-            StartInt = start.ToInt(start.Count);
-            EndInt = end.ToInt(end.Count);
-            CodeLength = start.Count;
+            StartInt = start.Span.ToInt();
+            EndInt = end.Span.ToInt();
+            CodeLength = start.Length;
         }
 
         /// <summary>
@@ -74,7 +73,7 @@
                 return false;
             }
 
-            var value = code.ToInt(codeLength);
+            var value = ((ReadOnlySpan<byte>)code).Slice(0, codeLength).ToInt();
             if (value >= StartInt && value <= EndInt)
             {
                 return true;

--- a/src/UglyToad.PdfPig/PdfFonts/Parser/Parts/BaseFontRangeParser.cs
+++ b/src/UglyToad.PdfPig/PdfFonts/Parser/Parts/BaseFontRangeParser.cs
@@ -34,7 +34,7 @@
                     throw new InvalidFontFormatException("bfrange ended unexpectedly after the high source code.");
                 }
 
-                List<byte>? destinationBytes = null;
+                byte[]? destinationBytes = null;
                 ArrayToken? destinationArray = null;
 
                 switch (scanner.CurrentToken)
@@ -43,7 +43,7 @@
                         destinationArray = arrayToken;
                         break;
                     case HexToken hexToken:
-                        destinationBytes = hexToken.Bytes.ToList();
+                        destinationBytes = [.. hexToken.Bytes];
                         break;
                     case NumericToken _:
                         throw new NotImplementedException("From the spec it seems this possible but the meaning is unclear...");
@@ -52,7 +52,7 @@
                 }
 
                 var done = false;
-                var startCode = new List<byte>(lowSourceCode.Bytes);
+                var startCode = lowSourceCode.Bytes.ToArray();
                 var endCode = highSourceCode.Bytes;
 
                 if (destinationArray != null)
@@ -76,7 +76,7 @@
                             builder.AddBaseFontCharacter(startCode, hex.Bytes);
                         }
                         
-                        Increment(startCode, startCode.Count - 1);
+                        Increment(startCode, startCode.Length - 1);
 
                         arrayIndex++;
                     }
@@ -93,14 +93,14 @@
 
                     builder.AddBaseFontCharacter(startCode, destinationBytes!);
 
-                    Increment(startCode, startCode.Count - 1);
+                    Increment(startCode, startCode.Length - 1);
 
-                    Increment(destinationBytes!, destinationBytes!.Count - 1);
+                    Increment(destinationBytes!, destinationBytes!.Length - 1);
                 }
             }
         }
 
-        private static void Increment(IList<byte> data, int position)
+        private static void Increment(Span<byte> data, int position)
         {
             if (position > 0 && (data[position] & 0xFF) == 255)
             {
@@ -113,9 +113,9 @@
             }
         }
 
-        private static int Compare(IReadOnlyList<byte> first, IReadOnlyList<byte> second)
+        private static int Compare(ReadOnlySpan<byte> first, ReadOnlySpan<byte> second)
         {
-            for (var i = 0; i < first.Count; i++)
+            for (var i = 0; i < first.Length; i++)
             {
                 if (first[i] == second[i])
                 {

--- a/src/UglyToad.PdfPig/PdfFonts/Parser/Parts/CidCharacterParser.cs
+++ b/src/UglyToad.PdfPig/PdfFonts/Parser/Parts/CidCharacterParser.cs
@@ -24,7 +24,7 @@
                     throw new InvalidOperationException("The destination token in a line for Cid Character should be an integer, instead it was: " + scanner.CurrentToken);
                 }
 
-                var sourceInteger = sourceCode.Bytes.ToInt(sourceCode.Bytes.Count);
+                var sourceInteger = sourceCode.Bytes.ToInt();
                 var mapping = new CidCharacterMapping(sourceInteger, destinationCode.Int);
 
                 results.Add(mapping);

--- a/src/UglyToad.PdfPig/PdfFonts/Parser/Parts/CodespaceRangeParser.cs
+++ b/src/UglyToad.PdfPig/PdfFonts/Parser/Parts/CodespaceRangeParser.cs
@@ -44,7 +44,7 @@
                     throw new InvalidOperationException("Codespace range contains an unexpected token: " + tokenScanner.CurrentToken);
                 }
 
-                ranges.Add(new CodespaceRange(start.Bytes, end.Bytes));
+                ranges.Add(new CodespaceRange(start.Memory, end.Memory));
             }
 
             builder.CodespaceRanges = ranges;

--- a/src/UglyToad.PdfPig/Polyfills/EncodingExtensions.cs
+++ b/src/UglyToad.PdfPig/Polyfills/EncodingExtensions.cs
@@ -1,0 +1,16 @@
+﻿#if NETFRAMEWORK || NETSTANDARD2_0
+
+namespace System.Text;
+
+internal static class EncodingExtensions
+{
+    public unsafe static string GetString(this Encoding encoding, ReadOnlySpan<byte> bytes)
+    {
+        fixed (byte* pBytes = bytes)
+        {
+            return encoding.GetString(pBytes, bytes.Length);
+        }
+    }
+}
+
+#endif

--- a/src/UglyToad.PdfPig/Polyfills/EncodingExtensions.cs
+++ b/src/UglyToad.PdfPig/Polyfills/EncodingExtensions.cs
@@ -6,8 +6,13 @@ internal static class EncodingExtensions
 {
     public static string GetString(this Encoding encoding, ReadOnlySpan<byte> bytes)
     {
+        if (bytes.IsEmpty)
+        {
+            return string.Empty;
+        }
+
         // NOTE: this can be made allocation free by introducing unsafe
-       
+
         return encoding.GetString(bytes.ToArray());
     }
 }

--- a/src/UglyToad.PdfPig/Polyfills/EncodingExtensions.cs
+++ b/src/UglyToad.PdfPig/Polyfills/EncodingExtensions.cs
@@ -4,12 +4,11 @@ namespace System.Text;
 
 internal static class EncodingExtensions
 {
-    public unsafe static string GetString(this Encoding encoding, ReadOnlySpan<byte> bytes)
+    public static string GetString(this Encoding encoding, ReadOnlySpan<byte> bytes)
     {
-        fixed (byte* pBytes = bytes)
-        {
-            return encoding.GetString(pBytes, bytes.Length);
-        }
+        // NOTE: this can be made allocation free by introducing unsafe
+       
+        return encoding.GetString(bytes.ToArray());
     }
 }
 

--- a/src/UglyToad.PdfPig/Tokenization/Scanner/PdfTokenScanner.cs
+++ b/src/UglyToad.PdfPig/Tokenization/Scanner/PdfTokenScanner.cs
@@ -825,7 +825,7 @@
 
             var scanner = new CoreTokenScanner(bytes, true, useLenientParsing: parsingOptions.UseLenientParsing);
 
-            var objects = new List<Tuple<long, long>>();
+            var objects = new List<(long, long)>();
 
             for (var i = 0; i < numberOfObjects.Int; i++)
             {
@@ -834,7 +834,7 @@
                 scanner.MoveNext();
                 var byteOffset = (NumericToken)scanner.CurrentToken;
 
-                objects.Add(Tuple.Create(objectNumber.Long, byteOffset.Long));
+                objects.Add((objectNumber.Long, byteOffset.Long));
             }
 
             var results = new List<ObjectToken>();

--- a/src/UglyToad.PdfPig/UglyToad.PdfPig.csproj
+++ b/src/UglyToad.PdfPig/UglyToad.PdfPig.csproj
@@ -8,6 +8,7 @@
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\pdfpig.snk</AssemblyOriginatorKeyFile>
     <Nullable>enable</Nullable>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|netstandard2.0|AnyCPU'">
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/src/UglyToad.PdfPig/UglyToad.PdfPig.csproj
+++ b/src/UglyToad.PdfPig/UglyToad.PdfPig.csproj
@@ -8,7 +8,6 @@
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\pdfpig.snk</AssemblyOriginatorKeyFile>
     <Nullable>enable</Nullable>
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|netstandard2.0|AnyCPU'">
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/src/UglyToad.PdfPig/Util/ColorSpaceDetailsParser.cs
+++ b/src/UglyToad.PdfPig/Util/ColorSpaceDetailsParser.cs
@@ -55,8 +55,7 @@
 
                 var colorSpaceDetails = GetColorSpaceDetails(colorSpace, imageDictionary.Without(NameToken.Filter).Without(NameToken.F), scanner, resourceStore, filterProvider, true);
 
-                var decodeRaw = imageDictionary.GetObjectOrDefault(NameToken.Decode, NameToken.D) as ArrayToken
-                    ?? new ArrayToken(Array.Empty<IToken>());
+                var decodeRaw = imageDictionary.GetObjectOrDefault(NameToken.Decode, NameToken.D) as ArrayToken ?? new ArrayToken([]);
                 var decode = decodeRaw.Data.OfType<NumericToken>().Select(x => x.Double).ToArray();
 
                 return IndexedColorSpaceDetails.Stencil(colorSpaceDetails, decode);
@@ -341,7 +340,7 @@
 
                         if (DirectObjectFinder.TryGet(fourth, scanner, out HexToken? tableHexToken))
                         {
-                            tableBytes = tableHexToken.Bytes;
+                            tableBytes = [.. tableHexToken.Bytes];
                         }
                         else if (DirectObjectFinder.TryGet(fourth, scanner, out StreamToken? tableStreamToken))
                         {

--- a/src/UglyToad.PdfPig/Writer/Fonts/ToUnicodeCMapBuilder.cs
+++ b/src/UglyToad.PdfPig/Writer/Fonts/ToUnicodeCMapBuilder.cs
@@ -16,7 +16,7 @@
 
         private static readonly TokenWriter TokenWriter = new TokenWriter();
 
-        public static IReadOnlyList<byte> ConvertToCMapStream(IReadOnlyDictionary<char, byte> unicodeToCharacterCode)
+        public static byte[] ConvertToCMapStream(IReadOnlyDictionary<char, byte> unicodeToCharacterCode)
         {
             using (var memoryStream = new MemoryStream())
             {

--- a/src/UglyToad.PdfPig/Writer/PdfPageBuilder.cs
+++ b/src/UglyToad.PdfPig/Writer/PdfPageBuilder.cs
@@ -702,7 +702,9 @@
             var png = Png.Open(pngStream);
 
             if (placementRectangle.Equals(default(PdfRectangle)))
+            {
                 placementRectangle = new PdfRectangle(0, 0, png.Width, png.Height);
+            }
 
             byte[] data;
             var pixelBuffer = new byte[3];


### PR DESCRIPTION
The PR is focused on spanifying the first round of classes and methods in preparation to replace IList<byte> and reduce allocations more broadly through the library. 

The big changes here are introducing polyfills for GetString(ReadOnlySpan<byte>) on older frameworks, introducing a ArrayPoolBufferWriter (to utilize IBufferWriter), and spanifying various methods that will be called in future PRs. 

