### PR TITLE
Spanify work 2

### DIFF
--- a/src/UglyToad.PdfPig.Core/IInputBytes.cs
+++ b/src/UglyToad.PdfPig.Core/IInputBytes.cs
@@ -47,8 +47,7 @@
         /// Fill the buffer with bytes starting from the current position.
         /// </summary>
         /// <param name="buffer">A buffer with a length corresponding to the number of bytes to read.</param>
-        /// <param name="length">Optional override for the number of bytes to read.</param>
         /// <returns>The number of bytes successfully read.</returns>
-        int Read(byte[] buffer, int? length = null);
+        int Read(Span<byte> buffer);
     }
 }

--- a/src/UglyToad.PdfPig.Core/MemoryInputBytes.cs
+++ b/src/UglyToad.PdfPig.Core/MemoryInputBytes.cs
@@ -7,7 +7,7 @@
     /// <summary>
     /// Input bytes from a byte array.
     /// </summary>
-    public class MemoryInputBytes : IInputBytes
+    public sealed class MemoryInputBytes : IInputBytes
     {
         private readonly int upperBound;
         private readonly ReadOnlyMemory<byte> memory;
@@ -73,31 +73,15 @@
         }
 
         /// <inheritdoc />
-        public int Read(byte[] buffer, int? length = null)
+        public int Read(Span<byte> buffer)
         {
-            var bytesToRead = buffer.Length;
-            if (length.HasValue)
-            {
-                if (length.Value < 0)
-                {
-                    throw new ArgumentOutOfRangeException($"Cannot use a negative length: {length.Value}.");
-                }
-
-                if (length.Value > bytesToRead)
-                {
-                    throw new ArgumentOutOfRangeException($"Cannot read more bytes {length.Value} than there is space in the buffer {buffer.Length}.");
-                }
-
-                bytesToRead = length.Value;
-            }
-
-            if (bytesToRead == 0)
+            if (buffer.IsEmpty)
             {
                 return 0;
             }
 
             var viableLength = (memory.Length - currentOffset - 1);
-            var readLength = viableLength < bytesToRead ? viableLength : bytesToRead;
+            var readLength = viableLength < buffer.Length ? viableLength : buffer.Length;
             var startFrom = currentOffset + 1;
 
             memory.Span.Slice(startFrom, readLength).CopyTo(buffer);

--- a/src/UglyToad.PdfPig.Core/OctalHelpers.cs
+++ b/src/UglyToad.PdfPig.Core/OctalHelpers.cs
@@ -12,31 +12,19 @@
         /// </summary>
         public static short CharacterToShort(this char c)
         {
-            switch (c)
-            {
-                case '0':
-                    return 0;
-                case '1':
-                    return 1;
-                case '2':
-                    return 2;
-                case '3':
-                    return 3;
-                case '4':
-                    return 4;
-                case '5':
-                    return 5;
-                case '6':
-                    return 6;
-                case '7':
-                    return 7;
-                case '8':
-                    return 8;
-                case '9':
-                    return 9;
-                default:
-                    throw new InvalidOperationException($"Could not convert the character {c} to a short.");
-            }
+            return c switch {
+                '0' => 0,
+                '1' => 1,
+                '2' => 2,
+                '3' => 3,
+                '4' => 4,
+                '5' => 5,
+                '6' => 6,
+                '7' => 7,
+                '8' => 8,
+                '9' => 9,
+                _ => throw new InvalidOperationException($"Could not convert the character {c} to a short.")
+            };
         }
 
         /// <summary>

--- a/src/UglyToad.PdfPig.Core/Polyfills/StreamExtensions.cs
+++ b/src/UglyToad.PdfPig.Core/Polyfills/StreamExtensions.cs
@@ -1,0 +1,26 @@
+﻿#if NETFRAMEWORK || NETSTANDARD2_0
+
+namespace System.IO;
+
+using System.Buffers;
+
+internal static class StreamExtensions
+{
+    public static void Write(this Stream stream, ReadOnlySpan<byte> data)
+    {
+        var buffer = ArrayPool<byte>.Shared.Rent(data.Length);
+
+        data.CopyTo(buffer);
+
+        try
+        {
+            stream.Write(buffer, 0, data.Length);
+        }
+        finally
+        {
+            ArrayPool<byte>.Shared.Return(buffer);
+        }
+    }
+}
+
+#endif

--- a/src/UglyToad.PdfPig.Core/StreamInputBytes.cs
+++ b/src/UglyToad.PdfPig.Core/StreamInputBytes.cs
@@ -7,7 +7,7 @@
     /// <summary>
     /// Input bytes from a stream.
     /// </summary>
-    public class StreamInputBytes : IInputBytes
+    public sealed class StreamInputBytes : IInputBytes
     {
         private readonly Stream stream;
         private readonly bool shouldDispose;
@@ -106,30 +106,15 @@
         }
 
         /// <inheritdoc />
-        public int Read(byte[] buffer, int? length = null)
+        public int Read(Span<byte> buffer)
         {
-            var bytesToRead = buffer.Length;
-            if (length.HasValue)
-            {
-                if (length.Value < 0)
-                {
-                    throw new ArgumentOutOfRangeException($"Cannot use a negative length: {length.Value}.");
-                }
-
-                if (length.Value > bytesToRead)
-                {
-                    throw new ArgumentOutOfRangeException($"Cannot read more bytes {length.Value} than there is space in the buffer {buffer.Length}.");
-                }
-
-                bytesToRead = length.Value;
-            }
-
-            if (bytesToRead == 0)
+            if (buffer.IsEmpty)
             {
                 return 0;
             }
 
-            var read = stream.Read(buffer, 0, bytesToRead);
+            int read = stream.Read(buffer);
+
             if (read > 0)
             {
                 CurrentByte = buffer[read - 1];

--- a/src/UglyToad.PdfPig.Core/WritingExtensions.cs
+++ b/src/UglyToad.PdfPig.Core/WritingExtensions.cs
@@ -1,5 +1,7 @@
 ﻿namespace UglyToad.PdfPig.Core
 {
+    using System;
+    using System.Buffers.Binary;
     using System.IO;
 
     /// <summary>
@@ -16,15 +18,11 @@
         /// </summary>
         public static void WriteUInt(this Stream stream, uint value)
         {
-            var buffer = new[]
-                {
-                    (byte) (value >> 24),
-                    (byte) (value >> 16),
-                    (byte) (value >> 8),
-                    (byte) value
-                };
+            Span<byte> buffer = stackalloc byte[4];
 
-            stream.Write(buffer, 0, 4);
+            BinaryPrimitives.WriteUInt32BigEndian(buffer, value);
+
+            stream.Write(buffer);
         }
 
         /// <summary>
@@ -36,13 +34,12 @@
         /// </summary>
         public static void WriteUShort(this Stream stream, ushort value)
         {
-            var buffer = new[]
-            {
-                    (byte) (value >> 8),
-                    (byte) value
-                };
+            ReadOnlySpan<byte> buffer = [
+                (byte) (value >> 8),
+                (byte) value
+            ];
 
-            stream.Write(buffer, 0, 2);
+            stream.Write(buffer);
         }
 
         /// <summary>
@@ -54,13 +51,12 @@
         /// </summary>
         public static void WriteShort(this Stream stream, short value)
         {
-            var buffer = new[]
-            {
+            ReadOnlySpan<byte> buffer = [
                 (byte) (value >> 8),
                 (byte) value
-            };
+            ];
 
-            stream.Write(buffer, 0, 2);
+            stream.Write(buffer);
         }
     }
 }

--- a/src/UglyToad.PdfPig.Fonts/CompactFontFormat/CharStrings/Type2CharStringParser.cs
+++ b/src/UglyToad.PdfPig.Fonts/CompactFontFormat/CharStrings/Type2CharStringParser.cs
@@ -24,13 +24,13 @@ namespace UglyToad.PdfPig.Fonts.CompactFontFormat.CharStrings
         private const byte CntrmaskByte = 20;
         private const byte VstemhmByte = 23;
 
-        private static readonly HashSet<byte> HintingCommandBytes = new HashSet<byte>
-        {
+        private static readonly HashSet<byte> HintingCommandBytes =
+        [
             HstemByte,
             VstemByte,
             HstemhmByte,
             VstemhmByte
-        };
+        ];
 
         private static readonly IReadOnlyDictionary<byte, LazyType2Command> SingleByteCommandStore = new Dictionary<byte, LazyType2Command>
         {
@@ -712,7 +712,7 @@ namespace UglyToad.PdfPig.Fonts.CompactFontFormat.CharStrings
             return SingleByteCommandStore[identifier.CommandId];
         }
 
-        public static Type2CharStrings Parse(IReadOnlyList<IReadOnlyList<byte>> charStringBytes,
+        public static Type2CharStrings Parse(IReadOnlyList<ReadOnlyMemory<byte>> charStringBytes,
             CompactFontFormatSubroutinesSelector subroutinesSelector, ICompactFontFormatCharset charset)
         {
             if (charStringBytes == null)
@@ -731,14 +731,15 @@ namespace UglyToad.PdfPig.Fonts.CompactFontFormat.CharStrings
                 var charString = charStringBytes[i];
                 var name = charset.GetNameByGlyphId(i);
                 var (globalSubroutines, localSubroutines) = subroutinesSelector.GetSubroutines(i);
-                var sequence = ParseSingle(charString.ToList(), localSubroutines, globalSubroutines);
+                var sequence = ParseSingle([.. charString.Span], localSubroutines, globalSubroutines);
                 charStrings[name] = sequence;
             }
 
             return new Type2CharStrings(charStrings);
         }
 
-        private static Type2CharStrings.CommandSequence ParseSingle(List<byte> bytes,
+        private static Type2CharStrings.CommandSequence ParseSingle(
+            List<byte> bytes,
             CompactFontFormatIndex localSubroutines,
             CompactFontFormatIndex globalSubroutines)
         {
@@ -843,7 +844,7 @@ namespace UglyToad.PdfPig.Fonts.CompactFontFormat.CharStrings
                 var index = precedingNumber + bias;
                 var subroutineBytes = isLocal ? localSubroutines[index] : globalSubroutines[index];
                 bytes.RemoveRange(i - 1, 2);
-                bytes.InsertRange(i - 1, subroutineBytes);
+                bytes.InsertRange(i - 1, [.. subroutineBytes.Span]);
 
                 // Remove the subroutine index
                 precedingValues.RemoveAt(precedingValues.Count - 1);

--- a/src/UglyToad.PdfPig.Fonts/CompactFontFormat/CompactFontFormatData.cs
+++ b/src/UglyToad.PdfPig.Fonts/CompactFontFormat/CompactFontFormatData.cs
@@ -11,7 +11,7 @@
     /// </summary>
     public class CompactFontFormatData
     {
-        private readonly IReadOnlyList<byte> dataBytes;
+        private readonly ReadOnlyMemory<byte> dataBytes;
 
         /// <summary>
         /// The current position in the data.
@@ -21,13 +21,13 @@
         /// <summary>
         /// The length of the data.
         /// </summary>
-        public int Length => dataBytes.Count;
+        public int Length => dataBytes.Length;
 
         /// <summary>
         /// Create a new <see cref="CompactFontFormatData"/>.
         /// </summary>
         [DebuggerStepThrough]
-        public CompactFontFormatData(IReadOnlyList<byte> dataBytes)
+        public CompactFontFormatData(ReadOnlyMemory<byte> dataBytes)
         {
             this.dataBytes = dataBytes;
         }
@@ -93,12 +93,12 @@
         {
             Position++;
 
-            if (Position >= dataBytes.Count)
+            if (Position >= dataBytes.Length)
             {
-                throw new IndexOutOfRangeException($"Cannot read byte at position {Position} of an array which is {dataBytes.Count} bytes long.");
+                throw new IndexOutOfRangeException($"Cannot read byte at position {Position} of an array which is {dataBytes.Length} bytes long.");
             }
 
-            return dataBytes[Position];
+            return dataBytes.Span[Position];
         }
 
         /// <summary>
@@ -106,7 +106,7 @@
         /// </summary>
         public byte Peek()
         {
-            return dataBytes[Position + 1];
+            return dataBytes.Span[Position + 1];
         }
 
         /// <summary>
@@ -114,7 +114,7 @@
         /// </summary>
         public bool CanRead()
         {
-            return Position < dataBytes.Count - 1;
+            return Position < dataBytes.Length - 1;
         }
 
         /// <summary>
@@ -166,16 +166,16 @@
                 return new CompactFontFormatData(Array.Empty<byte>());
             }
 
-            if (startLocation > dataBytes.Count - 1 || startLocation + length > dataBytes.Count)
+            if (startLocation > dataBytes.Length - 1 || startLocation + length > dataBytes.Length)
             {
-                throw new ArgumentException($"Attempted to create a snapshot of an invalid portion of the data. Length was {dataBytes.Count}, requested start: {startLocation} and requested length: {length}.");
+                throw new ArgumentException($"Attempted to create a snapshot of an invalid portion of the data. Length was {dataBytes.Length}, requested start: {startLocation} and requested length: {length}.");
             }
 
             var newData = new byte[length];
             var newI = 0;
             for (var i = startLocation; i < startLocation + length; i++)
             {
-                newData[newI] = dataBytes[i];
+                newData[newI] = dataBytes.Span[i];
                 newI++;
             }
 

--- a/src/UglyToad.PdfPig.Fonts/CompactFontFormat/CompactFontFormatIndex.cs
+++ b/src/UglyToad.PdfPig.Fonts/CompactFontFormat/CompactFontFormatIndex.cs
@@ -4,29 +4,36 @@
     using System.Collections;
     using System.Collections.Generic;
 
-    internal class CompactFontFormatIndex : IReadOnlyList<IReadOnlyList<byte>>
+    internal class CompactFontFormatIndex : IReadOnlyList<ReadOnlyMemory<byte>>
     {
-        private readonly IReadOnlyList<IReadOnlyList<byte>> bytes;
+        private readonly byte[][] bytes;
 
-        public int Count => bytes.Count;
+        public int Count => bytes.Length;
 
-        public IReadOnlyList<byte> this[int index] => bytes[index];
+        public ReadOnlyMemory<byte> this[int index] => bytes[index];
 
-        public static CompactFontFormatIndex None { get; } = new CompactFontFormatIndex(new byte[0][]);
+        public static CompactFontFormatIndex None { get; } = new CompactFontFormatIndex([]);
 
         public CompactFontFormatIndex(byte[][] bytes)
         {
-            this.bytes = bytes ?? Array.Empty<IReadOnlyList<byte>>();
+            this.bytes = bytes ?? [];
         }
         
-        public IEnumerator<IReadOnlyList<byte>> GetEnumerator()
+        public IEnumerator<ReadOnlyMemory<byte>> GetEnumerator()
         {
-            return bytes.GetEnumerator();
+            foreach (var item in bytes)
+            {
+                yield return new ReadOnlyMemory<byte>(item);
+            }
         }
 
         IEnumerator IEnumerable.GetEnumerator()
         {
-            return GetEnumerator();
+            foreach (var item in bytes)
+            {
+                yield return new ReadOnlyMemory<byte>(item);
+            }
+
         }
     }
 }

--- a/src/UglyToad.PdfPig.Fonts/CompactFontFormat/CompactFontFormatIndividualFontParser.cs
+++ b/src/UglyToad.PdfPig.Fonts/CompactFontFormat/CompactFontFormatIndividualFontParser.cs
@@ -23,7 +23,7 @@
             this.privateDictionaryReader = privateDictionaryReader;
         }
 
-        public CompactFontFormatFont Parse(CompactFontFormatData data, string name, IReadOnlyList<byte> topDictionaryIndex, IReadOnlyList<string> stringIndex,
+        public CompactFontFormatFont Parse(CompactFontFormatData data, string name, ReadOnlySpan<byte> topDictionaryIndex, IReadOnlyList<string> stringIndex,
             CompactFontFormatIndex globalSubroutineIndex)
         {
             var individualData = new CompactFontFormatData(topDictionaryIndex.ToArray());

--- a/src/UglyToad.PdfPig.Fonts/CompactFontFormat/CompactFontFormatParser.cs
+++ b/src/UglyToad.PdfPig.Fonts/CompactFontFormat/CompactFontFormatParser.cs
@@ -53,7 +53,7 @@
             {
                 var fontName = fontNames[i];
 
-                fonts[fontName] = individualFontParser.Parse(data, fontName, topLevelDictionaryIndex[i], stringIndex, globalSubroutineIndex);
+                fonts[fontName] = individualFontParser.Parse(data, fontName, topLevelDictionaryIndex[i].Span, stringIndex, globalSubroutineIndex);
             }
 
             return new CompactFontFormatFontCollection(header, fonts);

--- a/src/UglyToad.PdfPig.Fonts/Polyfills/EncodingExtensions.cs
+++ b/src/UglyToad.PdfPig.Fonts/Polyfills/EncodingExtensions.cs
@@ -1,0 +1,20 @@
+﻿#if NETFRAMEWORK || NETSTANDARD2_0
+
+namespace System.Text;
+
+internal static class EncodingExtensions
+{
+    public static string GetString(this Encoding encoding, ReadOnlySpan<byte> bytes)
+    {
+        if (bytes.IsEmpty)
+        {
+            return string.Empty;
+        }
+
+        // NOTE: this can be made allocation free by introducing unsafe
+
+        return encoding.GetString(bytes.ToArray());
+    }
+}
+
+#endif

--- a/src/UglyToad.PdfPig.Fonts/Polyfills/StreamExtensions.cs
+++ b/src/UglyToad.PdfPig.Fonts/Polyfills/StreamExtensions.cs
@@ -1,0 +1,26 @@
+﻿#if NETFRAMEWORK || NETSTANDARD2_0
+
+namespace System.IO;
+
+using System.Buffers;
+
+internal static class StreamExtensions
+{
+    public static void Write(this Stream stream, ReadOnlySpan<byte> buffer)
+    {
+        var tempBuffer = ArrayPool<byte>.Shared.Rent(buffer.Length);
+
+        buffer.CopyTo(tempBuffer);
+
+        try
+        {
+            stream.Write(tempBuffer, 0, buffer.Length);
+        }
+        finally
+        {
+            ArrayPool<byte>.Shared.Return(tempBuffer);
+        }
+    }
+}
+
+#endif

--- a/src/UglyToad.PdfPig.Fonts/Standard14Fonts/Standard14.cs
+++ b/src/UglyToad.PdfPig.Fonts/Standard14Fonts/Standard14.cs
@@ -121,7 +121,7 @@
                     }
 
                     resource.CopyTo(memory);
-                    bytes = new ByteArrayInputBytes(memory.ToArray());
+                    bytes = new MemoryInputBytes(memory.ToArray());
                 }
 
                 Standard14Cache[fontName] = AdobeFontMetricsParser.Parse(bytes, true);

--- a/src/UglyToad.PdfPig.Fonts/SystemFonts/SystemFontFinder.cs
+++ b/src/UglyToad.PdfPig.Fonts/SystemFonts/SystemFontFinder.cs
@@ -135,7 +135,7 @@ namespace UglyToad.PdfPig.Fonts.SystemFonts
 
             if (name.Contains(","))
             {
-                result = GetTrueTypeFontNamed(name.Replace(",", "-"));
+                result = GetTrueTypeFontNamed(name.Replace(',', '-'));
 
                 if (result != null)
                 {
@@ -237,7 +237,7 @@ namespace UglyToad.PdfPig.Fonts.SystemFonts
 
             var bytes = File.ReadAllBytes(fileName);
 
-            var data = new TrueTypeDataBytes(new ByteArrayInputBytes(bytes));
+            var data = new TrueTypeDataBytes(new MemoryInputBytes(bytes));
 
             if (readNameFirst)
             {

--- a/src/UglyToad.PdfPig.Fonts/TrueType/TrueTypeDataBytes.cs
+++ b/src/UglyToad.PdfPig.Fonts/TrueType/TrueTypeDataBytes.cs
@@ -15,7 +15,7 @@
         /// <summary>
         /// Create a new <see cref="TrueTypeDataBytes"/>.
         /// </summary>
-        public TrueTypeDataBytes(byte[] bytes) : this(new ByteArrayInputBytes(bytes)) { }
+        public TrueTypeDataBytes(byte[] bytes) : this(new MemoryInputBytes(bytes)) { }
 
         /// <summary>
         /// Create a new <see cref="TrueTypeDataBytes"/>.
@@ -102,7 +102,7 @@
             byte[] data = new byte[bytesToRead];
             if (ReadBuffered(data, bytesToRead))
             {
-                result = encoding.GetString(data, 0, data.Length);
+                result = encoding.GetString(data);
                 return true;
             }
 

--- a/src/UglyToad.PdfPig.Fonts/Type1/Parser/Type1EncryptedPortionParser.cs
+++ b/src/UglyToad.PdfPig.Fonts/Type1/Parser/Type1EncryptedPortionParser.cs
@@ -32,7 +32,7 @@
                 return (defaultPrivateDictionary, defaultCharstrings);
             }
 
-            var tokenizer = new Type1Tokenizer(new ByteArrayInputBytes([.. decrypted]));
+            var tokenizer = new Type1Tokenizer(new MemoryInputBytes(new ReadOnlyMemory<byte>([.. decrypted])));
 
             /*
              * After 4 random characters follows the /Private dictionary and the /CharString dictionary.

--- a/src/UglyToad.PdfPig.Fonts/Type1/Parser/Type1FontParser.cs
+++ b/src/UglyToad.PdfPig.Fonts/Type1/Parser/Type1FontParser.cs
@@ -39,7 +39,7 @@
                 var (ascii, binary) = ReadPfbHeader(inputBytes);
 
                 eexecPortion = binary;
-                inputBytes = new ByteArrayInputBytes(ascii);
+                inputBytes = new MemoryInputBytes(ascii);
             }
 
             var scanner = new CoreTokenScanner(inputBytes, false);

--- a/src/UglyToad.PdfPig.Tests/Fonts/Cmap/CodespaceRangeTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Fonts/Cmap/CodespaceRangeTests.cs
@@ -104,7 +104,7 @@
         public void ColorspaceParserError()
         {
             var parser = new CodespaceRangeParser();
-            var byteArrayInput = new ByteArrayInputBytes(OtherEncodings.StringAsLatin1Bytes("1 begincodespacerange\nendcodespacerange"));
+            var byteArrayInput = new MemoryInputBytes(OtherEncodings.StringAsLatin1Bytes("1 begincodespacerange\nendcodespacerange"));
             var tokenScanner = new CoreTokenScanner(byteArrayInput, false);
 
             Assert.True(tokenScanner.MoveNext());

--- a/src/UglyToad.PdfPig.Tests/Fonts/CompactFontFormat/Type2CharStringParserTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Fonts/CompactFontFormat/Type2CharStringParserTests.cs
@@ -24,7 +24,7 @@
             var input = StringToByteArray(Tika2121LegacySerifBookLetterBHex);
 
             var result = Type2CharStringParser.Parse(
-                new[] { input },
+                [new ReadOnlyMemory<byte>(input)],
                 EmptySubroutinesSelector,
                 NameCharset.Instance);
 

--- a/src/UglyToad.PdfPig.Tests/Fonts/Parser/AdobeFontMetricsParserTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Fonts/Parser/AdobeFontMetricsParserTests.cs
@@ -85,7 +85,7 @@ EndCharMetrics";
         {
             var helvetica = GetResourceBytes("UglyToad.PdfPig.Fonts.Resources.AdobeFontMetrics.Helvetica.afm");
 
-            var input = new ByteArrayInputBytes(helvetica);
+            var input = new MemoryInputBytes(helvetica);
 
             var metrics = AdobeFontMetricsParser.Parse(input, false);
 

--- a/src/UglyToad.PdfPig.Tests/Fonts/Parser/CMapParserTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Fonts/Parser/CMapParserTests.cs
@@ -118,7 +118,7 @@ endbfchar";
         {
             Debug.WriteLine("Parsing: " + resourceName);
             
-            var input = new ByteArrayInputBytes(ReadResourceBytes(resourceName));
+            var input = new MemoryInputBytes(ReadResourceBytes(resourceName));
 
             var cmap = cMapParser.Parse(input);
 
@@ -128,7 +128,7 @@ endbfchar";
         [Fact]
         public void CanParseIdentityHorizontalCMap()
         {
-            var input = new ByteArrayInputBytes(ReadResourceBytes("UglyToad.PdfPig.Resources.CMap.Identity-H"));
+            var input = new MemoryInputBytes(ReadResourceBytes("UglyToad.PdfPig.Resources.CMap.Identity-H"));
 
             var cmap = cMapParser.Parse(input);
 

--- a/src/UglyToad.PdfPig.Tests/Fonts/TrueType/Parser/TrueTypeFontParserTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Fonts/TrueType/Parser/TrueTypeFontParserTests.cs
@@ -16,7 +16,7 @@ namespace UglyToad.PdfPig.Tests.Fonts.TrueType.Parser
         {
             var bytes = TrueTypeTestHelper.GetFileBytes("Roboto-Regular");
 
-            var input = new TrueTypeDataBytes(new ByteArrayInputBytes(bytes));
+            var input = new TrueTypeDataBytes(new MemoryInputBytes(bytes));
 
             var font = TrueTypeFontParser.Parse(input);
 
@@ -90,7 +90,7 @@ namespace UglyToad.PdfPig.Tests.Fonts.TrueType.Parser
 
             var bytes = TrueTypeTestHelper.GetFileBytes("Roboto-Regular");
 
-            var input = new TrueTypeDataBytes(new ByteArrayInputBytes(bytes));
+            var input = new TrueTypeDataBytes(new MemoryInputBytes(bytes));
 
             var font = TrueTypeFontParser.Parse(input);
 
@@ -122,7 +122,7 @@ namespace UglyToad.PdfPig.Tests.Fonts.TrueType.Parser
         {
             var bytes = TrueTypeTestHelper.GetFileBytes("google-simple-doc");
 
-            var input = new TrueTypeDataBytes(new ByteArrayInputBytes(bytes));
+            var input = new TrueTypeDataBytes(new MemoryInputBytes(bytes));
 
             var font = TrueTypeFontParser.Parse(input);
 
@@ -134,7 +134,7 @@ namespace UglyToad.PdfPig.Tests.Fonts.TrueType.Parser
         {
             var bytes = TrueTypeTestHelper.GetFileBytes("Andada-Regular");
 
-            var input = new TrueTypeDataBytes(new ByteArrayInputBytes(bytes));
+            var input = new TrueTypeDataBytes(new MemoryInputBytes(bytes));
 
             var font = TrueTypeFontParser.Parse(input);
 
@@ -162,7 +162,7 @@ namespace UglyToad.PdfPig.Tests.Fonts.TrueType.Parser
         {
             var bytes = TrueTypeTestHelper.GetFileBytes("PMingLiU");
 
-            var input = new TrueTypeDataBytes(new ByteArrayInputBytes(bytes));
+            var input = new TrueTypeDataBytes(new MemoryInputBytes(bytes));
 
             var font = TrueTypeFontParser.Parse(input);
 
@@ -176,7 +176,7 @@ namespace UglyToad.PdfPig.Tests.Fonts.TrueType.Parser
 
             var bytes = TrueTypeTestHelper.GetFileBytes("Roboto-Regular");
 
-            var input = new TrueTypeDataBytes(new ByteArrayInputBytes(bytes));
+            var input = new TrueTypeDataBytes(new MemoryInputBytes(bytes));
 
             var font = TrueTypeFontParser.Parse(input);
 
@@ -221,7 +221,7 @@ namespace UglyToad.PdfPig.Tests.Fonts.TrueType.Parser
         {
             var bytes = TrueTypeTestHelper.GetFileBytes("issue-258-corrupt-name-table");
 
-            var input = new TrueTypeDataBytes(new ByteArrayInputBytes(bytes));
+            var input = new TrueTypeDataBytes(new MemoryInputBytes(bytes));
 
             var font = TrueTypeFontParser.Parse(input);
 

--- a/src/UglyToad.PdfPig.Tests/Fonts/TrueType/Tables/Os2TableTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Fonts/TrueType/Tables/Os2TableTests.cs
@@ -14,7 +14,7 @@
         {
             var fontBytes = TrueTypeTestHelper.GetFileBytes(fontFile);
 
-            var parsed = TrueTypeFontParser.Parse(new TrueTypeDataBytes(new ByteArrayInputBytes(fontBytes)));
+            var parsed = TrueTypeFontParser.Parse(new TrueTypeDataBytes(new MemoryInputBytes(fontBytes)));
 
             var os2 = parsed.TableRegister.Os2Table;
             var os2Header = parsed.TableHeaders.Single(x => x.Value.Tag == TrueTypeHeaderTable.Os2);

--- a/src/UglyToad.PdfPig.Tests/Fonts/TrueType/TrueTypeChecksumCalculatorTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Fonts/TrueType/TrueTypeChecksumCalculatorTests.cs
@@ -59,11 +59,11 @@
 
         private void Run(byte[] bytes, bool checkHeaderChecksum, bool checkWholeFileChecksum)
         {
-            var inputBytes = new ByteArrayInputBytes(bytes);
+            var inputBytes = new MemoryInputBytes(bytes);
 
             var font = TrueTypeFontParser.Parse(new TrueTypeDataBytes(inputBytes));
 
-            inputBytes = new ByteArrayInputBytes(bytes);
+            inputBytes = new MemoryInputBytes(bytes);
 
             foreach (var header in font.TableHeaders)
             {

--- a/src/UglyToad.PdfPig.Tests/Fonts/TrueType/TrueTypeDataBytesTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Fonts/TrueType/TrueTypeDataBytesTests.cs
@@ -8,7 +8,7 @@
         [Fact]
         public void ReadUnsignedInt()
         {
-            var input = new ByteArrayInputBytes(new byte[]
+            var input = new MemoryInputBytes(new byte[]
             {
                 220,
                 43,

--- a/src/UglyToad.PdfPig.Tests/Fonts/Type1/Type1FontParserTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Fonts/Type1/Type1FontParserTests.cs
@@ -11,7 +11,7 @@
         {
             var bytes = GetFileBytes("AdobeUtopia.pfa");
 
-            Type1FontParser.Parse(new ByteArrayInputBytes(bytes), 0, 0);
+            Type1FontParser.Parse(new MemoryInputBytes(bytes), 0, 0);
         }
 
         [Fact]
@@ -20,7 +20,7 @@
             // TODO: support reading in these pfb files
             var bytes = GetFileBytes("Raleway-Black.pfb");
 
-            Type1FontParser.Parse(new ByteArrayInputBytes(bytes), 0, 0);
+            Type1FontParser.Parse(new MemoryInputBytes(bytes), 0, 0);
         }
 
         [Fact]
@@ -28,7 +28,7 @@
         {
             var bytes = GetFileBytes("CMBX10.pfa");
 
-            Type1FontParser.Parse(new ByteArrayInputBytes(bytes), 0, 0);
+            Type1FontParser.Parse(new MemoryInputBytes(bytes), 0, 0);
         }
 
         [Fact]
@@ -36,7 +36,7 @@
         {
             var bytes = GetFileBytes("CMCSC10");
 
-            Type1FontParser.Parse(new ByteArrayInputBytes(bytes), 0, 0);
+            Type1FontParser.Parse(new MemoryInputBytes(bytes), 0, 0);
         }
 
         [Fact]
@@ -44,7 +44,7 @@
         {
             var bytes = GetFileBytes("CMBX12");
 
-            Type1FontParser.Parse(new ByteArrayInputBytes(bytes), 0, 0);
+            Type1FontParser.Parse(new MemoryInputBytes(bytes), 0, 0);
         }
 
         [Fact]
@@ -52,7 +52,7 @@
         {
             var bytes = GetFileBytes("CMBX10");
 
-            var result = Type1FontParser.Parse(new ByteArrayInputBytes(bytes), 0, 0);
+            var result = Type1FontParser.Parse(new MemoryInputBytes(bytes), 0, 0);
 
             var builder = new StringBuilder("<!DOCTYPE html><html><head></head><body>");
             foreach (var charString in result.CharStrings.CharStrings)
@@ -71,7 +71,7 @@
         {
             var bytes = GetFileBytes("CMR10");
 
-            Type1FontParser.Parse(new ByteArrayInputBytes(bytes), 0, 0);
+            Type1FontParser.Parse(new MemoryInputBytes(bytes), 0, 0);
         }
 
         private static byte[] GetFileBytes(string name)

--- a/src/UglyToad.PdfPig.Tests/Graphics/Operations/GraphicsStateOperationTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Graphics/Operations/GraphicsStateOperationTests.cs
@@ -39,7 +39,7 @@
                 }
                 else if (operationType == typeof(EndInlineImage))
                 {
-                    operation = new EndInlineImage(new List<byte>());
+                    operation = new EndInlineImage([]);
                 }
                 else if (operationType == typeof(BeginInlineImageData))
                 {

--- a/src/UglyToad.PdfPig.Tests/Graphics/TestOperationContext.cs
+++ b/src/UglyToad.PdfPig.Tests/Graphics/TestOperationContext.cs
@@ -180,7 +180,7 @@
         {
         }
 
-        public void EndInlineImage(IReadOnlyList<byte> bytes)
+        public void EndInlineImage(ReadOnlyMemory<byte> bytes)
         {
         }
 

--- a/src/UglyToad.PdfPig.Tests/IO/InputBytesTests.cs
+++ b/src/UglyToad.PdfPig.Tests/IO/InputBytesTests.cs
@@ -11,7 +11,7 @@
         {
             var bytes = OtherEncodings.StringAsLatin1Bytes(TestData);
 
-            var array = new ByteArrayInputBytes(bytes);
+            var array = new MemoryInputBytes(bytes);
 
             using (var memoryStream = new MemoryStream(bytes))
             {
@@ -220,7 +220,7 @@
             Assert.False(stream.MoveNext());
         }
 
-        private static ByteArrayInputBytes StringToBytes(string str) => new ByteArrayInputBytes(OtherEncodings.StringAsLatin1Bytes(str));
+        private static MemoryInputBytes StringToBytes(string str) => new MemoryInputBytes(OtherEncodings.StringAsLatin1Bytes(str));
         private static StreamInputBytes StringToStream(string str) => new StreamInputBytes(new MemoryStream(OtherEncodings.StringAsLatin1Bytes(str)));
     }
 }

--- a/src/UglyToad.PdfPig.Tests/Images/PngFromPdfImageFactoryTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Images/PngFromPdfImageFactoryTests.cs
@@ -218,13 +218,13 @@
             var image = new TestPdfImage
             {
                 ColorSpaceDetails = new CalRGBColorSpaceDetails(
-                    whitePoint: new List<double> { 0.95043, 1, 1.09 },
+                    whitePoint: [0.95043, 1, 1.09],
                     blackPoint: null,
-                    gamma: new List<double> { 2.2, 2.2, 2.2 },
-                    matrix: new List<double> {
+                    gamma: [2.2, 2.2, 2.2],
+                    matrix: [
                         0.41239, 0.21264, 0.01933,
                         0.35758, 0.71517, 0.11919,
-                        0.18045, 0.07218, 0.9504 }),
+                        0.18045, 0.07218, 0.9504]),
                 DecodedBytes = decodedBytes,
                 WidthInSamples = 153,
                 HeightInSamples = 83,
@@ -242,7 +242,7 @@
             var image = new TestPdfImage
             {
                 ColorSpaceDetails = new CalGrayColorSpaceDetails(
-                    whitePoint: new List<double> { 0.9505000114, 1, 1.0889999866 },
+                    whitePoint: [0.9505000114, 1, 1.0889999866],
                     blackPoint: null,
                     gamma: 2.2000000477),
                 DecodedBytes = decodedBytes,

--- a/src/UglyToad.PdfPig.Tests/Integration/AdvancedPdfDocumentAccessTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Integration/AdvancedPdfDocumentAccessTests.cs
@@ -17,7 +17,7 @@
                 {
                     var dict = new Dictionary<NameToken, IToken>();
                     dict[NameToken.Length] = new NumericToken(0);
-                    var replaced = new StreamToken(new DictionaryToken(dict), new List<byte>());
+                    var replaced = new StreamToken(new DictionaryToken(dict), []);
                     return replaced;
                 });
 
@@ -35,7 +35,7 @@
             {
                 var dict = new Dictionary<NameToken, IToken>();
                 dict[NameToken.Length] = new NumericToken(0);
-                var replacement = new StreamToken(new DictionaryToken(dict), new List<byte>());
+                var replacement = new StreamToken(new DictionaryToken(dict), []);
 
                 var pg = document.Structure.Catalog.Pages.GetPageNode(1).NodeDictionary;
                 var contents = pg.Data[NameToken.Contents] as IndirectReferenceToken;

--- a/src/UglyToad.PdfPig.Tests/Integration/EmbeddedFileAttachmentTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Integration/EmbeddedFileAttachmentTests.cs
@@ -29,7 +29,7 @@
 
                 Assert.Single(files);
 
-                Assert.Equal(20668, files[0].Bytes.Count);
+                Assert.Equal(20668, files[0].Memory.Length);
             }
         }
     }

--- a/src/UglyToad.PdfPig.Tests/Integration/PatternColorTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Integration/PatternColorTests.cs
@@ -80,7 +80,7 @@
                 Assert.NotNull(tillingColor.PatternStream);
                 Assert.Equal(1897.47, tillingColor.XStep);
                 Assert.Equal(2012.23, tillingColor.YStep);
-                Assert.Equal(142, tillingColor.Data.Count);
+                Assert.Equal(142, tillingColor.Data.Length);
 
                 Assert.Equal(new PdfPoint(-18.6026, -1992.51), tillingColor.BBox.BottomLeft);
                 Assert.Equal(new PdfPoint(1878.86, 19.7278), tillingColor.BBox.TopRight);

--- a/src/UglyToad.PdfPig.Tests/Integration/SinglePageLibreOfficeImages.cs
+++ b/src/UglyToad.PdfPig.Tests/Integration/SinglePageLibreOfficeImages.cs
@@ -70,13 +70,13 @@
                 var page = document.GetPage(1);
                 foreach (var image in page.GetImages())
                 {
-                    if (image.TryGetBytes(out var bytes))
+                    if (image.TryGetMemory(out var bytes))
                     {
-                        Assert.NotNull(bytes);
+                        Assert.False(bytes.IsEmpty);
                     }
                     else
                     {
-                        Assert.NotNull(image.RawBytes);
+                        Assert.False(image.RawMemory.IsEmpty);
                     }
                 }
             }

--- a/src/UglyToad.PdfPig.Tests/Integration/SinglePageLibreOfficeImages.cs
+++ b/src/UglyToad.PdfPig.Tests/Integration/SinglePageLibreOfficeImages.cs
@@ -70,7 +70,7 @@
                 var page = document.GetPage(1);
                 foreach (var image in page.GetImages())
                 {
-                    if (image.TryGetMemory(out var bytes))
+                    if (image.TryGetBytesAsMemory(out var bytes))
                     {
                         Assert.False(bytes.IsEmpty);
                     }

--- a/src/UglyToad.PdfPig.Tests/Integration/SwedishTouringCarChampionshipTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Integration/SwedishTouringCarChampionshipTests.cs
@@ -99,7 +99,7 @@
                 {
                     foreach (var image in page.GetImages())
                     {
-                        if (!image.TryGetMemory(out _))
+                        if (!image.TryGetBytesAsMemory(out _))
                         {
                             continue;
                         }

--- a/src/UglyToad.PdfPig.Tests/Integration/SwedishTouringCarChampionshipTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Integration/SwedishTouringCarChampionshipTests.cs
@@ -99,7 +99,7 @@
                 {
                     foreach (var image in page.GetImages())
                     {
-                        if (!image.TryGetBytes(out _))
+                        if (!image.TryGetMemory(out _))
                         {
                             continue;
                         }

--- a/src/UglyToad.PdfPig.Tests/Parser/Parts/BruteForceSearcherTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Parser/Parts/BruteForceSearcherTests.cs
@@ -53,7 +53,7 @@ startxref
         [Fact]
         public void SearcherFindsCorrectObjects()
         {
-            var input = new ByteArrayInputBytes(OtherEncodings.StringAsLatin1Bytes(TestData));
+            var input = new MemoryInputBytes(OtherEncodings.StringAsLatin1Bytes(TestData));
 
             var locations = BruteForceSearcher.GetObjectLocations(input);
 
@@ -99,7 +99,7 @@ endobj
 
 %%EOF";
 
-            var bytes = new ByteArrayInputBytes(OtherEncodings.StringAsLatin1Bytes(s));
+            var bytes = new MemoryInputBytes(OtherEncodings.StringAsLatin1Bytes(s));
 
             var locations = BruteForceSearcher.GetObjectLocations(bytes);
 
@@ -130,7 +130,7 @@ endobj
 << /IsEmpty false >>
 endobj";
 
-            var bytes = new ByteArrayInputBytes(OtherEncodings.StringAsLatin1Bytes(s));
+            var bytes = new MemoryInputBytes(OtherEncodings.StringAsLatin1Bytes(s));
 
             var locations = BruteForceSearcher.GetObjectLocations(bytes);
 
@@ -174,7 +174,7 @@ endobj";
         [Fact]
         public void BruteForceSearcherBytesFileOffsetsCorrect()
         {
-            var bytes = new ByteArrayInputBytes(File.ReadAllBytes(IntegrationHelpers.GetDocumentPath("Single Page Simple - from inkscape.pdf")));
+            var bytes = new MemoryInputBytes(File.ReadAllBytes(IntegrationHelpers.GetDocumentPath("Single Page Simple - from inkscape.pdf")));
 
             var locations = BruteForceSearcher.GetObjectLocations(bytes);
 
@@ -197,7 +197,7 @@ endobj";
         [Fact]
         public void BruteForceSearcherFileOffsetsCorrectOpenOffice()
         {
-            var bytes = new ByteArrayInputBytes(File.ReadAllBytes(IntegrationHelpers.GetDocumentPath("Single Page Simple - from open office.pdf")));
+            var bytes = new MemoryInputBytes(File.ReadAllBytes(IntegrationHelpers.GetDocumentPath("Single Page Simple - from open office.pdf")));
 
             var locations = BruteForceSearcher.GetObjectLocations(bytes);
 
@@ -224,7 +224,7 @@ endobj";
         [Fact]
         public void BruteForceSearcherCorrectlyFindsAllObjectsWhenOffset()
         {
-            var input = new ByteArrayInputBytes(OtherEncodings.StringAsLatin1Bytes(TestData));
+            var input = new MemoryInputBytes(OtherEncodings.StringAsLatin1Bytes(TestData));
 
             input.Seek(593);
 

--- a/src/UglyToad.PdfPig.Tests/Parser/Parts/FileHeaderParserTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Parser/Parts/FileHeaderParserTests.cs
@@ -147,7 +147,7 @@ three %PDF-1.6";
         {
             var input = OtherEncodings.StringAsLatin1Bytes("%PDF-1.7\r\n%âãÏÓ\r\n1 0 obj\r\n<</Lang(en-US)>>\r\nendobj");
 
-            var bytes = new ByteArrayInputBytes(input);
+            var bytes = new MemoryInputBytes(input);
 
             var scanner = new CoreTokenScanner(bytes, true, ScannerScope.None);
 

--- a/src/UglyToad.PdfPig.Tests/StringBytesTestConverter.cs
+++ b/src/UglyToad.PdfPig.Tests/StringBytesTestConverter.cs
@@ -8,7 +8,7 @@
     {
         public static Result Convert(string s, bool readFirst = true)
         {
-            var input = new ByteArrayInputBytes(Encoding.UTF8.GetBytes(s));
+            var input = new MemoryInputBytes(Encoding.UTF8.GetBytes(s));
 
             byte initialByte = 0;
             if (readFirst)
@@ -33,7 +33,7 @@
 
         internal static (CoreTokenScanner scanner, IInputBytes bytes) Scanner(string s)
         {
-            var inputBytes = new ByteArrayInputBytes(OtherEncodings.StringAsLatin1Bytes(s));
+            var inputBytes = new MemoryInputBytes(OtherEncodings.StringAsLatin1Bytes(s));
             var result = new CoreTokenScanner(inputBytes, true);
 
             return (result, inputBytes);

--- a/src/UglyToad.PdfPig.Tests/TestPdfImage.cs
+++ b/src/UglyToad.PdfPig.Tests/TestPdfImage.cs
@@ -17,7 +17,7 @@
 
         public int BitsPerComponent { get; set; } = 8;
 
-        public IReadOnlyList<byte> RawBytes { get; }
+        public ReadOnlyMemory<byte> RawMemory { get; }
 
         public RenderingIntent RenderingIntent { get; set; } = RenderingIntent.RelativeColorimetric;
 
@@ -33,12 +33,12 @@
 
         public ColorSpaceDetails ColorSpaceDetails { get; set; }
 
-        public IReadOnlyList<byte> DecodedBytes { get; set; }
+        public ReadOnlyMemory<byte> DecodedBytes { get; set; }
 
-        public bool TryGetBytes(out IReadOnlyList<byte> bytes)
+        public bool TryGetMemory(out ReadOnlyMemory<byte> bytes)
         {
             bytes = DecodedBytes;
-            return bytes != null;
+            return !bytes.IsEmpty;
         }
 
         public bool TryGetPng(out byte[] bytes) => PngFromPdfImageFactory.TryGenerate(this, out bytes);

--- a/src/UglyToad.PdfPig.Tests/TestPdfImage.cs
+++ b/src/UglyToad.PdfPig.Tests/TestPdfImage.cs
@@ -37,7 +37,7 @@
 
         public ReadOnlyMemory<byte> DecodedBytes { get; set; }
 
-        public bool TryGetMemory(out ReadOnlyMemory<byte> bytes)
+        public bool TryGetBytesAsMemory(out ReadOnlyMemory<byte> bytes)
         {
             bytes = DecodedBytes;
             return !bytes.IsEmpty;

--- a/src/UglyToad.PdfPig.Tests/TestPdfImage.cs
+++ b/src/UglyToad.PdfPig.Tests/TestPdfImage.cs
@@ -19,6 +19,8 @@
 
         public ReadOnlyMemory<byte> RawMemory { get; }
 
+        public ReadOnlySpan<byte> RawBytes => RawMemory.Span;
+
         public RenderingIntent RenderingIntent { get; set; } = RenderingIntent.RelativeColorimetric;
 
         public bool IsImageMask { get; set; }

--- a/src/UglyToad.PdfPig.Tests/Tokenization/StringTokenizerTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Tokenization/StringTokenizerTests.cs
@@ -29,7 +29,7 @@
         [InlineData('^')]
         public void DoesNotStartWithOpenBracket_ReturnsFalse(char firstByte)
         {
-            var input = new ByteArrayInputBytes(new[] {(byte)firstByte});
+            var input = new MemoryInputBytes(new[] {(byte)firstByte});
 
             var result = tokenizer.TryTokenize((byte)firstByte, input, out var token);
 
@@ -262,7 +262,7 @@ are the same.)";
         [Fact]
         public void HandlesUtf16Strings()
         {
-            var input = new ByteArrayInputBytes(new byte[]
+            var input = new MemoryInputBytes(new byte[]
             {
                 0xFE, 0xFF, 0x00, 0x4D, 0x00, 0x69, 0x00,
                 0x63, 0x29
@@ -278,7 +278,7 @@ are the same.)";
         [Fact]
         public void HandlesUtf16BigEndianStrings()
         {
-            var input = new ByteArrayInputBytes(new byte[]
+            var input = new MemoryInputBytes(new byte[]
             {
                 0xFF, 0xFE, 0x4D, 0x00, 0x69, 0x00, 0x63,
                 0x00, 0x29

--- a/src/UglyToad.PdfPig.Tests/Writer/Fonts/ToUnicodeCMapBuilderTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Writer/Fonts/ToUnicodeCMapBuilderTests.cs
@@ -24,7 +24,7 @@
 
             Assert.NotNull(str);
 
-            var result = new CMapParser().Parse(new ByteArrayInputBytes(cmapStream));
+            var result = new CMapParser().Parse(new MemoryInputBytes(cmapStream));
 
             Assert.Single(result.CodespaceRanges);
 

--- a/src/UglyToad.PdfPig.Tests/Writer/PdfDocumentBuilderTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Writer/PdfDocumentBuilderTests.cs
@@ -566,7 +566,7 @@
                 Assert.Equal(expectedBounds.BottomLeft, image.Bounds.BottomLeft);
                 Assert.Equal(expectedBounds.TopRight, image.Bounds.TopRight);
 
-                Assert.Equal(imageBytes, image.RawBytes);
+                Assert.Equal(imageBytes, image.RawMemory.ToArray());
             }
         }
 
@@ -622,9 +622,9 @@
 
                 Assert.Equal(expectedBounds3, image3.Bounds);
 
-                Assert.Equal(imageBytes, image1.RawBytes);
-                Assert.Equal(imageBytes, image2.RawBytes);
-                Assert.Equal(imageBytes, image3.RawBytes);
+                Assert.Equal(imageBytes, image1.RawMemory.ToArray());
+                Assert.Equal(imageBytes, image2.RawMemory.ToArray());
+                Assert.Equal(imageBytes, image3.RawMemory.ToArray());
             }
         }
 

--- a/src/UglyToad.PdfPig.Tests/Writer/PdfPageBuilderTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Writer/PdfPageBuilderTests.cs
@@ -35,6 +35,7 @@
                     var dataPNG = LoadPng("4-16bitRGBA.png");
                     page4.AddPng(dataPNG, new PdfRectangle(0, 0, 595, 842));
                 }
+
                 pdfBytes = pdfBuilder.Build();
             }
 
@@ -85,10 +86,6 @@
                     Assert.Equal(8, image1.BitsPerComponent);
                 }
             }
-            
-            
-
-
         }
 
 

--- a/src/UglyToad.PdfPig.Tokenization/Scanner/CoreTokenScanner.cs
+++ b/src/UglyToad.PdfPig.Tokenization/Scanner/CoreTokenScanner.cs
@@ -210,7 +210,7 @@
                         // Special case handling for inline images.
                         var imageData = ReadInlineImageData();
                         isInInlineImage = false;
-                        CurrentToken = new InlineImageDataToken(imageData);
+                        CurrentToken = new InlineImageDataToken(new ReadOnlyMemory<byte>([..imageData]));
                         hasBytePreRead = false;
                         return true;
                     }
@@ -287,7 +287,7 @@
             return data;
         }
 
-        private IReadOnlyList<byte> ReadInlineImageData()
+        private List<byte> ReadInlineImageData()
         {
             // The ID operator should be followed by a single white-space character, and the next character is interpreted
             // as the first byte of image data. 
@@ -305,7 +305,6 @@
         {
             const byte lastPlainText = 127;
             const byte space = 32;
-
 
             var imageData = new List<byte>();
             byte prevByte = 0;

--- a/src/UglyToad.PdfPig.Tokens/InlineImageDataToken.cs
+++ b/src/UglyToad.PdfPig.Tokens/InlineImageDataToken.cs
@@ -1,20 +1,20 @@
 ﻿namespace UglyToad.PdfPig.Tokens
 {
-    using System.Collections.Generic;
+    using System;
 
     /// <summary>
     /// Inline image data is used to embed images in PDF content streams. The content is wrapped by ID and ED tags in a BI operation.
     /// </summary>
-    public class InlineImageDataToken : IDataToken<IReadOnlyList<byte>>
+    public sealed class InlineImageDataToken : IDataToken<ReadOnlyMemory<byte>>
     {
         /// <inheritdoc />
-        public IReadOnlyList<byte> Data { get; }
+        public ReadOnlyMemory<byte> Data { get; }
 
         /// <summary>
         /// Create a new <see cref="InlineImageDataToken"/>.
         /// </summary>
         /// <param name="data"></param>
-        public InlineImageDataToken(IReadOnlyList<byte> data)
+        public InlineImageDataToken(ReadOnlyMemory<byte> data)
         {
             Data = data;
         }
@@ -32,21 +32,7 @@
                 return false;
             }
 
-            if (Data.Count != other.Data.Count)
-            {
-                return false;
-            }
-
-
-            for (var index = 0; index < Data.Count; ++index)
-            {
-                if (Data[index] != other.Data[index])
-                {
-                    return false;
-                }
-            }
-
-            return true;
+            return Data.Span.SequenceEqual(other.Data.Span);
         }
     }
 }

--- a/src/UglyToad.PdfPig.Tokens/StreamToken.cs
+++ b/src/UglyToad.PdfPig.Tokens/StreamToken.cs
@@ -1,13 +1,12 @@
 ﻿namespace UglyToad.PdfPig.Tokens
 {
     using System;
-    using System.Collections.Generic;
 
     /// <summary>
     /// A stream consists of a dictionary followed by zero or more bytes bracketed between the keywords stream and endstream.
     /// The bytes may be compressed by application of zero or more filters which are run in the order specified in the <see cref="StreamDictionary"/>.
     /// </summary>
-    public class StreamToken : IDataToken<IReadOnlyList<byte>>
+    public class StreamToken : IDataToken<ReadOnlyMemory<byte>>
     {
         /// <summary>
         /// The dictionary specifying the length of the stream, any applied compression filters and additional information.
@@ -17,17 +16,28 @@
         /// <summary>
         /// The compressed byte data of the stream.
         /// </summary>
-        public IReadOnlyList<byte> Data { get; }
+        public ReadOnlyMemory<byte> Data { get; }
 
         /// <summary>
         /// Create a new <see cref="StreamToken"/>.
         /// </summary>
         /// <param name="streamDictionary">The stream dictionary.</param>
         /// <param name="data">The stream data.</param>
-        public StreamToken(DictionaryToken streamDictionary, IReadOnlyList<byte> data)
+        public StreamToken(DictionaryToken streamDictionary, byte[] data)
         {
             StreamDictionary = streamDictionary ?? throw new ArgumentNullException(nameof(streamDictionary));
             Data = data ?? throw new ArgumentNullException(nameof(data));
+        }
+
+        /// <summary>
+        /// Create a new <see cref="StreamToken"/>.
+        /// </summary>
+        /// <param name="streamDictionary">The stream dictionary.</param>
+        /// <param name="data">The stream data.</param>
+        public StreamToken(DictionaryToken streamDictionary, ReadOnlyMemory<byte> data)
+        {
+            StreamDictionary = streamDictionary ?? throw new ArgumentNullException(nameof(streamDictionary));
+            Data = data;
         }
 
         /// <inheritdoc />
@@ -48,26 +58,13 @@
                 return false;
             }
 
-            if (Data.Count != other.Data.Count)
-            {
-                return false;
-            }
-
-            for (var index = 0; index < Data.Count; ++index)
-            {
-                if (Data[index] != other.Data[index])
-                {
-                    return false;
-                }
-            }
-
-            return true;
+            return Data.Span.SequenceEqual(other.Data.Span);
         }
 
         /// <inheritdoc />
         public override string ToString()
         {
-            return $"Length: {Data.Count}, Dictionary: {StreamDictionary}";
+            return $"Length: {Data.Length}, Dictionary: {StreamDictionary}";
         }
     }
 }

--- a/src/UglyToad.PdfPig/Annotations/AnnotationProvider.cs
+++ b/src/UglyToad.PdfPig/Annotations/AnnotationProvider.cs
@@ -115,13 +115,13 @@
 
                         if (values.Count == 8)
                         {
-                            quadPointRectangles.Add(new QuadPointsQuadrilateral(new[]
-                            {
+                            quadPointRectangles.Add(new QuadPointsQuadrilateral(
+                            [
                                 matrix.Transform(new PdfPoint(values[0], values[1])),
                                 matrix.Transform(new PdfPoint(values[2], values[3])),
                                 matrix.Transform(new PdfPoint(values[4], values[5])),
                                 matrix.Transform(new PdfPoint(values[6], values[7]))
-                            }));
+                            ]));
 
                             values.Clear();
                         }

--- a/src/UglyToad.PdfPig/Annotations/QuadPointsQuadrilateral.cs
+++ b/src/UglyToad.PdfPig/Annotations/QuadPointsQuadrilateral.cs
@@ -8,7 +8,7 @@
     /// A QuadPoints quadrilateral is four points defining the region for an annotation to use.
     /// An annotation may cover multiple quadrilaterals.
     /// </summary>
-    public class QuadPointsQuadrilateral
+    public readonly struct QuadPointsQuadrilateral
     {
         /// <summary>
         /// The 4 points defining this quadrilateral.
@@ -21,16 +21,16 @@
         /// <summary>
         /// Create a new <see cref="QuadPointsQuadrilateral"/>.
         /// </summary>
-        public QuadPointsQuadrilateral(IReadOnlyList<PdfPoint> points)
+        public QuadPointsQuadrilateral(PdfPoint[] points)
         {
             if (points is null)
             {
                 throw new ArgumentNullException(nameof(points));
             }
 
-            if (points.Count != 4)
+            if (points.Length != 4)
             {
-                throw new ArgumentException($"Quadpoints quadrilateral should only contain 4 points, instead got {points.Count} points.");
+                throw new ArgumentException($"Quadpoints quadrilateral should only contain 4 points, instead got {points.Length} points.");
             }
 
             Points = points;

--- a/src/UglyToad.PdfPig/Content/BasePageFactory.cs
+++ b/src/UglyToad.PdfPig/Content/BasePageFactory.cs
@@ -118,7 +118,7 @@
             }
             else if (DirectObjectFinder.TryGet<ArrayToken>(contents, PdfScanner, out var array))
             {
-                using var bytes = new ArrayPoolBufferWriter<byte>();
+                using var bytes = new ArrayPoolBufferWriter<byte>(1024 * 64);
 
                 for (var i = 0; i < array.Data.Count; i++)
                 {
@@ -144,7 +144,7 @@
                     }
                 }
 
-                page = ProcessPageInternal(number, dictionary, namedDestinations, mediaBox, cropBox, userSpaceUnit, rotation, initialMatrix, bytes.WrittenSpan.ToArray());
+                page = ProcessPageInternal(number, dictionary, namedDestinations, mediaBox, cropBox, userSpaceUnit, rotation, initialMatrix, bytes.WrittenMemory);
             }
             else
             {

--- a/src/UglyToad.PdfPig/Content/EmbeddedFile.cs
+++ b/src/UglyToad.PdfPig/Content/EmbeddedFile.cs
@@ -20,20 +20,25 @@
         public string FileSpecification { get; }
 
         /// <summary>
+        /// The decrypted memory of the file.
+        /// </summary>
+        public ReadOnlyMemory<byte> Memory { get; }
+
+        /// <summary>
         /// The decrypted bytes of the file.
         /// </summary>
-        public IReadOnlyList<byte> Bytes { get; }
+        public ReadOnlySpan<byte> Bytes => Memory.Span;
 
         /// <summary>
         /// The underlying embedded file stream.
         /// </summary>
         public StreamToken Stream { get; }
         
-        internal EmbeddedFile(string name, string fileSpecification, IReadOnlyList<byte> bytes, StreamToken stream)
+        internal EmbeddedFile(string name, string fileSpecification, ReadOnlyMemory<byte> bytes, StreamToken stream)
         {
             Name = name ?? throw new ArgumentNullException(nameof(name));
             FileSpecification = fileSpecification;
-            Bytes = bytes ?? throw new ArgumentNullException(nameof(bytes));
+            Memory = bytes;
             Stream = stream ?? throw new ArgumentNullException(nameof(stream));
         }
 

--- a/src/UglyToad.PdfPig/Content/IPdfImage.cs
+++ b/src/UglyToad.PdfPig/Content/IPdfImage.cs
@@ -40,6 +40,11 @@
         ReadOnlyMemory<byte> RawMemory { get; }
 
         /// <summary>
+        /// The encoded memory span of the image with all filters still applied.
+        /// </summary>
+        ReadOnlySpan<byte> RawBytes { get; }
+
+        /// <summary>
         /// The color rendering intent to be used when rendering the image.
         /// </summary>
         RenderingIntent RenderingIntent { get; }
@@ -90,10 +95,10 @@
         ColorSpaceDetails? ColorSpaceDetails { get; }
 
         /// <summary>
-        /// Get the decoded bytes of the image if applicable. For JPEG images and some other types the
+        /// Get the decoded memory of the image if applicable. For JPEG images and some other types the
         /// <see cref="RawMemory"/> should be used directly.
         /// </summary>
-        bool TryGetMemory(out ReadOnlyMemory<byte> bytes);
+        bool TryGetMemory(out ReadOnlyMemory<byte> memory);
 
         /// <summary>
         /// Try to convert the image to PNG. Doesn't support conversion of JPG to PNG.

--- a/src/UglyToad.PdfPig/Content/IPdfImage.cs
+++ b/src/UglyToad.PdfPig/Content/IPdfImage.cs
@@ -98,7 +98,7 @@
         /// Get the decoded memory of the image if applicable. For JPEG images and some other types the
         /// <see cref="RawMemory"/> should be used directly.
         /// </summary>
-        bool TryGetMemory(out ReadOnlyMemory<byte> memory);
+        bool TryGetBytesAsMemory(out ReadOnlyMemory<byte> memory);
 
         /// <summary>
         /// Try to convert the image to PNG. Doesn't support conversion of JPG to PNG.

--- a/src/UglyToad.PdfPig/Content/IPdfImage.cs
+++ b/src/UglyToad.PdfPig/Content/IPdfImage.cs
@@ -1,5 +1,6 @@
 ﻿namespace UglyToad.PdfPig.Content
 {
+    using System;
     using System.Collections.Generic;
     using System.Diagnostics.CodeAnalysis;
     using Core;
@@ -34,9 +35,9 @@
         int BitsPerComponent { get; }
 
         /// <summary>
-        /// The encoded bytes of the image with all filters still applied.
+        /// The encoded memory of the image with all filters still applied.
         /// </summary>
-        IReadOnlyList<byte> RawBytes { get; }
+        ReadOnlyMemory<byte> RawMemory { get; }
 
         /// <summary>
         /// The color rendering intent to be used when rendering the image.
@@ -90,9 +91,9 @@
 
         /// <summary>
         /// Get the decoded bytes of the image if applicable. For JPEG images and some other types the
-        /// <see cref="RawBytes"/> should be used directly.
+        /// <see cref="RawMemory"/> should be used directly.
         /// </summary>
-        bool TryGetBytes([NotNullWhen(true)] out IReadOnlyList<byte>? bytes);
+        bool TryGetMemory(out ReadOnlyMemory<byte> bytes);
 
         /// <summary>
         /// Try to convert the image to PNG. Doesn't support conversion of JPG to PNG.

--- a/src/UglyToad.PdfPig/Content/InlineImage.cs
+++ b/src/UglyToad.PdfPig/Content/InlineImage.cs
@@ -3,7 +3,6 @@
     using System;
     using System.Collections.Generic;
     using System.Diagnostics.CodeAnalysis;
-    using System.Linq;
     using Core;
     using Filters;
     using Graphics.Colors;
@@ -17,7 +16,7 @@
     /// </summary>
     public class InlineImage : IPdfImage
     {
-        private readonly Lazy<IReadOnlyList<byte>>? bytesFactory;
+        private readonly Lazy<ReadOnlyMemory<byte>>? memoryFactory;
 
         /// <inheritdoc />
         public PdfRectangle Bounds { get; }
@@ -50,7 +49,7 @@
         public bool Interpolate { get; }
 
         /// <inheritdoc />
-        public IReadOnlyList<byte> RawBytes { get; }
+        public ReadOnlyMemory<byte> RawMemory { get; }
 
         /// <inheritdoc />
         public ColorSpaceDetails ColorSpaceDetails { get; }
@@ -62,7 +61,7 @@
             RenderingIntent renderingIntent,
             bool interpolate,
             IReadOnlyList<double> decode,
-            IReadOnlyList<byte> bytes,
+            ReadOnlyMemory<byte> bytes,
             IReadOnlyList<IFilter> filters,
             DictionaryToken streamDictionary,
             ColorSpaceDetails colorSpaceDetails)
@@ -77,7 +76,7 @@
             Interpolate = interpolate;
             ImageDictionary = streamDictionary;
 
-            RawBytes = bytes;
+            RawMemory = bytes;
             ColorSpaceDetails = colorSpaceDetails;
 
             var supportsFilters = true;
@@ -90,7 +89,7 @@
                 }
             }
 
-            bytesFactory = supportsFilters ? new Lazy<IReadOnlyList<byte>>(() =>
+            memoryFactory = supportsFilters ? new Lazy<ReadOnlyMemory<byte>>(() =>
             {
                 var b = bytes.ToArray();
                 for (var i = 0; i < filters.Count; i++)
@@ -104,15 +103,15 @@
         }
 
         /// <inheritdoc />
-        public bool TryGetBytes([NotNullWhen(true)] out IReadOnlyList<byte>? bytes)
+        public bool TryGetMemory(out ReadOnlyMemory<byte> bytes)
         {
             bytes = null;
-            if (bytesFactory is null)
+            if (memoryFactory is null)
             {
                 return false;
             }
 
-            bytes = bytesFactory.Value;
+            bytes = memoryFactory.Value;
 
             return true;
         }

--- a/src/UglyToad.PdfPig/Content/InlineImage.cs
+++ b/src/UglyToad.PdfPig/Content/InlineImage.cs
@@ -105,7 +105,7 @@
         }
 
         /// <inheritdoc />
-        public bool TryGetMemory(out ReadOnlyMemory<byte> bytes)
+        public bool TryGetBytesAsMemory(out ReadOnlyMemory<byte> bytes)
         {
             bytes = null;
             if (memoryFactory is null)

--- a/src/UglyToad.PdfPig/Content/InlineImage.cs
+++ b/src/UglyToad.PdfPig/Content/InlineImage.cs
@@ -52,6 +52,9 @@
         public ReadOnlyMemory<byte> RawMemory { get; }
 
         /// <inheritdoc />
+        public ReadOnlySpan<byte> RawBytes => RawMemory.Span;
+
+        /// <inheritdoc />
         public ColorSpaceDetails ColorSpaceDetails { get; }
 
         /// <summary>
@@ -61,7 +64,7 @@
             RenderingIntent renderingIntent,
             bool interpolate,
             IReadOnlyList<double> decode,
-            ReadOnlyMemory<byte> bytes,
+            ReadOnlyMemory<byte> rawMemory,
             IReadOnlyList<IFilter> filters,
             DictionaryToken streamDictionary,
             ColorSpaceDetails colorSpaceDetails)
@@ -75,8 +78,7 @@
             RenderingIntent = renderingIntent;
             Interpolate = interpolate;
             ImageDictionary = streamDictionary;
-
-            RawMemory = bytes;
+            RawMemory = rawMemory;
             ColorSpaceDetails = colorSpaceDetails;
 
             var supportsFilters = true;
@@ -91,14 +93,14 @@
 
             memoryFactory = supportsFilters ? new Lazy<ReadOnlyMemory<byte>>(() =>
             {
-                var b = bytes.ToArray();
+                var b = rawMemory.Span;
                 for (var i = 0; i < filters.Count; i++)
                 {
                     var filter = filters[i];
                     b = filter.Decode(b, streamDictionary, i);
                 }
 
-                return b;
+                return b.ToArray();
             }) : null;
         }
 

--- a/src/UglyToad.PdfPig/Content/XmpMetadata.cs
+++ b/src/UglyToad.PdfPig/Content/XmpMetadata.cs
@@ -1,11 +1,9 @@
 ﻿namespace UglyToad.PdfPig.Content
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Linq;
-    using System.Xml.Linq;
     using Core;
     using Filters;
+    using System;
+    using System.Xml.Linq;
     using Tokenization.Scanner;
     using Tokens;
 
@@ -34,9 +32,9 @@
         /// Get the decoded bytes for the metadata stream. This can be interpreted as a sequence of plain-text bytes.
         /// </summary>
         /// <returns>The bytes for the metadata object with any filters removed.</returns>
-        public IReadOnlyList<byte> GetXmlBytes()
+        public ReadOnlySpan<byte> GetXmlBytes()
         {
-            return MetadataStreamToken.Decode(filterProvider, pdfTokenScanner);
+            return MetadataStreamToken.Decode(filterProvider, pdfTokenScanner).Span;
         }
 
         /// <summary>
@@ -45,7 +43,7 @@
         /// <returns>The <see cref="XDocument"/> for the XMP XML.</returns>
         public XDocument GetXDocument()
         {
-            return XDocument.Parse(OtherEncodings.BytesAsLatin1String(GetXmlBytes().ToArray()));
+            return XDocument.Parse(OtherEncodings.BytesAsLatin1String(GetXmlBytes()));
         }
     }
 }

--- a/src/UglyToad.PdfPig/Encryption/EncryptionHandler.cs
+++ b/src/UglyToad.PdfPig/Encryption/EncryptionHandler.cs
@@ -424,9 +424,7 @@ namespace UglyToad.PdfPig.Encryption
                                 continue;
                             }
 
-                            if (keyValuePair.Value is StringToken || keyValuePair.Value is ArrayToken
-                                                                  || keyValuePair.Value is DictionaryToken
-                                                                  || keyValuePair.Value is HexToken)
+                            if (keyValuePair.Value is StringToken or ArrayToken or DictionaryToken or HexToken)
                             {
                                 var inner = DecryptInternal(reference, keyValuePair.Value);
                                 dictionary = dictionary.With(keyValuePair.Key, inner);
@@ -455,7 +453,7 @@ namespace UglyToad.PdfPig.Encryption
             return token;
         }
 
-        private static StringToken GetStringTokenFromDecryptedData(byte[] data)
+        private static StringToken GetStringTokenFromDecryptedData(ReadOnlySpan<byte> data)
         {
             if (data.Length >= 2)
             {

--- a/src/UglyToad.PdfPig/Encryption/RC4.cs
+++ b/src/UglyToad.PdfPig/Encryption/RC4.cs
@@ -1,8 +1,10 @@
 ﻿namespace UglyToad.PdfPig.Encryption
 {
+    using System;
+
     internal static class RC4
     {
-        public static byte[] Encrypt(byte[] key, byte[] data)
+        public static byte[] Encrypt(ReadOnlySpan<byte> key, ReadOnlySpan<byte> data)
         {
             // Key-scheduling algorithm
             var s = new byte[256];

--- a/src/UglyToad.PdfPig/Encryption/RC4.cs
+++ b/src/UglyToad.PdfPig/Encryption/RC4.cs
@@ -7,7 +7,7 @@
         public static byte[] Encrypt(ReadOnlySpan<byte> key, ReadOnlySpan<byte> data)
         {
             // Key-scheduling algorithm
-            var s = new byte[256];
+            Span<byte> s = stackalloc byte[256];
             for (var i = 0; i < 256; i++)
             {
                 s[i] = (byte)i;

--- a/src/UglyToad.PdfPig/Filters/Ascii85Filter.cs
+++ b/src/UglyToad.PdfPig/Filters/Ascii85Filter.cs
@@ -29,18 +29,17 @@
         public bool IsSupported { get; } = true;
 
         /// <inheritdoc />
-        public byte[] Decode(ReadOnlyMemory<byte> input, DictionaryToken streamDictionary, int filterIndex)
+        public byte[] Decode(ReadOnlySpan<byte> input, DictionaryToken streamDictionary, int filterIndex)
         {
-            var inputSpan = input.Span;
             var asciiBuffer = new byte[5];
 
             var index = 0;
 
             using var writer = new ArrayPoolBufferWriter<byte>();
            
-            for (var i = 0; i < inputSpan.Length; i++)
+            for (var i = 0; i < input.Length; i++)
             {
-                var value = inputSpan[i];
+                var value = input[i];
 
                 if (IsWhiteSpace(value))
                 {
@@ -49,7 +48,7 @@
 
                 if (value == EndOfDataBytes[0])
                 {
-                    if (i == inputSpan.Length - 1 || inputSpan[i + 1] == EndOfDataBytes[1])
+                    if (i == input.Length - 1 || input[i + 1] == EndOfDataBytes[1])
                     {
                         if (index > 0)
                         {

--- a/src/UglyToad.PdfPig/Filters/Ascii85Filter.cs
+++ b/src/UglyToad.PdfPig/Filters/Ascii85Filter.cs
@@ -29,17 +29,18 @@
         public bool IsSupported { get; } = true;
 
         /// <inheritdoc />
-        public byte[] Decode(IReadOnlyList<byte> input, DictionaryToken streamDictionary, int filterIndex)
+        public byte[] Decode(ReadOnlyMemory<byte> input, DictionaryToken streamDictionary, int filterIndex)
         {
+            var inputSpan = input.Span;
             var asciiBuffer = new byte[5];
 
             var index = 0;
 
             using var writer = new ArrayPoolBufferWriter<byte>();
            
-            for (var i = 0; i < input.Count; i++)
+            for (var i = 0; i < inputSpan.Length; i++)
             {
-                var value = input[i];
+                var value = inputSpan[i];
 
                 if (IsWhiteSpace(value))
                 {
@@ -48,7 +49,7 @@
 
                 if (value == EndOfDataBytes[0])
                 {
-                    if (i == input.Count - 1 || input[i + 1] == EndOfDataBytes[1])
+                    if (i == inputSpan.Length - 1 || inputSpan[i + 1] == EndOfDataBytes[1])
                     {
                         if (index > 0)
                         {

--- a/src/UglyToad.PdfPig/Filters/AsciiHexDecodeFilter.cs
+++ b/src/UglyToad.PdfPig/Filters/AsciiHexDecodeFilter.cs
@@ -30,27 +30,28 @@
         public bool IsSupported { get; } = true;
 
         /// <inheritdoc />
-        public byte[] Decode(IReadOnlyList<byte> input, DictionaryToken streamDictionary, int filterIndex)
+        public byte[] Decode(ReadOnlyMemory<byte> input, DictionaryToken streamDictionary, int filterIndex)
         {
+            var inputSpan = input.Span;
             var pair = new byte[2];
             var index = 0;
 
             using (var memoryStream = new MemoryStream())
             using (var binaryWriter = new BinaryWriter(memoryStream))
             {
-                for (var i = 0; i < input.Count; i++)
+                for (var i = 0; i < inputSpan.Length; i++)
                 {
-                    if (input[i] == '>')
+                    if (inputSpan[i] == '>')
                     {
                         break;
                     }
 
-                    if (IsWhitespace(input[i]) || input[i] == '<')
+                    if (IsWhitespace(inputSpan[i]) || inputSpan[i] == '<')
                     {
                         continue;
                     }
 
-                    pair[index] = input[i];
+                    pair[index] = inputSpan[i];
                     index++;
 
                     if (index == 2)
@@ -76,7 +77,7 @@
             }
         }
 
-        private static void WriteHexToByte(byte[] hexBytes, BinaryWriter writer)
+        private static void WriteHexToByte(ReadOnlySpan<byte> hexBytes, BinaryWriter writer)
         {
             var first = ReverseHex[hexBytes[0]];
             var second = ReverseHex[hexBytes[1]];

--- a/src/UglyToad.PdfPig/Filters/AsciiHexDecodeFilter.cs
+++ b/src/UglyToad.PdfPig/Filters/AsciiHexDecodeFilter.cs
@@ -1,7 +1,6 @@
 ﻿namespace UglyToad.PdfPig.Filters
 {
     using System;
-    using System.Collections.Generic;
     using System.IO;
     using Tokens;
 
@@ -9,7 +8,7 @@
     /// <summary>
     /// Encodes/decodes data using the ASCII hexadecimal encoding where each byte is represented by two ASCII characters.
     /// </summary>
-    internal class AsciiHexDecodeFilter : IFilter
+    internal sealed class AsciiHexDecodeFilter : IFilter
     {
         private static readonly short[] ReverseHex = 
         [
@@ -30,28 +29,27 @@
         public bool IsSupported { get; } = true;
 
         /// <inheritdoc />
-        public byte[] Decode(ReadOnlyMemory<byte> input, DictionaryToken streamDictionary, int filterIndex)
+        public byte[] Decode(ReadOnlySpan<byte> input, DictionaryToken streamDictionary, int filterIndex)
         {
-            var inputSpan = input.Span;
-            var pair = new byte[2];
+            Span<byte> pair = stackalloc byte[2];
             var index = 0;
 
             using (var memoryStream = new MemoryStream())
             using (var binaryWriter = new BinaryWriter(memoryStream))
             {
-                for (var i = 0; i < inputSpan.Length; i++)
+                for (var i = 0; i < input.Length; i++)
                 {
-                    if (inputSpan[i] == '>')
+                    if (input[i] == '>')
                     {
                         break;
                     }
 
-                    if (IsWhitespace(inputSpan[i]) || inputSpan[i] == '<')
+                    if (IsWhitespace(input[i]) || input[i] == '<')
                     {
                         continue;
                     }
 
-                    pair[index] = inputSpan[i];
+                    pair[index] = input[i];
                     index++;
 
                     if (index == 2)

--- a/src/UglyToad.PdfPig/Filters/BitStream.cs
+++ b/src/UglyToad.PdfPig/Filters/BitStream.cs
@@ -1,18 +1,17 @@
 ﻿namespace UglyToad.PdfPig.Filters
 {
     using System;
-    using System.Collections.Generic;
 
-    internal class BitStream
+    internal ref struct BitStream
     {
-        private readonly IReadOnlyList<byte> data;
+        private readonly ReadOnlySpan<byte> data;
 
         private int currentWithinByteBitOffset;
         private int currentByteIndex;
 
-        public BitStream(IReadOnlyList<byte> data)
+        public BitStream(ReadOnlySpan<byte> data)
         {
-            this.data = data ?? throw new ArgumentNullException(nameof(data));
+            this.data = data;
         }
 
         public int Get(int numberOfBits)
@@ -34,7 +33,7 @@
                     currentByteIndex++;
                 }
 
-                if (currentByteIndex >= data.Count)
+                if (currentByteIndex >= data.Length)
                 {
                     throw new InvalidOperationException($"Reached the end of the bit stream while trying to read {i} bits.");
                 }

--- a/src/UglyToad.PdfPig/Filters/CcittFaxDecodeFilter.cs
+++ b/src/UglyToad.PdfPig/Filters/CcittFaxDecodeFilter.cs
@@ -1,9 +1,7 @@
 ﻿namespace UglyToad.PdfPig.Filters
 {
     using System;
-    using System.Collections.Generic;
     using System.IO;
-    using System.Linq;
     using Tokens;
     using Util;
 
@@ -12,13 +10,13 @@
     ///
     /// Ported from https://github.com/apache/pdfbox/blob/714156a15ea6fcfe44ac09345b01e192cbd74450/pdfbox/src/main/java/org/apache/pdfbox/filter/CCITTFaxFilter.java
     /// </summary>
-    internal class CcittFaxDecodeFilter : IFilter
+    internal sealed class CcittFaxDecodeFilter : IFilter
     {
         /// <inheritdoc />
         public bool IsSupported { get; } = true;
 
         /// <inheritdoc />
-        public byte[] Decode(ReadOnlyMemory<byte> input, DictionaryToken streamDictionary, int filterIndex)
+        public byte[] Decode(ReadOnlySpan<byte> input, DictionaryToken streamDictionary, int filterIndex)
         {
             var decodeParms = DecodeParameterResolver.GetFilterParameters(streamDictionary, filterIndex);
 
@@ -38,7 +36,7 @@
 
             var k = decodeParms.GetIntOrDefault(NameToken.K, 0);
             var encodedByteAlign = decodeParms.GetBooleanOrDefault(NameToken.EncodedByteAlign, false);
-            var compressionType = DetermineCompressionType(input.Span, k);
+            var compressionType = DetermineCompressionType(input, k);
             using (var stream = new CcittFaxDecoderStream(new MemoryStream(input.ToArray()), cols, compressionType, encodedByteAlign))
             {
                 var arraySize = (cols + 7) / 8 * rows;

--- a/src/UglyToad.PdfPig/Filters/CcittFaxDecoderStream.cs
+++ b/src/UglyToad.PdfPig/Filters/CcittFaxDecoderStream.cs
@@ -329,7 +329,7 @@
 
             if (index != columns)
             {
-                throw new InvalidOperationException("Sum of run-lengths does not equal scan line width: " + index + " > " + columns);
+                throw new InvalidOperationException($"Sum of run-lengths does not equal scan line width: {index} > {columns}");
             }
 
             decodedLength = (index + 7) / 8;

--- a/src/UglyToad.PdfPig/Filters/DctDecodeFilter.cs
+++ b/src/UglyToad.PdfPig/Filters/DctDecodeFilter.cs
@@ -9,7 +9,7 @@
         public bool IsSupported { get; } = false;
 
         /// <inheritdoc />
-        public byte[] Decode(ReadOnlyMemory<byte> input, DictionaryToken streamDictionary, int filterIndex)
+        public byte[] Decode(ReadOnlySpan<byte> input, DictionaryToken streamDictionary, int filterIndex)
         {
             throw new NotSupportedException("The DST (Discrete Cosine Transform) Filter indicates data is encoded in JPEG format. " +
                                             "This filter is not currently supported but the raw data can be supplied to JPEG supporting libraries.");

--- a/src/UglyToad.PdfPig/Filters/DctDecodeFilter.cs
+++ b/src/UglyToad.PdfPig/Filters/DctDecodeFilter.cs
@@ -1,7 +1,6 @@
 ﻿namespace UglyToad.PdfPig.Filters
 {
     using System;
-    using System.Collections.Generic;
     using Tokens;
 
     internal class DctDecodeFilter : IFilter
@@ -10,7 +9,7 @@
         public bool IsSupported { get; } = false;
 
         /// <inheritdoc />
-        public byte[] Decode(IReadOnlyList<byte> input, DictionaryToken streamDictionary, int filterIndex)
+        public byte[] Decode(ReadOnlyMemory<byte> input, DictionaryToken streamDictionary, int filterIndex)
         {
             throw new NotSupportedException("The DST (Discrete Cosine Transform) Filter indicates data is encoded in JPEG format. " +
                                             "This filter is not currently supported but the raw data can be supplied to JPEG supporting libraries.");

--- a/src/UglyToad.PdfPig/Filters/FlateFilter.cs
+++ b/src/UglyToad.PdfPig/Filters/FlateFilter.cs
@@ -34,13 +34,8 @@
         public bool IsSupported { get; } = true;
 
         /// <inheritdoc />
-        public byte[] Decode(IReadOnlyList<byte> input, DictionaryToken streamDictionary, int filterIndex)
+        public byte[] Decode(ReadOnlyMemory<byte> input, DictionaryToken streamDictionary, int filterIndex)
         {
-            if (input is null)
-            {
-                throw new ArgumentNullException(nameof(input));
-            }
-
             var parameters = DecodeParameterResolver.GetFilterParameters(streamDictionary, filterIndex);
 
             var predictor = parameters.GetIntOrDefault(NameToken.Predictor, -1);

--- a/src/UglyToad.PdfPig/Filters/FlateFilter.cs
+++ b/src/UglyToad.PdfPig/Filters/FlateFilter.cs
@@ -2,10 +2,8 @@
 {
     using Fonts;
     using System;
-    using System.Collections.Generic;
     using System.IO;
     using System.IO.Compression;
-    using System.Linq;
     using Tokens;
     using Util;
 
@@ -20,7 +18,7 @@
     /// See section 3.3.3 of the spec (version 1.7) for details on the FlateDecode filter.
     /// The flate decode filter may have a predictor function to further compress the stream.
     /// </remarks>
-    internal class FlateFilter : IFilter
+    internal sealed class FlateFilter : IFilter
     {
         // Defaults are from table 3.7 in the spec (version 1.7)
         private const int DefaultColors = 1;
@@ -34,7 +32,7 @@
         public bool IsSupported { get; } = true;
 
         /// <inheritdoc />
-        public byte[] Decode(ReadOnlyMemory<byte> input, DictionaryToken streamDictionary, int filterIndex)
+        public byte[] Decode(ReadOnlySpan<byte> input, DictionaryToken streamDictionary, int filterIndex)
         {
             var parameters = DecodeParameterResolver.GetFilterParameters(streamDictionary, filterIndex);
 

--- a/src/UglyToad.PdfPig/Filters/IFilter.cs
+++ b/src/UglyToad.PdfPig/Filters/IFilter.cs
@@ -1,7 +1,6 @@
 ﻿namespace UglyToad.PdfPig.Filters
 {
     using System;
-    using System.Collections.Generic;
     using Tokens;
 
     /// <summary>
@@ -21,6 +20,6 @@
         /// <param name="streamDictionary">The dictionary of the <see cref="StreamToken"/> (or other dictionary types, e.g. inline images) containing these bytes.</param>
         /// <param name="filterIndex">The position of this filter in the pipeline used to encode data.</param>
         /// <returns>The decoded bytes.</returns>
-        byte[] Decode(ReadOnlyMemory<byte> input, DictionaryToken streamDictionary, int filterIndex);
+        byte[] Decode(ReadOnlySpan<byte> input, DictionaryToken streamDictionary, int filterIndex);
     }
 }

--- a/src/UglyToad.PdfPig/Filters/IFilter.cs
+++ b/src/UglyToad.PdfPig/Filters/IFilter.cs
@@ -1,5 +1,6 @@
 ﻿namespace UglyToad.PdfPig.Filters
 {
+    using System;
     using System.Collections.Generic;
     using Tokens;
 
@@ -20,6 +21,6 @@
         /// <param name="streamDictionary">The dictionary of the <see cref="StreamToken"/> (or other dictionary types, e.g. inline images) containing these bytes.</param>
         /// <param name="filterIndex">The position of this filter in the pipeline used to encode data.</param>
         /// <returns>The decoded bytes.</returns>
-        byte[] Decode(IReadOnlyList<byte> input, DictionaryToken streamDictionary, int filterIndex);
+        byte[] Decode(ReadOnlyMemory<byte> input, DictionaryToken streamDictionary, int filterIndex);
     }
 }

--- a/src/UglyToad.PdfPig/Filters/Jbig2DecodeFilter.cs
+++ b/src/UglyToad.PdfPig/Filters/Jbig2DecodeFilter.cs
@@ -9,7 +9,7 @@
         public bool IsSupported { get; } = false;
 
         /// <inheritdoc />
-        public byte[] Decode(ReadOnlyMemory<byte> input, DictionaryToken streamDictionary, int filterIndex)
+        public byte[] Decode(ReadOnlySpan<byte> input, DictionaryToken streamDictionary, int filterIndex)
         {
             throw new NotSupportedException("The JBIG2 Filter for monochrome image data is not currently supported. " +
                                             "Try accessing the raw compressed data directly.");

--- a/src/UglyToad.PdfPig/Filters/Jbig2DecodeFilter.cs
+++ b/src/UglyToad.PdfPig/Filters/Jbig2DecodeFilter.cs
@@ -1,16 +1,15 @@
 ﻿namespace UglyToad.PdfPig.Filters
 {
     using System;
-    using System.Collections.Generic;
     using Tokens;
 
-    internal class Jbig2DecodeFilter : IFilter
+    internal sealed class Jbig2DecodeFilter : IFilter
     {
         /// <inheritdoc />
         public bool IsSupported { get; } = false;
 
         /// <inheritdoc />
-        public byte[] Decode(IReadOnlyList<byte> input, DictionaryToken streamDictionary, int filterIndex)
+        public byte[] Decode(ReadOnlyMemory<byte> input, DictionaryToken streamDictionary, int filterIndex)
         {
             throw new NotSupportedException("The JBIG2 Filter for monochrome image data is not currently supported. " +
                                             "Try accessing the raw compressed data directly.");

--- a/src/UglyToad.PdfPig/Filters/JpxDecodeFilter.cs
+++ b/src/UglyToad.PdfPig/Filters/JpxDecodeFilter.cs
@@ -1,7 +1,6 @@
 ﻿namespace UglyToad.PdfPig.Filters
 {
     using System;
-    using System.Collections.Generic;
     using Tokens;
 
     internal class JpxDecodeFilter : IFilter
@@ -10,7 +9,7 @@
         public bool IsSupported { get; } = false;
 
         /// <inheritdoc />
-        public byte[] Decode(IReadOnlyList<byte> input, DictionaryToken streamDictionary, int filterIndex)
+        public byte[] Decode(ReadOnlyMemory<byte> input, DictionaryToken streamDictionary, int filterIndex)
         {
             throw new NotSupportedException("The JPX Filter (JPEG2000) for image data is not currently supported. " +
                                             "Try accessing the raw compressed data directly.");

--- a/src/UglyToad.PdfPig/Filters/JpxDecodeFilter.cs
+++ b/src/UglyToad.PdfPig/Filters/JpxDecodeFilter.cs
@@ -9,7 +9,7 @@
         public bool IsSupported { get; } = false;
 
         /// <inheritdoc />
-        public byte[] Decode(ReadOnlyMemory<byte> input, DictionaryToken streamDictionary, int filterIndex)
+        public byte[] Decode(ReadOnlySpan<byte> input, DictionaryToken streamDictionary, int filterIndex)
         {
             throw new NotSupportedException("The JPX Filter (JPEG2000) for image data is not currently supported. " +
                                             "Try accessing the raw compressed data directly.");

--- a/src/UglyToad.PdfPig/Filters/LzwFilter.cs
+++ b/src/UglyToad.PdfPig/Filters/LzwFilter.cs
@@ -29,7 +29,7 @@ namespace UglyToad.PdfPig.Filters
         public bool IsSupported { get; } = true;
 
         /// <inheritdoc />
-        public byte[] Decode(ReadOnlyMemory<byte> input, DictionaryToken streamDictionary, int filterIndex)
+        public byte[] Decode(ReadOnlySpan<byte> input, DictionaryToken streamDictionary, int filterIndex)
         {
             var parameters = DecodeParameterResolver.GetFilterParameters(streamDictionary, filterIndex);
 
@@ -39,7 +39,7 @@ namespace UglyToad.PdfPig.Filters
 
             if (predictor > 1)
             {
-                var decompressed = Decode(input.Span, earlyChange == 1);
+                var decompressed = Decode(input, earlyChange == 1);
 
                 var colors = Math.Min(parameters.GetIntOrDefault(NameToken.Colors, DefaultColors), 32);
                 var bitsPerComponent = parameters.GetIntOrDefault(NameToken.BitsPerComponent, DefaultBitsPerComponent);
@@ -50,7 +50,7 @@ namespace UglyToad.PdfPig.Filters
                 return result;
             }
 
-            var data = Decode(input.Span, earlyChange == 1);
+            var data = Decode(input, earlyChange == 1);
 
             return data;
         }

--- a/src/UglyToad.PdfPig/Filters/LzwFilter.cs
+++ b/src/UglyToad.PdfPig/Filters/LzwFilter.cs
@@ -29,7 +29,7 @@ namespace UglyToad.PdfPig.Filters
         public bool IsSupported { get; } = true;
 
         /// <inheritdoc />
-        public byte[] Decode(IReadOnlyList<byte> input, DictionaryToken streamDictionary, int filterIndex)
+        public byte[] Decode(ReadOnlyMemory<byte> input, DictionaryToken streamDictionary, int filterIndex)
         {
             var parameters = DecodeParameterResolver.GetFilterParameters(streamDictionary, filterIndex);
 
@@ -39,7 +39,7 @@ namespace UglyToad.PdfPig.Filters
 
             if (predictor > 1)
             {
-                var decompressed = Decode(input, earlyChange == 1);
+                var decompressed = Decode(input.Span, earlyChange == 1);
 
                 var colors = Math.Min(parameters.GetIntOrDefault(NameToken.Colors, DefaultColors), 32);
                 var bitsPerComponent = parameters.GetIntOrDefault(NameToken.BitsPerComponent, DefaultBitsPerComponent);
@@ -50,15 +50,15 @@ namespace UglyToad.PdfPig.Filters
                 return result;
             }
 
-            var data = Decode(input, earlyChange == 1);
+            var data = Decode(input.Span, earlyChange == 1);
 
             return data;
         }
 
-        private static byte[] Decode(IReadOnlyList<byte> input, bool isEarlyChange)
+        private static byte[] Decode(ReadOnlySpan<byte> input, bool isEarlyChange)
         {
             // A guess.
-            var result = new List<byte>((int)(input.Count * 1.5));
+            var result = new List<byte>((int)(input.Length * 1.5));
 
             var table = GetDefaultTable();
 

--- a/src/UglyToad.PdfPig/Filters/RunLengthFilter.cs
+++ b/src/UglyToad.PdfPig/Filters/RunLengthFilter.cs
@@ -1,5 +1,6 @@
 ﻿namespace UglyToad.PdfPig.Filters
 {
+    using System;
     using System.Collections.Generic;
     using System.IO;
     using Tokens;
@@ -17,15 +18,16 @@
         public bool IsSupported { get; } = true;
 
         /// <inheritdoc />
-        public byte[] Decode(IReadOnlyList<byte> input, DictionaryToken streamDictionary, int filterIndex)
+        public byte[] Decode(ReadOnlyMemory<byte> input, DictionaryToken streamDictionary, int filterIndex)
         {
+            var inputSpan = input.Span;
             using (var memoryStream = new MemoryStream())
             using (var writer = new BinaryWriter(memoryStream))
             {
                 var i = 0;
-                while (i < input.Count)
+                while (i < inputSpan.Length)
                 {
-                    var runLength = input[i];
+                    var runLength = inputSpan[i];
 
                     if (runLength == EndOfDataLength)
                     {
@@ -41,7 +43,7 @@
                         {
                             i++;
 
-                            writer.Write(input[i]);
+                            writer.Write(inputSpan[i]);
 
                             rangeToWriteLiterally--;
                         }
@@ -54,7 +56,7 @@
                     {
                         var numberOfTimesToCopy = 257 - runLength;
 
-                        var byteToCopy = input[i + 1];
+                        var byteToCopy = inputSpan[i + 1];
 
                         for (int j = 0; j < numberOfTimesToCopy; j++)
                         {

--- a/src/UglyToad.PdfPig/Filters/RunLengthFilter.cs
+++ b/src/UglyToad.PdfPig/Filters/RunLengthFilter.cs
@@ -55,10 +55,8 @@
 
                     var byteToCopy = input[i + 1];
 
-                    for (int j = 0; j < numberOfTimesToCopy; j++)
-                    {
-                        output.Write(byteToCopy);
-                    }
+                    output.GetSpan(numberOfTimesToCopy).Slice(0, numberOfTimesToCopy).Fill(byteToCopy);
+                    output.Advance(numberOfTimesToCopy);
 
                     // Move to the single byte after the byte to copy.
                     i += 2;

--- a/src/UglyToad.PdfPig/Filters/RunLengthFilter.cs
+++ b/src/UglyToad.PdfPig/Filters/RunLengthFilter.cs
@@ -1,16 +1,15 @@
 ﻿namespace UglyToad.PdfPig.Filters
 {
     using System;
-    using System.Collections.Generic;
-    using System.IO;
     using Tokens;
+    using UglyToad.PdfPig.Core;
 
     /// <inheritdoc />
     /// <summary>
     /// The Run Length filterencodes data in a simple byte-oriented format based on run length.
     /// The encoded data is a sequence of runs, where each run consists of a length byte followed by 1 to 128 bytes of data.
     /// </summary>
-    internal class RunLengthFilter : IFilter
+    internal sealed class RunLengthFilter : IFilter
     {
         private const byte EndOfDataLength = 128;
 
@@ -18,60 +17,55 @@
         public bool IsSupported { get; } = true;
 
         /// <inheritdoc />
-        public byte[] Decode(ReadOnlyMemory<byte> input, DictionaryToken streamDictionary, int filterIndex)
+        public byte[] Decode(ReadOnlySpan<byte> input, DictionaryToken streamDictionary, int filterIndex)
         {
-            var inputSpan = input.Span;
-            using (var memoryStream = new MemoryStream())
-            using (var writer = new BinaryWriter(memoryStream))
+            using var output = new ArrayPoolBufferWriter<byte>(input.Length);
+
+            var i = 0;
+            while (i < input.Length)
             {
-                var i = 0;
-                while (i < inputSpan.Length)
+                var runLength = input[i];
+
+                if (runLength == EndOfDataLength)
                 {
-                    var runLength = inputSpan[i];
-
-                    if (runLength == EndOfDataLength)
-                    {
-                        break;
-                    }
-
-                    // if length byte in range 0 - 127 copy the following length + 1 bytes literally to the output.
-                    if (runLength <= 127)
-                    {
-                        var rangeToWriteLiterally = runLength + 1;
-
-                        while (rangeToWriteLiterally > 0)
-                        {
-                            i++;
-
-                            writer.Write(inputSpan[i]);
-
-                            rangeToWriteLiterally--;
-                        }
-
-                        // Move to the following byte.
-                        i++;
-                    }
-                    // Otherwise copy the single following byte 257 - length times (between 2 - 128 times)
-                    else
-                    {
-                        var numberOfTimesToCopy = 257 - runLength;
-
-                        var byteToCopy = inputSpan[i + 1];
-
-                        for (int j = 0; j < numberOfTimesToCopy; j++)
-                        {
-                            writer.Write(byteToCopy);
-                        }
-
-                        // Move to the single byte after the byte to copy.
-                        i += 2;
-                    }
+                    break;
                 }
 
-                writer.Flush();
+                // if length byte in range 0 - 127 copy the following length + 1 bytes literally to the output.
+                if (runLength <= 127)
+                {
+                    var rangeToWriteLiterally = runLength + 1;
 
-                return memoryStream.ToArray();
+                    while (rangeToWriteLiterally > 0)
+                    {
+                        i++;
+
+                        output.Write(input[i]);
+
+                        rangeToWriteLiterally--;
+                    }
+
+                    // Move to the following byte.
+                    i++;
+                }
+                // Otherwise copy the single following byte 257 - length times (between 2 - 128 times)
+                else
+                {
+                    var numberOfTimesToCopy = 257 - runLength;
+
+                    var byteToCopy = input[i + 1];
+
+                    for (int j = 0; j < numberOfTimesToCopy; j++)
+                    {
+                        output.Write(byteToCopy);
+                    }
+
+                    // Move to the single byte after the byte to copy.
+                    i += 2;
+                }
             }
+
+            return output.WrittenSpan.ToArray();
         }
     }
 }

--- a/src/UglyToad.PdfPig/Graphics/BaseStreamProcessor.cs
+++ b/src/UglyToad.PdfPig/Graphics/BaseStreamProcessor.cs
@@ -392,7 +392,7 @@
                         bytes = ((StringToken)token).GetBytes();
                     }
 
-                    ShowText(new ByteArrayInputBytes(bytes));
+                    ShowText(new MemoryInputBytes(bytes));
                 }
             }
         }
@@ -568,7 +568,7 @@
             var contentStream = formStream.Decode(FilterProvider, PdfScanner);
 
             var operations = PageContentParser.Parse(PageNumber,
-                new ByteArrayInputBytes(contentStream),
+                new MemoryInputBytes(contentStream),
                 ParsingOptions.Logger);
 
             // 3. We don't respect clipping currently.
@@ -616,8 +616,7 @@
                    && operations.OfType<InvokeNamedXObject>()?.Any(o => o.Name == xObjectName) ==
                    true // operations contain another form with same name
                    && ResourceStore.TryGetXObject(xObjectName, out var result)
-                   && result.Data.SequenceEqual(formStream
-                       .Data); // The form contained in the operations has identical data to current form
+                   && result.Data.Span.SequenceEqual(formStream.Data.Span); // The form contained in the operations has identical data to current form
         }
 
         /// <inheritdoc/>
@@ -776,7 +775,7 @@
         }
 
         /// <inheritdoc/>
-        public virtual void EndInlineImage(IReadOnlyList<byte> bytes)
+        public virtual void EndInlineImage(ReadOnlyMemory<byte> bytes)
         {
             if (InlineImageBuilder is null)
             {

--- a/src/UglyToad.PdfPig/Graphics/Colors/ColorSpaceDetails.cs
+++ b/src/UglyToad.PdfPig/Graphics/Colors/ColorSpaceDetails.cs
@@ -4,6 +4,7 @@
     using System.Collections.Concurrent;
     using System.Collections.Generic;
     using System.Linq;
+    using System.Runtime.InteropServices;
     using Tokens;
     using UglyToad.PdfPig.Content;
     using UglyToad.PdfPig.Functions;
@@ -572,7 +573,12 @@
                     transformed.Add(ConvertToByte(colors[c]));
                 }
             }
+
+#if NET8_0_OR_GREATER
+            return CollectionsMarshal.AsSpan(transformed);
+#else
             return transformed.ToArray();
+#endif
         }
 
         /// <inheritdoc/>
@@ -721,7 +727,7 @@
         internal override ReadOnlySpan<byte> Transform(ReadOnlySpan<byte> values)
         {
             var cache = new Dictionary<int, double[]>();
-            var transformed = new List<byte>();
+            var transformed = new List<byte>(values.Length * 3);
             for (var i = 0; i < values.Length; i += 3)
             {
                 byte b = values[i++];
@@ -737,7 +743,11 @@
                 }
             }
 
+#if NET8_0_OR_GREATER
+            return CollectionsMarshal.AsSpan(transformed);
+#else
             return transformed.ToArray();
+#endif
         }
 
         /// <inheritdoc/>

--- a/src/UglyToad.PdfPig/Graphics/Colors/PatternColor.cs
+++ b/src/UglyToad.PdfPig/Graphics/Colors/PatternColor.cs
@@ -122,14 +122,14 @@
         /// <summary>
         /// Content containing the painting operators needed to paint one instance of the cell.
         /// </summary>
-        public IReadOnlyList<byte> Data { get; }
+        public ReadOnlyMemory<byte> Data { get; }
 
         /// <summary>
         /// Create a new <see cref="TilingPatternColor"/>.
         /// </summary>
         public TilingPatternColor(TransformationMatrix matrix, DictionaryToken extGState, StreamToken patternStream,
             PatternPaintType paintType, PatternTilingType tilingType, PdfRectangle bbox, double xStep, double yStep,
-            DictionaryToken resources, IReadOnlyList<byte> data)
+            DictionaryToken resources, ReadOnlyMemory<byte> data)
             : base(PatternType.Tiling, patternStream.StreamDictionary, extGState, matrix)
         {
             PatternStream = patternStream;
@@ -165,7 +165,7 @@
                 XStep.Equals(other.XStep) &&
                 YStep.Equals(other.YStep) &&
                 Resources.Equals(other.Resources) &&
-                Data.SequenceEqual(other.Data);
+                Data.Span.SequenceEqual(other.Data.Span);
         }
 
         /// <inheritdoc />

--- a/src/UglyToad.PdfPig/Graphics/IOperationContext.cs
+++ b/src/UglyToad.PdfPig/Graphics/IOperationContext.cs
@@ -1,6 +1,7 @@
 ﻿namespace UglyToad.PdfPig.Graphics
 {
     using PdfPig.Core;
+    using System;
     using System.Collections.Generic;
     using Tokens;
     using UglyToad.PdfPig.Graphics.Core;
@@ -158,7 +159,7 @@
         /// <summary>
         /// Indicates that the current inline image is complete.
         /// </summary>
-        void EndInlineImage(IReadOnlyList<byte> bytes);
+        void EndInlineImage(ReadOnlyMemory<byte> bytes);
 
         /// <summary>
         /// Modify the clipping rule of the current path.

--- a/src/UglyToad.PdfPig/Graphics/InlineImageBuilder.cs
+++ b/src/UglyToad.PdfPig/Graphics/InlineImageBuilder.cs
@@ -23,7 +23,7 @@
         /// <summary>
         /// Inline image bytes.
         /// </summary>
-        public IReadOnlyList<byte>? Bytes { get; internal set; }
+        public ReadOnlyMemory<byte> Bytes { get; internal set; }
 
         internal InlineImage CreateInlineImage(TransformationMatrix transformationMatrix,
             ILookupFilterProvider filterProvider,
@@ -31,7 +31,7 @@
             RenderingIntent defaultRenderingIntent,
             IResourceStore resourceStore)
         {
-            if (Properties is null || Bytes is null)
+            if (Properties is null)
             {
                 throw new InvalidOperationException($"Inline image builder not completely defined before calling {nameof(CreateInlineImage)}.");
             }

--- a/src/UglyToad.PdfPig/Graphics/Operations/InlineImages/EndInlineImage.cs
+++ b/src/UglyToad.PdfPig/Graphics/Operations/InlineImages/EndInlineImage.cs
@@ -18,7 +18,7 @@
         /// <summary>
         /// The raw data for the inline image which should be interpreted according to the corresponding <see cref="BeginInlineImageData.Dictionary"/>.
         /// </summary>
-        public IReadOnlyList<byte> ImageData { get; }
+        public ReadOnlyMemory<byte> ImageData { get; }
         
         /// <inheritdoc />
         public string Operator => Symbol;
@@ -27,9 +27,18 @@
         /// Create a new <see cref="EndInlineImage"/> operation.
         /// </summary>
         /// <param name="imageData">The raw byte data of this image.</param>
-        public EndInlineImage(IReadOnlyList<byte> imageData)
+        public EndInlineImage(ReadOnlyMemory<byte> imageData)
         {
-            ImageData = imageData ?? throw new ArgumentNullException(nameof(imageData));
+            ImageData = imageData;
+        }
+
+        /// <summary>
+        /// Create a new <see cref="EndInlineImage"/> operation.
+        /// </summary>
+        /// <param name="imageData">The raw byte data of this image.</param>
+        public EndInlineImage(byte[] imageData)
+        {
+            ImageData = imageData;
         }
 
         /// <inheritdoc />

--- a/src/UglyToad.PdfPig/Graphics/Operations/OperationWriteHelper.cs
+++ b/src/UglyToad.PdfPig/Graphics/Operations/OperationWriteHelper.cs
@@ -1,9 +1,10 @@
 ﻿namespace UglyToad.PdfPig.Graphics.Operations
 {
+    using PdfPig.Core;
     using System;
     using System.Globalization;
     using System.IO;
-    using PdfPig.Core;
+    using UglyToad.PdfPig.Util;
 
     internal static class OperationWriteHelper
     {
@@ -20,9 +21,10 @@
             }
         }
 
-        public static void WriteHex(this Stream stream, byte[] bytes)
+        public static void WriteHex(this Stream stream, ReadOnlySpan<byte> bytes)
         {
-            var text = BitConverter.ToString(bytes).Replace("-", string.Empty);
+            var text = Hex.GetString(bytes);
+
             stream.WriteText($"<{text}>");
         }
 

--- a/src/UglyToad.PdfPig/Graphics/Operations/TextShowing/ShowText.cs
+++ b/src/UglyToad.PdfPig/Graphics/Operations/TextShowing/ShowText.cs
@@ -59,7 +59,7 @@
         /// <inheritdoc />
         public void Run(IOperationContext operationContext)
         {
-            var input = new ByteArrayInputBytes(Text != null ? OtherEncodings.StringAsLatin1Bytes(Text) : Bytes);
+            var input = new MemoryInputBytes(Text != null ? OtherEncodings.StringAsLatin1Bytes(Text) : Bytes);
 
             operationContext.ShowText(input);
         }

--- a/src/UglyToad.PdfPig/IO/StreamWrapper.cs
+++ b/src/UglyToad.PdfPig/IO/StreamWrapper.cs
@@ -1,5 +1,6 @@
 ﻿namespace UglyToad.PdfPig.IO
 {
+    using System;
     using System.IO;
 
     internal class StreamWrapper : Stream
@@ -35,6 +36,13 @@
         {
             Stream.Write(buffer, offset, count);
         }
+
+#if NET6_0_OR_GREATER
+        public override void Write(ReadOnlySpan<byte> buffer)
+        {
+            Stream.Write(buffer);
+        }
+#endif
 
         public override bool CanRead => Stream.CanRead;
 

--- a/src/UglyToad.PdfPig/IO/StreamWrapper.cs
+++ b/src/UglyToad.PdfPig/IO/StreamWrapper.cs
@@ -27,6 +27,13 @@
             Stream.SetLength(value);
         }
 
+#if NET6_0_OR_GREATER
+        public override int Read(Span<byte> buffer)
+        {
+            return Stream.Read(buffer);
+        }
+#endif
+
         public override int Read(byte[] buffer, int offset, int count)
         {
             return Stream.Read(buffer, offset, count);

--- a/src/UglyToad.PdfPig/Images/ColorSpaceDetailsByteConverter.cs
+++ b/src/UglyToad.PdfPig/Images/ColorSpaceDetailsByteConverter.cs
@@ -11,7 +11,7 @@
     public static class ColorSpaceDetailsByteConverter
     {
         /// <summary>
-        /// Converts the output bytes (if available) of <see cref="IPdfImage.TryGetMemory"/>
+        /// Converts the output bytes (if available) of <see cref="IPdfImage.TryGetBytesAsMemory"/>
         /// to actual pixel values using the <see cref="IPdfImage.ColorSpaceDetails"/>. For most images this doesn't
         /// change the data but for <see cref="ColorSpace.Indexed"/> it will convert the bytes which are indexes into the
         /// real pixel data into the real pixel data.

--- a/src/UglyToad.PdfPig/Images/Png/Crc32.cs
+++ b/src/UglyToad.PdfPig/Images/Png/Crc32.cs
@@ -67,7 +67,7 @@
         /// <summary>
         /// Calculate the combined CRC32 for data.
         /// </summary>
-        public static uint Calculate(byte[] data, byte[] data2)
+        public static uint Calculate(ReadOnlySpan<byte> data, ReadOnlySpan<byte> data2)
         {
             var crc32 = uint.MaxValue;
             for (var i = 0; i < data.Length; i++)

--- a/src/UglyToad.PdfPig/Images/Png/Crc32.cs
+++ b/src/UglyToad.PdfPig/Images/Png/Crc32.cs
@@ -1,12 +1,11 @@
 ﻿namespace UglyToad.PdfPig.Images.Png
 {
     using System;
-    using System.Collections.Generic;
 
     /// <summary>
     /// 32-bit Cyclic Redundancy Code used by the PNG for checking the data is intact.
     /// </summary>
-    internal static class Crc32
+    internal class Crc32
     {
         private const uint Polynomial = 0xEDB88320;
 
@@ -50,21 +49,6 @@
         }
 
         /// <summary>
-        /// Calculate the CRC32 for data.
-        /// </summary>
-        public static uint Calculate(List<byte> data)
-        {
-            var crc32 = uint.MaxValue;
-            for (var i = 0; i < data.Count; i++)
-            {
-                var index = (crc32 ^ data[i]) & 0xFF;
-                crc32 = (crc32 >> 8) ^ Lookup[index];
-            }
-
-            return crc32 ^ uint.MaxValue;
-        }
-
-        /// <summary>
         /// Calculate the combined CRC32 for data.
         /// </summary>
         public static uint Calculate(ReadOnlySpan<byte> data, ReadOnlySpan<byte> data2)
@@ -83,6 +67,31 @@
             }
 
             return crc32 ^ uint.MaxValue;
+        }
+
+
+        private uint state = uint.MaxValue;
+
+        /// <summary>
+        /// Calculate the CRC32 for data.
+        /// </summary>
+        public void Append(ReadOnlySpan<byte> data)
+        {
+            for (var i = 0; i < data.Length; i++)
+            {
+                var index = (state ^ data[i]) & 0xFF;
+                state = (state >> 8) ^ Lookup[index];
+            }
+        }
+
+        public uint GetCurrentHashAsUInt32()
+        {
+            return state ^ uint.MaxValue;
+        }
+
+        public void Reset()
+        {
+            state = uint.MaxValue;
         }
     }
 }

--- a/src/UglyToad.PdfPig/Images/Png/HeaderValidationResult.cs
+++ b/src/UglyToad.PdfPig/Images/Png/HeaderValidationResult.cs
@@ -1,8 +1,10 @@
 ﻿namespace UglyToad.PdfPig.Images.Png
 {
+    using System;
+
     internal readonly struct HeaderValidationResult
     {
-        public static readonly byte[] ExpectedHeader = {
+        public static ReadOnlySpan<byte> ExpectedHeader => [
             137,
             80,
             78,
@@ -11,7 +13,7 @@
             10,
             26,
             10
-        };
+        ];
 
         public int Byte1 { get; }
 

--- a/src/UglyToad.PdfPig/Images/Png/ImageHeader.cs
+++ b/src/UglyToad.PdfPig/Images/Png/ImageHeader.cs
@@ -8,17 +8,15 @@
     /// </summary>
     internal readonly struct ImageHeader
     {
-        internal static ReadOnlySpan<byte> HeaderBytes => [
-            73, 72, 68, 82
-        ];
+        internal static ReadOnlySpan<byte> HeaderBytes => [73, 72, 68, 82];
 
         private static readonly IReadOnlyDictionary<ColorType, HashSet<byte>> PermittedBitDepths = new Dictionary<ColorType, HashSet<byte>>
         {
-            {ColorType.None, new HashSet<byte> {1, 2, 4, 8, 16}},
-            {ColorType.ColorUsed, new HashSet<byte> {8, 16}},
-            {ColorType.PaletteUsed | ColorType.ColorUsed, new HashSet<byte> {1, 2, 4, 8}},
-            {ColorType.AlphaChannelUsed, new HashSet<byte> {8, 16}},
-            {ColorType.AlphaChannelUsed | ColorType.ColorUsed, new HashSet<byte> {8, 16}},
+            {ColorType.None, [1, 2, 4, 8, 16]},
+            {ColorType.ColorUsed, [8, 16]},
+            {ColorType.PaletteUsed | ColorType.ColorUsed, [1, 2, 4, 8]},
+            {ColorType.AlphaChannelUsed, [8, 16]},
+            {ColorType.AlphaChannelUsed | ColorType.ColorUsed, [8, 16]},
         };
 
         /// <summary>

--- a/src/UglyToad.PdfPig/Images/Png/ImageHeader.cs
+++ b/src/UglyToad.PdfPig/Images/Png/ImageHeader.cs
@@ -8,9 +8,9 @@
     /// </summary>
     internal readonly struct ImageHeader
     {
-        internal static readonly byte[] HeaderBytes = {
+        internal static ReadOnlySpan<byte> HeaderBytes => [
             73, 72, 68, 82
-        };
+        ];
 
         private static readonly IReadOnlyDictionary<ColorType, HashSet<byte>> PermittedBitDepths = new Dictionary<ColorType, HashSet<byte>>
         {

--- a/src/UglyToad.PdfPig/Images/Png/Palette.cs
+++ b/src/UglyToad.PdfPig/Images/Png/Palette.cs
@@ -27,7 +27,7 @@
         /// <summary>
         /// Adds transparency values from tRNS chunk.
         /// </summary>
-        public void SetAlphaValues(byte[] bytes)
+        public void SetAlphaValues(ReadOnlySpan<byte> bytes)
         {
             HasAlphaValues = true;
 

--- a/src/UglyToad.PdfPig/Images/Png/PngBuilder.cs
+++ b/src/UglyToad.PdfPig/Images/Png/PngBuilder.cs
@@ -80,7 +80,7 @@
         /// </summary>
         public void Save(Stream outputStream)
         {
-            outputStream.Write(HeaderValidationResult.ExpectedHeader, 0, HeaderValidationResult.ExpectedHeader.Length);
+            outputStream.Write(HeaderValidationResult.ExpectedHeader);
 
             var stream = new PngStreamWriteHelper(outputStream);
 
@@ -106,12 +106,12 @@
 
             var imageData = Compress(rawData);
             stream.WriteChunkLength(imageData.Length);
-            stream.WriteChunkHeader("IDAT"u8.ToArray());
-            stream.Write(imageData, 0, imageData.Length);
+            stream.WriteChunkHeader("IDAT"u8);
+            stream.Write(imageData);
             stream.WriteCrc();
 
             stream.WriteChunkLength(0);
-            stream.WriteChunkHeader("IEND"u8.ToArray());
+            stream.WriteChunkHeader("IEND"u8);
             stream.WriteCrc();
         }
 

--- a/src/UglyToad.PdfPig/Images/Png/PngFromPdfImageFactory.cs
+++ b/src/UglyToad.PdfPig/Images/Png/PngFromPdfImageFactory.cs
@@ -15,10 +15,12 @@
 
             var isColorSpaceSupported = hasValidDetails && image.ColorSpaceDetails!.BaseType != ColorSpace.Pattern;
 
-            if (!isColorSpaceSupported || !image.TryGetBytes(out var bytesPure))
+            if (!isColorSpaceSupported || !image.TryGetMemory(out var imageMemory))
             {
                 return false;
             }
+
+            var bytesPure = imageMemory.Span;
 
             try
             {
@@ -33,8 +35,8 @@
 
                 var requiredSize = (image.WidthInSamples * image.HeightInSamples * numberOfComponents);
 
-                var actualSize = bytesPure.Count;
-                var isCorrectlySized = bytesPure.Count == requiredSize ||
+                var actualSize = bytesPure.Length;
+                var isCorrectlySized = bytesPure.Length == requiredSize ||
                     // Spec, p. 37: "...error if the stream contains too much data, with the exception that
                     // there may be an extra end-of-line marker..."
                     (actualSize == requiredSize + 1 && bytesPure[actualSize - 1] == ReadHelper.AsciiLineFeed) ||
@@ -43,11 +45,6 @@
                     (actualSize == requiredSize + 2 &&
                         bytesPure[actualSize - 2] == ReadHelper.AsciiCarriageReturn &&
                         bytesPure[actualSize - 1] == ReadHelper.AsciiLineFeed);
-
-                if (!isCorrectlySized)
-                {
-                    return false;
-                }
 
                 if (image.ColorSpaceDetails.BaseType == ColorSpace.DeviceCMYK || numberOfComponents == 4)
                 {

--- a/src/UglyToad.PdfPig/Images/Png/PngFromPdfImageFactory.cs
+++ b/src/UglyToad.PdfPig/Images/Png/PngFromPdfImageFactory.cs
@@ -15,7 +15,7 @@
 
             var isColorSpaceSupported = hasValidDetails && image.ColorSpaceDetails!.BaseType != ColorSpace.Pattern;
 
-            if (!isColorSpaceSupported || !image.TryGetMemory(out var imageMemory))
+            if (!isColorSpaceSupported || !image.TryGetBytesAsMemory(out var imageMemory))
             {
                 return false;
             }

--- a/src/UglyToad.PdfPig/Images/Png/PngStreamWriteHelper.cs
+++ b/src/UglyToad.PdfPig/Images/Png/PngStreamWriteHelper.cs
@@ -31,10 +31,10 @@
 
         public override void Flush() => inner.Flush();
 
-        public void WriteChunkHeader(byte[] header)
+        public void WriteChunkHeader(ReadOnlySpan<byte> header)
         {
             written.Clear();
-            Write(header, 0, header.Length);
+            Write(header);
         }
 
         public void WriteChunkLength(int length)
@@ -53,6 +53,20 @@
             written.AddRange(buffer.Skip(offset).Take(count));
             inner.Write(buffer, offset, count);
         }
+
+#if NET8_0_OR_GREATER
+        public override void Write(ReadOnlySpan<byte> buffer)
+        {
+            written.AddRange(buffer);
+            inner.Write(buffer);
+        }
+#else
+        public void Write(ReadOnlySpan<byte> buffer)
+        {
+            written.AddRange(buffer.ToArray());
+            inner.Write(buffer);
+        }
+#endif
 
         public void WriteCrc()
         {

--- a/src/UglyToad.PdfPig/Images/Png/PngStreamWriteHelper.cs
+++ b/src/UglyToad.PdfPig/Images/Png/PngStreamWriteHelper.cs
@@ -53,7 +53,7 @@
             inner.Write(buffer, offset, count);
         }
 
-#if NET8_0_OR_GREATER
+#if NET6_0_OR_GREATER
         public override void Write(ReadOnlySpan<byte> buffer)
         {
             crc.Append(buffer);

--- a/src/UglyToad.PdfPig/Images/Png/StreamHelper.cs
+++ b/src/UglyToad.PdfPig/Images/Png/StreamHelper.cs
@@ -1,34 +1,18 @@
 ﻿namespace UglyToad.PdfPig.Images.Png
 {
     using System;
+    using System.Buffers.Binary;
     using System.IO;
 
     internal static class StreamHelper
     {
-        public static int ReadBigEndianInt32(Stream stream)
-        {
-            return (ReadOrTerminate(stream) << 24) + (ReadOrTerminate(stream) << 16)
-                                                   + (ReadOrTerminate(stream) << 8) + ReadOrTerminate(stream);
-        }
-
         public static void WriteBigEndianInt32(Stream stream, int value)
         {
-            stream.WriteByte((byte)(value >> 24));
-            stream.WriteByte((byte)(value >> 16));
-            stream.WriteByte((byte)(value >> 8));
-            stream.WriteByte((byte)value);
-        }
+            Span<byte> buffer = stackalloc byte[4];
 
-        private static byte ReadOrTerminate(Stream stream)
-        {
-            var b = stream.ReadByte();
+            BinaryPrimitives.WriteInt32BigEndian(buffer, value);
 
-            if (b == -1)
-            {
-                throw new InvalidOperationException($"Unexpected end of stream at {stream.Position}.");
-            }
-
-            return (byte) b;
+            stream.Write(buffer);
         }
 
         public static bool TryReadHeaderBytes(Stream stream, out byte[] bytes)

--- a/src/UglyToad.PdfPig/Parser/FileStructure/CrossReferenceParser.cs
+++ b/src/UglyToad.PdfPig/Parser/FileStructure/CrossReferenceParser.cs
@@ -312,7 +312,7 @@
 
             bytes.Seek(lastOffset);
 
-            var buffer = new byte[5];
+            Span<byte> buffer = stackalloc byte[5];
 
             while (bytes.Read(buffer) == buffer.Length)
             {
@@ -347,9 +347,8 @@
 
                 bytes.Seek(lastOffset);
             }
+
             bytes.Read(buffer);
-
-
 
             return false;
         }

--- a/src/UglyToad.PdfPig/Parser/FileStructure/FileHeaderParser.cs
+++ b/src/UglyToad.PdfPig/Parser/FileStructure/FileHeaderParser.cs
@@ -103,13 +103,13 @@
 
             // Slide a window of bufferLength bytes across the file allowing for the fact the version could get split by
             // the window (so always ensure an overlap of versionLength bytes between the end of the previous and start of the next buffer).
-            var buffer = new byte[bufferLength];
+            Span<byte> buffer = stackalloc byte[bufferLength];
 
             var currentOffset = startPosition;
             int readLength;
             do
             {
-                readLength = inputBytes.Read(buffer, bufferLength);
+                readLength = inputBytes.Read(buffer);
 
                 var content = OtherEncodings.BytesAsLatin1String(buffer);
 

--- a/src/UglyToad.PdfPig/Parser/PageContentParser.cs
+++ b/src/UglyToad.PdfPig/Parser/PageContentParser.cs
@@ -101,7 +101,7 @@
 
                             // Replace the last end image operator with one containing the full set of data.
                             graphicsStateOperations.Remove(lastEndImage);
-                            graphicsStateOperations.Add(new EndInlineImage([.. lastEndImage.ImageData, .. missingData]));
+                            graphicsStateOperations.Add(new EndInlineImage([.. lastEndImage.ImageData.Span, .. missingData.AsSpan()]));
                         }
 
                         lastEndImageOffset = actualEndImageOffset;
@@ -143,7 +143,7 @@
 
                                 var nextByteSet = scanner.RecoverFromIncorrectEndImage(lastEndImageOffset.Value);
                                 graphicsStateOperations.RemoveRange(index, graphicsStateOperations.Count - index);
-                                var newEndInlineImage = new EndInlineImage([.. prevEndInlineImage.ImageData, .. nextByteSet]);
+                                var newEndInlineImage = new EndInlineImage([.. prevEndInlineImage.ImageData.Span, .. nextByteSet]);
                                 graphicsStateOperations.Add(newEndInlineImage);
                                 lastEndImageOffset = scanner.CurrentPosition - 3;
                             }

--- a/src/UglyToad.PdfPig/Parser/Parts/CrossReference/CrossReferenceStreamParser.cs
+++ b/src/UglyToad.PdfPig/Parser/Parts/CrossReference/CrossReferenceStreamParser.cs
@@ -21,11 +21,11 @@
         /// </summary>
         public CrossReferenceTablePart Parse(long streamOffset, long? fromTableAtOffset, StreamToken stream)
         {
-            var decoded = stream.Decode(filterProvider);
+            var decoded = stream.Decode(filterProvider).Span;
 
             var fieldSizes = new CrossReferenceStreamFieldSize(stream.StreamDictionary);
 
-            var lineCount = decoded.Count / fieldSizes.LineLength;
+            var lineCount = decoded.Length / fieldSizes.LineLength;
             
             long previousOffset = -1;
             if (stream.StreamDictionary.TryGet(NameToken.Prev, out var prevToken) && prevToken is NumericToken prevNumeric)

--- a/src/UglyToad.PdfPig/Parser/PdfDocumentFactory.cs
+++ b/src/UglyToad.PdfPig/Parser/PdfDocumentFactory.cs
@@ -28,7 +28,7 @@
     {
         public static PdfDocument Open(byte[] fileBytes, ParsingOptions? options = null)
         {
-            var inputBytes = new ByteArrayInputBytes(fileBytes);
+            var inputBytes = new MemoryInputBytes(fileBytes);
 
             return Open(inputBytes, options);
         }

--- a/src/UglyToad.PdfPig/PdfExtensions.cs
+++ b/src/UglyToad.PdfPig/PdfExtensions.cs
@@ -63,7 +63,7 @@
             var transform = stream.Data;
             for (var i = 0; i < filters.Count; i++)
             {
-                transform = filters[i].Decode(transform, stream.StreamDictionary, i);
+                transform = filters[i].Decode(transform.Span, stream.StreamDictionary, i);
             }
 
             return transform;
@@ -79,7 +79,7 @@
             var transform = stream.Data;
             for (var i = 0; i < filters.Count; i++)
             {
-                transform = filters[i].Decode(transform, stream.StreamDictionary, i);
+                transform = filters[i].Decode(transform.Span, stream.StreamDictionary, i);
             }
 
             return transform;

--- a/src/UglyToad.PdfPig/PdfExtensions.cs
+++ b/src/UglyToad.PdfPig/PdfExtensions.cs
@@ -1,5 +1,6 @@
 ﻿namespace UglyToad.PdfPig
 {
+    using System;
     using System.Collections.Generic;
     using System.Diagnostics.CodeAnalysis;
     using Core;
@@ -55,7 +56,7 @@
         /// <summary>
         /// Get the decoded data from this stream.
         /// </summary>
-        public static IReadOnlyList<byte> Decode(this StreamToken stream, IFilterProvider filterProvider)
+        public static ReadOnlyMemory<byte> Decode(this StreamToken stream, IFilterProvider filterProvider)
         {
             var filters = filterProvider.GetFilters(stream.StreamDictionary);
 
@@ -71,7 +72,7 @@
         /// <summary>
         /// Get the decoded data from this stream.
         /// </summary>
-        public static IReadOnlyList<byte> Decode(this StreamToken stream, ILookupFilterProvider filterProvider, IPdfTokenScanner scanner)
+        public static ReadOnlyMemory<byte> Decode(this StreamToken stream, ILookupFilterProvider filterProvider, IPdfTokenScanner scanner)
         {
             var filters = filterProvider.GetFilters(stream.StreamDictionary, scanner);
 

--- a/src/UglyToad.PdfPig/PdfFonts/CidFonts/CharacterIdentifierToGlyphIndexMap.cs
+++ b/src/UglyToad.PdfPig/PdfFonts/CidFonts/CharacterIdentifierToGlyphIndexMap.cs
@@ -1,6 +1,6 @@
 ﻿namespace UglyToad.PdfPig.PdfFonts.CidFonts
 {
-    using System.Collections.Generic;
+    using System;
 
     /// <summary>
     /// Specifies mapping from character identifiers to glyph indices.
@@ -17,9 +17,9 @@
             map = null;
         }
 
-        public CharacterIdentifierToGlyphIndexMap(IReadOnlyList<byte> streamBytes)
+        public CharacterIdentifierToGlyphIndexMap(ReadOnlySpan<byte> streamBytes)
         {
-            var numberOfEntries = streamBytes.Count / 2;
+            var numberOfEntries = streamBytes.Length / 2;
 
             map = new int[numberOfEntries];
             var offset = 0;

--- a/src/UglyToad.PdfPig/PdfFonts/Cmap/CMap.cs
+++ b/src/UglyToad.PdfPig/PdfFonts/Cmap/CMap.cs
@@ -176,7 +176,7 @@
                 {
                     if (range.IsFullMatch(result, byteCount))
                     {
-                        return ByteArrayToInt(result, byteCount);
+                        return ByteArrayToInt(result.AsSpan(0, byteCount));
                     }
                 }
                 if (byteCount < maxCodeLength)
@@ -198,10 +198,10 @@
             return bytes.CurrentByte;
         }
 
-        private static int ByteArrayToInt(byte[] data, int dataLen)
+        private static int ByteArrayToInt(ReadOnlySpan<byte> data)
         {
             int code = 0;
-            for (int i = 0; i < dataLen; ++i)
+            for (int i = 0; i < data.Length; ++i)
             {
                 code <<= 8;
                 code |= (data[i] & 0xFF);

--- a/src/UglyToad.PdfPig/PdfFonts/Parser/CMapParser.cs
+++ b/src/UglyToad.PdfPig/PdfFonts/Parser/CMapParser.cs
@@ -155,7 +155,7 @@
                 }
             }
 
-            result = Parse(new ByteArrayInputBytes(bytes));
+            result = Parse(new MemoryInputBytes(bytes));
 
             return true;
         }

--- a/src/UglyToad.PdfPig/PdfFonts/Parser/Handlers/TrueTypeFontHandler.cs
+++ b/src/UglyToad.PdfPig/PdfFonts/Parser/Handlers/TrueTypeFontHandler.cs
@@ -115,11 +115,9 @@
                 {
                     var toUnicode = DirectObjectFinder.Get<StreamToken>(toUnicodeObj, pdfScanner);
 
-                    var decodedUnicodeCMap = toUnicode.Decode(filterProvider, pdfScanner);
-
-                    if (decodedUnicodeCMap != null)
+                    if (toUnicode.Decode(filterProvider, pdfScanner) is ReadOnlyMemory<byte> decodedUnicodeCMap)
                     {
-                        toUnicodeCMap = CMapCache.Parse(new ByteArrayInputBytes(decodedUnicodeCMap));
+                        toUnicodeCMap = CMapCache.Parse(new MemoryInputBytes(decodedUnicodeCMap));
                     }
                 }
                 catch (Exception ex)
@@ -211,7 +209,7 @@
                     }
                 }
 
-                var font = TrueTypeFontParser.Parse(new TrueTypeDataBytes(new ByteArrayInputBytes(fontFile)));
+                var font = TrueTypeFontParser.Parse(new TrueTypeDataBytes(new MemoryInputBytes(fontFile)));
 
                 return font;
             }

--- a/src/UglyToad.PdfPig/PdfFonts/Parser/Handlers/Type0FontHandler.cs
+++ b/src/UglyToad.PdfPig/PdfFonts/Parser/Handlers/Type0FontHandler.cs
@@ -73,11 +73,9 @@
 
                 if (DirectObjectFinder.TryGet<StreamToken>(toUnicodeValue, scanner, out var toUnicodeStream))
                 {
-                    var decodedUnicodeCMap = toUnicodeStream?.Decode(filterProvider, scanner);
-
-                    if (decodedUnicodeCMap != null)
+                    if (toUnicodeStream?.Decode(filterProvider, scanner) is ReadOnlyMemory<byte> decodedUnicodeCMap)
                     {
-                        toUnicodeCMap = CMapCache.Parse(new ByteArrayInputBytes(decodedUnicodeCMap));
+                        toUnicodeCMap = CMapCache.Parse(new MemoryInputBytes(decodedUnicodeCMap));
                     }
                 }
                 else if (DirectObjectFinder.TryGet<NameToken>(toUnicodeValue, scanner, out var toUnicodeName)
@@ -165,7 +163,7 @@
             {
                 var decoded = stream.Decode(filterProvider, scanner);
 
-                var cmap = CMapCache.Parse(new ByteArrayInputBytes(decoded));
+                var cmap = CMapCache.Parse(new MemoryInputBytes(decoded));
 
                 result = cmap ?? throw new InvalidOperationException($"Could not read CMap from stream in the dictionary: {dictionary}");
             }

--- a/src/UglyToad.PdfPig/PdfFonts/Parser/Handlers/Type1FontHandler.cs
+++ b/src/UglyToad.PdfPig/PdfFonts/Parser/Handlers/Type1FontHandler.cs
@@ -11,6 +11,7 @@
     using Fonts.Type1.Parser;
     using PdfPig.Parser.Parts;
     using Simple;
+    using System;
     using Tokenization.Scanner;
     using Tokens;
 
@@ -92,11 +93,9 @@
             {
                 var toUnicode = DirectObjectFinder.Get<StreamToken>(toUnicodeObj, pdfScanner);
 
-                var decodedUnicodeCMap = toUnicode?.Decode(filterProvider, pdfScanner);
-
-                if (decodedUnicodeCMap != null)
+                if (toUnicode?.Decode(filterProvider, pdfScanner) is ReadOnlyMemory<byte> decodedUnicodeCMap)
                 {
-                    toUnicodeCMap = CMapCache.Parse(new ByteArrayInputBytes(decodedUnicodeCMap));
+                    toUnicodeCMap = CMapCache.Parse(new MemoryInputBytes(decodedUnicodeCMap));
                 }
             }
 
@@ -156,7 +155,7 @@
                 var length1 = stream.StreamDictionary.Get<NumericToken>(NameToken.Length1, pdfScanner);
                 var length2 = stream.StreamDictionary.Get<NumericToken>(NameToken.Length2, pdfScanner);
 
-                var font = Type1FontParser.Parse(new ByteArrayInputBytes(bytes), length1.Int, length2.Int);
+                var font = Type1FontParser.Parse(new MemoryInputBytes(bytes), length1.Int, length2.Int);
 
                 return Union<Type1Font, CompactFontFormatFontCollection>.One(font);
             }

--- a/src/UglyToad.PdfPig/PdfFonts/Parser/Handlers/Type3FontHandler.cs
+++ b/src/UglyToad.PdfPig/PdfFonts/Parser/Handlers/Type3FontHandler.cs
@@ -7,6 +7,7 @@
     using Fonts.Encodings;
     using PdfPig.Parser.Parts;
     using Simple;
+    using System;
     using Tokenization.Scanner;
     using Tokens;
     using Util;
@@ -48,11 +49,9 @@
             {
                 var toUnicode = DirectObjectFinder.Get<StreamToken>(toUnicodeObj, scanner);
 
-                var decodedUnicodeCMap = toUnicode?.Decode(filterProvider, scanner);
-
-                if (decodedUnicodeCMap != null)
+                if (toUnicode?.Decode(filterProvider, scanner) is ReadOnlyMemory<byte> decodedUnicodeCMap)
                 {
-                    toUnicodeCMap = CMapCache.Parse(new ByteArrayInputBytes(decodedUnicodeCMap));
+                    toUnicodeCMap = CMapCache.Parse(new MemoryInputBytes(decodedUnicodeCMap));
                 }
             }
 

--- a/src/UglyToad.PdfPig/PdfFonts/Parser/Parts/CidFontFactory.cs
+++ b/src/UglyToad.PdfPig/PdfFonts/Parser/Parts/CidFontFactory.cs
@@ -109,7 +109,7 @@
             {
                 case DescriptorFontFile.FontFileType.TrueType:
                     {
-                        var input = new TrueTypeDataBytes(new ByteArrayInputBytes(fontFile));
+                        var input = new TrueTypeDataBytes(new MemoryInputBytes(fontFile));
                         var ttf = TrueTypeFontParser.Parse(input);
                         return new PdfCidTrueTypeFont(ttf);
                     }
@@ -136,7 +136,7 @@
                         if (subtypeName == NameToken.OpenType)
                         {
                             var bytes = str.Decode(filterProvider, pdfScanner);
-                            var ttf = TrueTypeFontParser.Parse(new TrueTypeDataBytes(new ByteArrayInputBytes(bytes)));
+                            var ttf = TrueTypeFontParser.Parse(new TrueTypeDataBytes(new MemoryInputBytes(bytes)));
                             return new PdfCidTrueTypeFont(ttf);
                         }
 
@@ -292,7 +292,7 @@
 
             var bytes = stream.Decode(filterProvider, pdfScanner);
 
-            return new CharacterIdentifierToGlyphIndexMap(bytes);
+            return new CharacterIdentifierToGlyphIndexMap(bytes.Span);
         }
 
         private string SafeKeyAccess(DictionaryToken dictionary, NameToken keyName)

--- a/src/UglyToad.PdfPig/Polyfills/StreamExtensions.cs
+++ b/src/UglyToad.PdfPig/Polyfills/StreamExtensions.cs
@@ -1,0 +1,26 @@
+﻿#if NETFRAMEWORK || NETSTANDARD2_0
+
+namespace System.IO;
+
+using System.Buffers;
+
+internal static class StreamExtensions
+{
+    public static void Write(this Stream stream, ReadOnlySpan<byte> data)
+    {
+        var buffer = ArrayPool<byte>.Shared.Rent(data.Length);
+
+        data.CopyTo(buffer);
+
+        try
+        {
+            stream.Write(buffer, 0, data.Length);
+        }
+        finally
+        {
+            ArrayPool<byte>.Shared.Return(buffer);
+        }
+    }
+}
+
+#endif

--- a/src/UglyToad.PdfPig/Tokenization/Scanner/PdfTokenScanner.cs
+++ b/src/UglyToad.PdfPig/Tokenization/Scanner/PdfTokenScanner.cs
@@ -821,7 +821,7 @@
             }
 
             // Read the N integers
-            var bytes = new ByteArrayInputBytes(stream.Decode(filterProvider, this));
+            var bytes = new MemoryInputBytes(stream.Decode(filterProvider, this));
 
             var scanner = new CoreTokenScanner(bytes, true, useLenientParsing: parsingOptions.UseLenientParsing);
 

--- a/src/UglyToad.PdfPig/Util/ColorSpaceDetailsParser.cs
+++ b/src/UglyToad.PdfPig/Util/ColorSpaceDetailsParser.cs
@@ -2,15 +2,14 @@
 {
     using System.Collections.Generic;
     using System.Diagnostics.CodeAnalysis;
+    using System.Linq;
     using Content;
     using Filters;
     using Graphics.Colors;
     using Parser.Parts;
-    using System.Linq;
     using Tokenization.Scanner;
     using Tokens;
     using UglyToad.PdfPig.Functions;
-    using System;
 
     internal static class ColorSpaceMapper
     {
@@ -56,7 +55,7 @@
                 var colorSpaceDetails = GetColorSpaceDetails(colorSpace, imageDictionary.Without(NameToken.Filter).Without(NameToken.F), scanner, resourceStore, filterProvider, true);
 
                 var decodeRaw = imageDictionary.GetObjectOrDefault(NameToken.Decode, NameToken.D) as ArrayToken ?? new ArrayToken([]);
-                var decode = decodeRaw.Data.OfType<NumericToken>().Select(x => x.Double).ToArray();
+                var decode = decodeRaw.Data.OfType<NumericToken>().Select(static x => x.Double).ToArray();
 
                 return IndexedColorSpaceDetails.Stencil(colorSpaceDetails, decode);
             }
@@ -195,14 +194,14 @@
                         var whitePoint = whitePointToken.Data.OfType<NumericToken>().Select(x => x.Double).ToArray();
 
                         // BlackPoint is optional
-                        IReadOnlyList<double>? blackPoint = null;
+                        double[]? blackPoint = null;
                         if (dictionaryToken.TryGet(NameToken.BlackPoint, scanner, out ArrayToken? blackPointToken))
                         {
                             blackPoint = blackPointToken.Data.OfType<NumericToken>().Select(x => x.Double).ToArray();
                         }
 
                         // Matrix is optional
-                        IReadOnlyList<double>? matrix = null;
+                        double[]? matrix = null;
                         if (dictionaryToken.TryGet(NameToken.Matrix, scanner, out ArrayToken? matrixToken))
                         {
                             matrix = matrixToken.Data.OfType<NumericToken>().Select(x => x.Double).ToArray();
@@ -245,7 +244,7 @@
                         }
 
                         // Range is optional
-                        IReadOnlyList<double>? range = null;
+                        double[]? range = null;
                         if (streamToken.StreamDictionary.TryGet(NameToken.Range, scanner, out ArrayToken? arrayToken))
                         {
                             range = arrayToken.Data.OfType<NumericToken>().Select(x => x.Double).ToArray();

--- a/src/UglyToad.PdfPig/Util/ColorSpaceDetailsParser.cs
+++ b/src/UglyToad.PdfPig/Util/ColorSpaceDetailsParser.cs
@@ -1,6 +1,5 @@
 ﻿namespace UglyToad.PdfPig.Util
 {
-    using System;
     using System.Collections.Generic;
     using System.Diagnostics.CodeAnalysis;
     using Content;
@@ -11,6 +10,7 @@
     using Tokenization.Scanner;
     using Tokens;
     using UglyToad.PdfPig.Functions;
+    using System;
 
     internal static class ColorSpaceMapper
     {
@@ -102,7 +102,7 @@
                         var whitePoint = whitePointToken.Data.OfType<NumericToken>().Select(x => x.Double).ToArray();
 
                         // BlackPoint is optional
-                        IReadOnlyList<double>? blackPoint = null;
+                        double[]? blackPoint = null;
                         if (dictionaryToken.TryGet(NameToken.BlackPoint, scanner, out ArrayToken? blackPointToken))
                         {
                             blackPoint = blackPointToken.Data.OfType<NumericToken>().Select(x => x.Double).ToArray();
@@ -145,24 +145,24 @@
                         var whitePoint = whitePointToken.Data.OfType<NumericToken>().Select(x => x.Double).ToArray();
 
                         // BlackPoint is optional
-                        IReadOnlyList<double>? blackPoint = null;
+                        double[]? blackPoint = null;
                         if (dictionaryToken.TryGet(NameToken.BlackPoint, scanner, out ArrayToken? blackPointToken))
                         {
-                            blackPoint = blackPointToken.Data.OfType<NumericToken>().Select(x => x.Double).ToArray();
+                            blackPoint = blackPointToken.Data.OfType<NumericToken>().Select(static x => x.Double).ToArray();
                         }
 
                         // Gamma is optional
-                        IReadOnlyList<double>? gamma = null;
+                        double[]? gamma = null;
                         if (dictionaryToken.TryGet(NameToken.Gamma, scanner, out ArrayToken? gammaToken))
                         {
-                            gamma = gammaToken.Data.OfType<NumericToken>().Select(x => x.Double).ToArray();
+                            gamma = gammaToken.Data.OfType<NumericToken>().Select(static x => x.Double).ToArray();
                         }
 
                         // Matrix is optional
-                        IReadOnlyList<double>? matrix = null;
+                        double[]? matrix = null;
                         if (dictionaryToken.TryGet(NameToken.Matrix, scanner, out ArrayToken? matrixToken))
                         {
-                            matrix = matrixToken.Data.OfType<NumericToken>().Select(x => x.Double).ToArray();
+                            matrix = matrixToken.Data.OfType<NumericToken>().Select(static x => x.Double).ToArray();
                         }
 
                         return new CalRGBColorSpaceDetails(whitePoint, blackPoint, gamma, matrix);
@@ -336,7 +336,7 @@
 
                         var fourth = colorSpaceArray[3];
 
-                        IReadOnlyList<byte> tableBytes;
+                        byte[] tableBytes;
 
                         if (DirectObjectFinder.TryGet(fourth, scanner, out HexToken? tableHexToken))
                         {
@@ -344,7 +344,7 @@
                         }
                         else if (DirectObjectFinder.TryGet(fourth, scanner, out StreamToken? tableStreamToken))
                         {
-                            tableBytes = tableStreamToken.Decode(filterProvider, scanner);
+                            tableBytes = tableStreamToken.Decode(filterProvider, scanner).Span.ToArray();
                         }
                         else if (DirectObjectFinder.TryGet(fourth, scanner, out StringToken? stringToken))
                         {

--- a/src/UglyToad.PdfPig/Util/PatternParser.cs
+++ b/src/UglyToad.PdfPig/Util/PatternParser.cs
@@ -20,7 +20,7 @@
             if (DirectObjectFinder.TryGet(pattern, scanner, out StreamToken? fs))
             {
                 patternDictionary = fs.StreamDictionary;
-                patternStream = new StreamToken(fs.StreamDictionary, fs.Decode(filterProvider, scanner).ToArray());
+                patternStream = new StreamToken(fs.StreamDictionary, fs.Decode(filterProvider, scanner));
             }
             else if (DirectObjectFinder.TryGet(pattern, scanner, out DictionaryToken? fd))
             {

--- a/src/UglyToad.PdfPig/Util/PatternParser.cs
+++ b/src/UglyToad.PdfPig/Util/PatternParser.cs
@@ -20,7 +20,7 @@
             if (DirectObjectFinder.TryGet(pattern, scanner, out StreamToken? fs))
             {
                 patternDictionary = fs.StreamDictionary;
-                patternStream = new StreamToken(fs.StreamDictionary, fs.Decode(filterProvider, scanner));
+                patternStream = new StreamToken(fs.StreamDictionary, fs.Decode(filterProvider, scanner).ToArray());
             }
             else if (DirectObjectFinder.TryGet(pattern, scanner, out DictionaryToken? fd))
             {

--- a/src/UglyToad.PdfPig/Util/PdfFunctionParser.cs
+++ b/src/UglyToad.PdfPig/Util/PdfFunctionParser.cs
@@ -20,7 +20,7 @@
             if (DirectObjectFinder.TryGet(function, scanner, out StreamToken? fs))
             {
                 functionDictionary = fs.StreamDictionary;
-                functionStream = new StreamToken(fs.StreamDictionary, fs.Decode(filterProvider, scanner).ToArray());
+                functionStream = new StreamToken(fs.StreamDictionary, fs.Decode(filterProvider, scanner));
             }
             else if (DirectObjectFinder.TryGet(function, scanner, out DictionaryToken? fd))
             {

--- a/src/UglyToad.PdfPig/Util/PdfFunctionParser.cs
+++ b/src/UglyToad.PdfPig/Util/PdfFunctionParser.cs
@@ -3,6 +3,7 @@
     using System;
     using System.Collections.Generic;
     using System.IO;
+    using System.Linq;
     using UglyToad.PdfPig.Filters;
     using UglyToad.PdfPig.Functions;
     using UglyToad.PdfPig.Parser.Parts;
@@ -19,7 +20,7 @@
             if (DirectObjectFinder.TryGet(function, scanner, out StreamToken? fs))
             {
                 functionDictionary = fs.StreamDictionary;
-                functionStream = new StreamToken(fs.StreamDictionary, fs.Decode(filterProvider, scanner));
+                functionStream = new StreamToken(fs.StreamDictionary, fs.Decode(filterProvider, scanner).ToArray());
             }
             else if (DirectObjectFinder.TryGet(function, scanner, out DictionaryToken? fd))
             {

--- a/src/UglyToad.PdfPig/Util/ShadingParser.cs
+++ b/src/UglyToad.PdfPig/Util/ShadingParser.cs
@@ -21,7 +21,7 @@
             if (shading is StreamToken fs)
             {
                 shadingDictionary = fs.StreamDictionary;
-                shadingStream = new StreamToken(fs.StreamDictionary, fs.Decode(filterProvider, scanner));
+                shadingStream = new StreamToken(fs.StreamDictionary, fs.Decode(filterProvider, scanner).ToArray());
             }
             else if (shading is DictionaryToken fd)
             {
@@ -125,7 +125,7 @@
             }
             else
             {
-                return new PdfFunction[] { PdfFunctionParser.Create(functionToken, scanner, filterProvider) };
+                return [PdfFunctionParser.Create(functionToken, scanner, filterProvider)];
             }
         }
 

--- a/src/UglyToad.PdfPig/Util/ShadingParser.cs
+++ b/src/UglyToad.PdfPig/Util/ShadingParser.cs
@@ -21,7 +21,7 @@
             if (shading is StreamToken fs)
             {
                 shadingDictionary = fs.StreamDictionary;
-                shadingStream = new StreamToken(fs.StreamDictionary, fs.Decode(filterProvider, scanner).ToArray());
+                shadingStream = new StreamToken(fs.StreamDictionary, fs.Decode(filterProvider, scanner));
             }
             else if (shading is DictionaryToken fd)
             {

--- a/src/UglyToad.PdfPig/Writer/Fonts/ToUnicodeCMapBuilder.cs
+++ b/src/UglyToad.PdfPig/Writer/Fonts/ToUnicodeCMapBuilder.cs
@@ -1,5 +1,6 @@
 ﻿namespace UglyToad.PdfPig.Writer.Fonts
 {
+    using System;
     using System.Collections.Generic;
     using System.IO;
     using Graphics.Operations;
@@ -83,8 +84,8 @@
                     var from = Hex.GetString([keyValuePair.Value]);
                     var to = Hex.GetString([high, low]);
 
-                    TokenWriter.WriteToken(new HexToken(from.ToCharArray()), memoryStream);
-                    TokenWriter.WriteToken(new HexToken(to.ToCharArray()), memoryStream);
+                    TokenWriter.WriteToken(new HexToken(from.AsSpan()), memoryStream);
+                    TokenWriter.WriteToken(new HexToken(to.AsSpan()), memoryStream);
 
                     memoryStream.WriteNewLine();
                 }

--- a/src/UglyToad.PdfPig/Writer/Fonts/TrueTypeWritingFont.cs
+++ b/src/UglyToad.PdfPig/Writer/Fonts/TrueTypeWritingFont.cs
@@ -14,7 +14,7 @@
     internal class TrueTypeWritingFont : IWritingFont
     {
         private readonly TrueTypeFont font;
-        private readonly IReadOnlyList<byte> fontFileBytes;
+        private readonly ReadOnlyMemory<byte> fontFileBytes;
 
         private readonly object mappingLock = new object();
         private readonly Dictionary<char, byte> characterMapping = new Dictionary<char, byte>();
@@ -24,7 +24,7 @@
 
         public string Name => font.Name;
 
-        public TrueTypeWritingFont(TrueTypeFont font, IReadOnlyList<byte> fontFileBytes)
+        public TrueTypeWritingFont(TrueTypeFont font, ReadOnlyMemory<byte> fontFileBytes)
         {
             this.font = font;
             this.fontFileBytes = fontFileBytes;

--- a/src/UglyToad.PdfPig/Writer/NoTextTokenWriter.cs
+++ b/src/UglyToad.PdfPig/Writer/NoTextTokenWriter.cs
@@ -43,11 +43,11 @@ namespace UglyToad.PdfPig.Writer
 
             WriteDictionary(outputStreamToken.StreamDictionary, outputStream);
             WriteLineBreak(outputStream);
-            outputStream.Write(StreamStart, 0, StreamStart.Length);
+            outputStream.Write(StreamStart);
             WriteLineBreak(outputStream);
-            outputStream.Write(outputStreamToken.Data.ToArray(), 0, outputStreamToken.Data.Count);
+            outputStream.Write(outputStreamToken.Data.Span);
             WriteLineBreak(outputStream);
-            outputStream.Write(StreamEnd, 0, StreamEnd.Length);
+            outputStream.Write(StreamEnd);
         }
 
         private static bool IsFormStream(StreamToken streamToken)
@@ -66,7 +66,7 @@ namespace UglyToad.PdfPig.Writer
         private bool TryGetStreamWithoutText(StreamToken streamToken, [NotNullWhen(true)] out StreamToken? outputStreamToken)
         {
             var filterProvider = new FilterProviderWithLookup(DefaultFilterProvider.Instance);
-            IReadOnlyList<byte> bytes;
+            ReadOnlyMemory<byte> bytes;
             try
             {
                 bytes = streamToken.Decode(filterProvider);
@@ -81,7 +81,7 @@ namespace UglyToad.PdfPig.Writer
             IReadOnlyList<IGraphicsStateOperation> operations;
             try
             {
-                operations = pageContentParser.Parse(Page, new ByteArrayInputBytes(bytes), new NoOpLog());
+                operations = pageContentParser.Parse(Page, new MemoryInputBytes(bytes), new NoOpLog());
             }
             catch (Exception)
             {

--- a/src/UglyToad.PdfPig/Writer/PdfDedupStreamWriter.cs
+++ b/src/UglyToad.PdfPig/Writer/PdfDedupStreamWriter.cs
@@ -73,20 +73,7 @@
         {
             public bool Equals(byte[] x, byte[] y)
             {
-                if (x.Length != y.Length)
-                {
-                    return false;
-                }
-
-                for (var i = 0; i < x.Length; i++)
-                {
-                    if (x[i] != y[i])
-                    {
-                        return false;
-                    }
-                }
-
-                return true;
+                return x.AsSpan().SequenceEqual(y.AsSpan());
             }
 
             public int GetHashCode(byte[] obj)

--- a/src/UglyToad.PdfPig/Writer/PdfPageBuilder.cs
+++ b/src/UglyToad.PdfPig/Writer/PdfPageBuilder.cs
@@ -706,25 +706,19 @@
                 placementRectangle = new PdfRectangle(0, 0, png.Width, png.Height);
             }
 
-            byte[] data;
-            var pixelBuffer = new byte[3];
-            using (var memoryStream = new MemoryStream())
+            var data = new byte[png.Width * png.Height * 3];
+            int pixelIndex = 0;
+          
+            for (var rowIndex = 0; rowIndex < png.Height; rowIndex++)
             {
-                for (var rowIndex = 0; rowIndex < png.Height; rowIndex++)
+                for (var colIndex = 0; colIndex < png.Width; colIndex++)
                 {
-                    for (var colIndex = 0; colIndex < png.Width; colIndex++)
-                    {
-                        var pixel = png.GetPixel(colIndex, rowIndex);
+                    var pixel = png.GetPixel(colIndex, rowIndex);
 
-                        pixelBuffer[0] = pixel.R;
-                        pixelBuffer[1] = pixel.G;
-                        pixelBuffer[2] = pixel.B;
-
-                        memoryStream.Write(pixelBuffer, 0, pixelBuffer.Length);
-                    }
+                    data[pixelIndex++] = pixel.R;
+                    data[pixelIndex++] = pixel.G;
+                    data[pixelIndex++] = pixel.B;
                 }
-
-                data = memoryStream.ToArray();
             }
 
             var widthToken = new NumericToken(png.Width);
@@ -795,12 +789,12 @@
 
             currentStream.Add(Push.Value);
             // This needs to be the placement rectangle.
-            currentStream.Add(new ModifyCurrentTransformationMatrix(new[]
-            {
+            currentStream.Add(new ModifyCurrentTransformationMatrix(
+            [
                 placementRectangle.Width, 0,
                 0, placementRectangle.Height,
                 placementRectangle.BottomLeft.X, placementRectangle.BottomLeft.Y
-            }));
+            ]));
             currentStream.Add(new InvokeNamedXObject(key));
             currentStream.Add(Pop.Value);
 

--- a/src/UglyToad.PdfPig/Writer/Xmp/XmpWriter.cs
+++ b/src/UglyToad.PdfPig/Writer/Xmp/XmpWriter.cs
@@ -52,28 +52,25 @@ namespace UglyToad.PdfPig.Writer.Xmp
 
             // Dublin Core Schema
             AddElementsForSchema(rdfDescriptionElement, DublinCorePrefix, DublinCoreNamespace, builder,
-                new List<SchemaMapper>
-                {
+                [
                     new SchemaMapper("format", b => "application/pdf"),
                     new SchemaMapper("creator", b => b.Author),
                     new SchemaMapper("description", b => b.Subject),
                     new SchemaMapper("title", b => b.Title)
-                });
+                ]);
 
             // XMP Basic Schema
             AddElementsForSchema(rdfDescriptionElement, XmpBasicPrefix, XmpBasicNamespace, builder,
-                new List<SchemaMapper>
-                {
+                [
                     new SchemaMapper("CreatorTool", b => b.Creator)
-                });
+                ]);
 
             // Adobe PDF Schema
             AddElementsForSchema(rdfDescriptionElement, AdobePdfPrefix, AdobePdfNamespace, builder,
-                new List<SchemaMapper>
-                {
+                [
                     new SchemaMapper("PDFVersion", b => version.ToString("F1", CultureInfo.InvariantCulture)),
                     new SchemaMapper("Producer", b => b.Producer)
-                });
+                ]);
 
             var pdfAIdContainer = GetVersionAndConformanceLevelIdentificationElement(rdf, emptyRdfAbout, standard);
 

--- a/src/UglyToad.PdfPig/XObjects/XObjectFactory.cs
+++ b/src/UglyToad.PdfPig/XObjects/XObjectFactory.cs
@@ -113,7 +113,7 @@
 
             var streamToken = new StreamToken(dictionary, xObject.Stream.Data);
 
-            var decodedBytes = supportsFilters ? new Lazy<IReadOnlyList<byte>>(() => streamToken.Decode(filterProvider, pdfScanner))
+            var decodedBytes = supportsFilters ? new Lazy<ReadOnlyMemory<byte>>(() => streamToken.Decode(filterProvider, pdfScanner))
                 : null;
 
             var decode = Array.Empty<double>();

--- a/src/UglyToad.PdfPig/XObjects/XObjectImage.cs
+++ b/src/UglyToad.PdfPig/XObjects/XObjectImage.cs
@@ -16,7 +16,7 @@
     /// </summary>
     public class XObjectImage : IPdfImage
     {
-        private readonly Lazy<IReadOnlyList<byte>>? bytesFactory;
+        private readonly Lazy<ReadOnlyMemory<byte>>? memoryFactory;
 
         /// <inheritdoc />
         public PdfRectangle Bounds { get; }
@@ -56,7 +56,7 @@
         public DictionaryToken ImageDictionary { get; }
 
         /// <inheritdoc />
-        public IReadOnlyList<byte> RawBytes { get; }
+        public ReadOnlyMemory<byte> RawMemory { get; }
 
         /// <inheritdoc />
         public ColorSpaceDetails? ColorSpaceDetails { get; }
@@ -74,8 +74,8 @@
             bool interpolate,
             IReadOnlyList<double> decode,
             DictionaryToken imageDictionary,
-            IReadOnlyList<byte> rawBytes,
-            Lazy<IReadOnlyList<byte>>? bytes,
+            ReadOnlyMemory<byte> rawMemory,
+            Lazy<ReadOnlyMemory<byte>>? bytes,
             ColorSpaceDetails? colorSpaceDetails)
         {
             Bounds = bounds;
@@ -88,21 +88,21 @@
             Interpolate = interpolate;
             Decode = decode;
             ImageDictionary = imageDictionary ?? throw new ArgumentNullException(nameof(imageDictionary));
-            RawBytes = rawBytes;
+            RawMemory = rawMemory;
             ColorSpaceDetails = colorSpaceDetails;
-            bytesFactory = bytes;
+            memoryFactory = bytes;
         }
 
         /// <inheritdoc />
-        public bool TryGetBytes([NotNullWhen(true)] out IReadOnlyList<byte>? bytes)
+        public bool TryGetMemory(out ReadOnlyMemory<byte> bytes)
         {
             bytes = null;
-            if (bytesFactory is null)
+            if (memoryFactory is null)
             {
                 return false;
             }
 
-            bytes = bytesFactory.Value;
+            bytes = memoryFactory.Value;
 
             return true;
         }

--- a/src/UglyToad.PdfPig/XObjects/XObjectImage.cs
+++ b/src/UglyToad.PdfPig/XObjects/XObjectImage.cs
@@ -59,6 +59,9 @@
         public ReadOnlyMemory<byte> RawMemory { get; }
 
         /// <inheritdoc />
+        public ReadOnlySpan<byte> RawBytes => RawMemory.Span;
+
+        /// <inheritdoc />
         public ColorSpaceDetails? ColorSpaceDetails { get; }
 
         /// <summary>

--- a/src/UglyToad.PdfPig/XObjects/XObjectImage.cs
+++ b/src/UglyToad.PdfPig/XObjects/XObjectImage.cs
@@ -97,7 +97,7 @@
         }
 
         /// <inheritdoc />
-        public bool TryGetMemory(out ReadOnlyMemory<byte> bytes)
+        public bool TryGetBytesAsMemory(out ReadOnlyMemory<byte> bytes)
         {
             bytes = null;
             if (memoryFactory is null)


### PR DESCRIPTION
This PR:

- Update the filters and their callers to utilize ReadOnly{Memory,Span}<byte>
- Polyfills Stream.Write(ReadOnlySpan<byte>)
- Updates various methods to accept ReadOnlySpan<byte>
- Eliminates various allocations
- Makes QuadPointsQuadrilateral a readonly struct
- Spanifies PngBuilder
- Spanifies InputBytes