### PR TITLE
Cleanup using statements

### DIFF
--- a/src/UglyToad.PdfPig/AcroForms/AcroForm.cs
+++ b/src/UglyToad.PdfPig/AcroForms/AcroForm.cs
@@ -1,7 +1,5 @@
 ﻿namespace UglyToad.PdfPig.AcroForms
 {
-    using System;
-    using System.Collections.Generic;
     using System.Linq;
     using Core;
     using Fields;

--- a/src/UglyToad.PdfPig/AcroForms/AcroFormExtensions.cs
+++ b/src/UglyToad.PdfPig/AcroForms/AcroFormExtensions.cs
@@ -1,8 +1,7 @@
 namespace UglyToad.PdfPig.AcroForms
 {
-    using System.Collections.Generic;
     using System.Linq;
-    using UglyToad.PdfPig.AcroForms.Fields;
+    using Fields;
 
     /// <summary>
     /// Extensions for AcroForm.

--- a/src/UglyToad.PdfPig/AcroForms/AcroFormFactory.cs
+++ b/src/UglyToad.PdfPig/AcroForms/AcroFormFactory.cs
@@ -1,14 +1,12 @@
 ﻿namespace UglyToad.PdfPig.AcroForms
 {
+    using System.Linq;
     using Content;
     using Core;
     using CrossReference;
     using Fields;
     using Filters;
     using Parser.Parts;
-    using System;
-    using System.Collections.Generic;
-    using System.Linq;
     using Tokenization.Scanner;
     using Tokens;
     using Util;

--- a/src/UglyToad.PdfPig/AcroForms/Fields/AcroButtonFieldFlags.cs
+++ b/src/UglyToad.PdfPig/AcroForms/Fields/AcroButtonFieldFlags.cs
@@ -1,7 +1,5 @@
 ﻿namespace UglyToad.PdfPig.AcroForms.Fields
 {
-    using System;
-
     /// <summary>
     /// Flags specifying various characteristics of a button type field in an <see cref="AcroFieldBase"/>.
     /// </summary>

--- a/src/UglyToad.PdfPig/AcroForms/Fields/AcroCheckboxesField.cs
+++ b/src/UglyToad.PdfPig/AcroForms/Fields/AcroCheckboxesField.cs
@@ -1,6 +1,5 @@
 ﻿namespace UglyToad.PdfPig.AcroForms.Fields
 {
-    using System.Collections.Generic;
     using Tokens;
 
     /// <inheritdoc />

--- a/src/UglyToad.PdfPig/AcroForms/Fields/AcroChoiceFieldFlags.cs
+++ b/src/UglyToad.PdfPig/AcroForms/Fields/AcroChoiceFieldFlags.cs
@@ -1,7 +1,5 @@
 ﻿namespace UglyToad.PdfPig.AcroForms.Fields
 {
-    using System;
-
     /// <summary>
     /// Flags specifying various characteristics of a choice type field in an <see cref="AcroFieldBase"/>.
     /// </summary>

--- a/src/UglyToad.PdfPig/AcroForms/Fields/AcroComboBoxField.cs
+++ b/src/UglyToad.PdfPig/AcroForms/Fields/AcroComboBoxField.cs
@@ -1,7 +1,5 @@
 ﻿namespace UglyToad.PdfPig.AcroForms.Fields
 {
-    using System;
-    using System.Collections.Generic;
     using Core;
     using Tokens;
 

--- a/src/UglyToad.PdfPig/AcroForms/Fields/AcroFieldBase.cs
+++ b/src/UglyToad.PdfPig/AcroForms/Fields/AcroFieldBase.cs
@@ -1,7 +1,6 @@
 ﻿namespace UglyToad.PdfPig.AcroForms.Fields
 {
     using Core;
-    using System;
     using Tokens;
 
     /// <summary>

--- a/src/UglyToad.PdfPig/AcroForms/Fields/AcroListBoxField.cs
+++ b/src/UglyToad.PdfPig/AcroForms/Fields/AcroListBoxField.cs
@@ -1,7 +1,5 @@
 ﻿namespace UglyToad.PdfPig.AcroForms.Fields
 {
-    using System;
-    using System.Collections.Generic;
     using Core;
     using Tokens;
 

--- a/src/UglyToad.PdfPig/AcroForms/Fields/AcroNonTerminalField.cs
+++ b/src/UglyToad.PdfPig/AcroForms/Fields/AcroNonTerminalField.cs
@@ -1,7 +1,5 @@
 ﻿namespace UglyToad.PdfPig.AcroForms.Fields
 {
-    using System;
-    using System.Collections.Generic;
     using Tokens;
 
     /// <inheritdoc />

--- a/src/UglyToad.PdfPig/AcroForms/Fields/AcroRadioButtonsField.cs
+++ b/src/UglyToad.PdfPig/AcroForms/Fields/AcroRadioButtonsField.cs
@@ -1,6 +1,5 @@
 ﻿namespace UglyToad.PdfPig.AcroForms.Fields
 {
-    using System.Collections.Generic;
     using Tokens;
 
     /// <inheritdoc />

--- a/src/UglyToad.PdfPig/AcroForms/Fields/AcroTextFieldFlags.cs
+++ b/src/UglyToad.PdfPig/AcroForms/Fields/AcroTextFieldFlags.cs
@@ -1,7 +1,5 @@
 ﻿namespace UglyToad.PdfPig.AcroForms.Fields
 {
-    using System;
-
     /// <summary>
     /// Flags specifying various characteristics of a text type field in an <see cref="AcroFieldBase"/>.
     /// </summary>

--- a/src/UglyToad.PdfPig/AcroForms/SignatureFlags.cs
+++ b/src/UglyToad.PdfPig/AcroForms/SignatureFlags.cs
@@ -1,7 +1,5 @@
 ﻿namespace UglyToad.PdfPig.AcroForms
 {
-    using System;
-
     /// <summary>
     /// Specifies document level characteristics for any signature fields in the document's <see cref="AcroForm"/>.
     /// </summary>
@@ -12,6 +10,7 @@
         /// The document contains at least one signature field.
         /// </summary>
         SignaturesExist = 1 << 0,
+
         /// <summary>
         /// The document contains signatures which may be invalidated if the file is saved
         /// in a way which alters its previous content rather than simply appending new content.

--- a/src/UglyToad.PdfPig/AdvancedPdfDocumentAccess.cs
+++ b/src/UglyToad.PdfPig/AdvancedPdfDocumentAccess.cs
@@ -1,7 +1,5 @@
 ﻿namespace UglyToad.PdfPig
 {
-    using System;
-    using System.Collections.Generic;
     using System.Diagnostics.CodeAnalysis;
     using Content;
     using Core;

--- a/src/UglyToad.PdfPig/Annotations/Annotation.cs
+++ b/src/UglyToad.PdfPig/Annotations/Annotation.cs
@@ -1,7 +1,5 @@
 ﻿namespace UglyToad.PdfPig.Annotations
 {
-    using System;
-    using System.Collections.Generic;
     using Core;
     using Actions;
     using Tokens;

--- a/src/UglyToad.PdfPig/Annotations/AnnotationBorder.cs
+++ b/src/UglyToad.PdfPig/Annotations/AnnotationBorder.cs
@@ -1,7 +1,5 @@
 ﻿namespace UglyToad.PdfPig.Annotations
 {
-    using System.Collections.Generic;
-
     /// <summary>
     /// A border for a PDF <see cref="Annotation"/> object.
     /// </summary>

--- a/src/UglyToad.PdfPig/Annotations/AnnotationFlags.cs
+++ b/src/UglyToad.PdfPig/Annotations/AnnotationFlags.cs
@@ -1,7 +1,5 @@
 ﻿namespace UglyToad.PdfPig.Annotations
 {
-    using System;
-
     /// <summary>
     /// Specifies characteristics of an annotation in a PDF or FDF document.
     /// </summary>

--- a/src/UglyToad.PdfPig/Annotations/AnnotationProvider.cs
+++ b/src/UglyToad.PdfPig/Annotations/AnnotationProvider.cs
@@ -1,7 +1,5 @@
 ﻿namespace UglyToad.PdfPig.Annotations
 {
-    using System;
-    using System.Collections.Generic;
     using System.Linq;
     using Actions;
     using Core;

--- a/src/UglyToad.PdfPig/Annotations/AppearanceStream.cs
+++ b/src/UglyToad.PdfPig/Annotations/AppearanceStream.cs
@@ -1,7 +1,5 @@
 ﻿namespace UglyToad.PdfPig.Annotations
 {
-    using System;
-    using System.Collections.Generic;
     using Tokens;
 
     /// <summary>

--- a/src/UglyToad.PdfPig/Annotations/AppearanceStreamFactory.cs
+++ b/src/UglyToad.PdfPig/Annotations/AppearanceStreamFactory.cs
@@ -1,6 +1,5 @@
 ﻿namespace UglyToad.PdfPig.Annotations
 {
-    using System.Collections.Generic;
     using System.Diagnostics.CodeAnalysis;
     using Tokenization.Scanner;
     using Tokens;

--- a/src/UglyToad.PdfPig/Annotations/HyperlinkFactory.cs
+++ b/src/UglyToad.PdfPig/Annotations/HyperlinkFactory.cs
@@ -1,6 +1,5 @@
 ﻿namespace UglyToad.PdfPig.Annotations
 {
-    using System.Collections.Generic;
     using System.Linq;
     using Content;
     using Core;

--- a/src/UglyToad.PdfPig/Annotations/QuadPointsQuadrilateral.cs
+++ b/src/UglyToad.PdfPig/Annotations/QuadPointsQuadrilateral.cs
@@ -1,7 +1,5 @@
 ﻿namespace UglyToad.PdfPig.Annotations
 {
-    using System;
-    using System.Collections.Generic;
     using Core;
 
     /// <summary>

--- a/src/UglyToad.PdfPig/Content/ArtifactMarkedContentElement.cs
+++ b/src/UglyToad.PdfPig/Content/ArtifactMarkedContentElement.cs
@@ -1,10 +1,8 @@
 ﻿namespace UglyToad.PdfPig.Content
 {
-    using System;
-    using System.Collections.Generic;
     using Core;
+    using Graphics;
     using Tokens;
-    using UglyToad.PdfPig.Graphics;
 
     /// <inheritdoc />
     /// <summary>

--- a/src/UglyToad.PdfPig/Content/BasePageFactory.cs
+++ b/src/UglyToad.PdfPig/Content/BasePageFactory.cs
@@ -1,7 +1,5 @@
 ﻿namespace UglyToad.PdfPig.Content
 {
-    using System;
-    using System.Collections.Generic;
     using Core;
     using Filters;
     using Geometry;

--- a/src/UglyToad.PdfPig/Content/Catalog.cs
+++ b/src/UglyToad.PdfPig/Content/Catalog.cs
@@ -1,6 +1,5 @@
 ﻿namespace UglyToad.PdfPig.Content
 {
-    using System;
     using Outline.Destinations;
     using Tokens;
 

--- a/src/UglyToad.PdfPig/Content/DocumentInformation.cs
+++ b/src/UglyToad.PdfPig/Content/DocumentInformation.cs
@@ -1,7 +1,5 @@
 ﻿namespace UglyToad.PdfPig.Content
 {
-    using System;
-    using System.Collections.Generic;
     using System.Text;
     using Tokens;
     using Util;

--- a/src/UglyToad.PdfPig/Content/EmbeddedFile.cs
+++ b/src/UglyToad.PdfPig/Content/EmbeddedFile.cs
@@ -1,7 +1,5 @@
 ﻿namespace UglyToad.PdfPig.Content
 {
-    using System;
-    using System.Collections.Generic;
     using Tokens;
 
     /// <summary>

--- a/src/UglyToad.PdfPig/Content/HeaderVersion.cs
+++ b/src/UglyToad.PdfPig/Content/HeaderVersion.cs
@@ -1,8 +1,6 @@
 ﻿namespace UglyToad.PdfPig.Content
 {
-    using System;
-
-    internal class HeaderVersion
+    internal sealed class HeaderVersion
     {
         public double Version { get; }
 

--- a/src/UglyToad.PdfPig/Content/Hyperlink.cs
+++ b/src/UglyToad.PdfPig/Content/Hyperlink.cs
@@ -1,7 +1,5 @@
 ﻿namespace UglyToad.PdfPig.Content
 {
-    using System;
-    using System.Collections.Generic;
     using Annotations;
     using Core;
 

--- a/src/UglyToad.PdfPig/Content/IPdfImage.cs
+++ b/src/UglyToad.PdfPig/Content/IPdfImage.cs
@@ -1,12 +1,10 @@
 ﻿namespace UglyToad.PdfPig.Content
 {
-    using System;
-    using System.Collections.Generic;
     using System.Diagnostics.CodeAnalysis;
     using Core;
     using Graphics.Colors;
     using Graphics.Core;
-    using UglyToad.PdfPig.Tokens;
+    using Tokens;
     using XObjects;
 
     /// <summary>

--- a/src/UglyToad.PdfPig/Content/IResourceStore.cs
+++ b/src/UglyToad.PdfPig/Content/IResourceStore.cs
@@ -1,6 +1,5 @@
 ﻿namespace UglyToad.PdfPig.Content
 {
-    using System.Collections.Generic;
     using System.Diagnostics.CodeAnalysis;
     using Graphics.Colors;
     using PdfFonts;

--- a/src/UglyToad.PdfPig/Content/InlineImage.cs
+++ b/src/UglyToad.PdfPig/Content/InlineImage.cs
@@ -1,7 +1,5 @@
 ﻿namespace UglyToad.PdfPig.Content
 {
-    using System;
-    using System.Collections.Generic;
     using System.Diagnostics.CodeAnalysis;
     using Core;
     using Filters;

--- a/src/UglyToad.PdfPig/Content/MarkedContentElement.cs
+++ b/src/UglyToad.PdfPig/Content/MarkedContentElement.cs
@@ -1,9 +1,7 @@
 ﻿namespace UglyToad.PdfPig.Content
 {
-    using System;
-    using System.Collections.Generic;
+    using Graphics;
     using Tokens;
-    using UglyToad.PdfPig.Graphics;
 
     /// <summary>
     /// A marked content element can be used to provide application specific data in the

--- a/src/UglyToad.PdfPig/Content/MediaBox.cs
+++ b/src/UglyToad.PdfPig/Content/MediaBox.cs
@@ -1,6 +1,5 @@
 ﻿namespace UglyToad.PdfPig.Content
 {
-    using System;
     using Core;
 
     /// <summary>

--- a/src/UglyToad.PdfPig/Content/OptionalContentGroupElement.cs
+++ b/src/UglyToad.PdfPig/Content/OptionalContentGroupElement.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using UglyToad.PdfPig.Tokenization.Scanner;
+﻿using UglyToad.PdfPig.Tokenization.Scanner;
 using UglyToad.PdfPig.Tokens;
 
 namespace UglyToad.PdfPig.Content

--- a/src/UglyToad.PdfPig/Content/Page.cs
+++ b/src/UglyToad.PdfPig/Content/Page.cs
@@ -1,7 +1,5 @@
 ﻿namespace UglyToad.PdfPig.Content
 {
-    using System;
-    using System.Collections.Generic;
     using System.Text;
     using System.Linq;
     using Annotations;

--- a/src/UglyToad.PdfPig/Content/PageContent.cs
+++ b/src/UglyToad.PdfPig/Content/PageContent.cs
@@ -4,8 +4,6 @@
     using Filters;
     using Graphics;
     using Graphics.Operations;
-    using System;
-    using System.Collections.Generic;
     using Tokenization.Scanner;
     using XObjects;
 

--- a/src/UglyToad.PdfPig/Content/PageRotationDegrees.cs
+++ b/src/UglyToad.PdfPig/Content/PageRotationDegrees.cs
@@ -1,6 +1,5 @@
 ﻿namespace UglyToad.PdfPig.Content
 {
-    using System;
     using System.Globalization;
 
     /// <summary>

--- a/src/UglyToad.PdfPig/Content/PageSize.cs
+++ b/src/UglyToad.PdfPig/Content/PageSize.cs
@@ -1,9 +1,7 @@
 ﻿namespace UglyToad.PdfPig.Content
 {
-    using System.Collections.Generic;
     using System.Linq;
     using Core;
-    using System;
 
     /// <summary>
     /// The corresponding named size of the <see cref="Page"/>.

--- a/src/UglyToad.PdfPig/Content/PageTreeMembers.cs
+++ b/src/UglyToad.PdfPig/Content/PageTreeMembers.cs
@@ -2,7 +2,6 @@
 
 namespace UglyToad.PdfPig.Content
 {
-    using System.Collections.Generic;
     using Tokens;
 
     /// <summary>

--- a/src/UglyToad.PdfPig/Content/PageTreeNode.cs
+++ b/src/UglyToad.PdfPig/Content/PageTreeNode.cs
@@ -1,7 +1,5 @@
 ﻿namespace UglyToad.PdfPig.Content
 {
-    using System;
-    using System.Collections.Generic;
     using Core;
     using Tokens;
 

--- a/src/UglyToad.PdfPig/Content/Pages.cs
+++ b/src/UglyToad.PdfPig/Content/Pages.cs
@@ -1,7 +1,5 @@
 ﻿namespace UglyToad.PdfPig.Content
 {
-    using System;
-    using System.Collections.Generic;
     using Core;
     using Filters;
     using Outline.Destinations;

--- a/src/UglyToad.PdfPig/Content/PagesFactory.cs
+++ b/src/UglyToad.PdfPig/Content/PagesFactory.cs
@@ -1,11 +1,9 @@
 ﻿namespace UglyToad.PdfPig.Content
 {
+    using System.Linq;
     using Core;
     using Logging;
     using Parser.Parts;
-    using System;
-    using System.Collections.Generic;
-    using System.Linq;
     using Tokenization.Scanner;
     using Tokens;
     using Util;

--- a/src/UglyToad.PdfPig/Content/ResourceStore.cs
+++ b/src/UglyToad.PdfPig/Content/ResourceStore.cs
@@ -1,7 +1,5 @@
 ﻿namespace UglyToad.PdfPig.Content
 {
-    using System;
-    using System.Collections.Generic;
     using System.Diagnostics.CodeAnalysis;
     using Core;
     using Graphics.Colors;

--- a/src/UglyToad.PdfPig/Content/Word.cs
+++ b/src/UglyToad.PdfPig/Content/Word.cs
@@ -1,10 +1,8 @@
 ﻿namespace UglyToad.PdfPig.Content
 {
-    using Core;
-    using System;
-    using System.Collections.Generic;
     using System.Linq;
     using System.Text;
+    using Core;
 
     /// <summary>
     /// A word.

--- a/src/UglyToad.PdfPig/Content/XmpMetadata.cs
+++ b/src/UglyToad.PdfPig/Content/XmpMetadata.cs
@@ -2,7 +2,6 @@
 {
     using Core;
     using Filters;
-    using System;
     using System.Xml.Linq;
     using Tokenization.Scanner;
     using Tokens;

--- a/src/UglyToad.PdfPig/CrossReference/CrossReferenceTable.cs
+++ b/src/UglyToad.PdfPig/CrossReference/CrossReferenceTable.cs
@@ -1,7 +1,5 @@
 ﻿namespace UglyToad.PdfPig.CrossReference
 {
-    using System;
-    using System.Collections.Generic;
     using Core;
 
     /// <summary>

--- a/src/UglyToad.PdfPig/CrossReference/CrossReferenceTableBuilder.cs
+++ b/src/UglyToad.PdfPig/CrossReference/CrossReferenceTableBuilder.cs
@@ -1,7 +1,5 @@
 ﻿namespace UglyToad.PdfPig.CrossReference
 {
-    using System;
-    using System.Collections.Generic;
     using System.Linq;
     using Core;
     using Logging;

--- a/src/UglyToad.PdfPig/CrossReference/CrossReferenceTablePart.cs
+++ b/src/UglyToad.PdfPig/CrossReference/CrossReferenceTablePart.cs
@@ -1,6 +1,5 @@
 ﻿namespace UglyToad.PdfPig.CrossReference
 {
-    using System.Collections.Generic;
     using Core;
     using Tokens;
 

--- a/src/UglyToad.PdfPig/CrossReference/CrossReferenceTablePartBuilder.cs
+++ b/src/UglyToad.PdfPig/CrossReference/CrossReferenceTablePartBuilder.cs
@@ -1,6 +1,5 @@
 ﻿namespace UglyToad.PdfPig.CrossReference
 {
-    using System.Collections.Generic;
     using Core;
     using Tokens;
 

--- a/src/UglyToad.PdfPig/CrossReference/TrailerDictionary.cs
+++ b/src/UglyToad.PdfPig/CrossReference/TrailerDictionary.cs
@@ -1,7 +1,5 @@
 ﻿namespace UglyToad.PdfPig.CrossReference
 {
-    using System;
-    using System.Collections.Generic;
     using Core;
     using Tokens;
     using Util;

--- a/src/UglyToad.PdfPig/Encryption/AesEncryptionHelper.cs
+++ b/src/UglyToad.PdfPig/Encryption/AesEncryptionHelper.cs
@@ -1,6 +1,5 @@
 ﻿namespace UglyToad.PdfPig.Encryption
 {
-    using System;
     using System.IO;
     using System.Security.Cryptography;
 

--- a/src/UglyToad.PdfPig/Encryption/CryptHandler.cs
+++ b/src/UglyToad.PdfPig/Encryption/CryptHandler.cs
@@ -1,6 +1,5 @@
 ﻿namespace UglyToad.PdfPig.Encryption
 {
-    using System;
     using Exceptions;
     using Tokens;
 

--- a/src/UglyToad.PdfPig/Encryption/EncryptionDictionary.cs
+++ b/src/UglyToad.PdfPig/Encryption/EncryptionDictionary.cs
@@ -1,6 +1,5 @@
 ﻿namespace UglyToad.PdfPig.Encryption
 {
-    using System;
     using System.Diagnostics.CodeAnalysis;
     using Exceptions;
     using Tokens;

--- a/src/UglyToad.PdfPig/Encryption/EncryptionDictionaryFactory.cs
+++ b/src/UglyToad.PdfPig/Encryption/EncryptionDictionaryFactory.cs
@@ -1,7 +1,5 @@
 ﻿namespace UglyToad.PdfPig.Encryption
 {
-    using System;
-    using System.Linq;
     using Core;
     using Tokenization.Scanner;
     using Tokens;

--- a/src/UglyToad.PdfPig/Encryption/EncryptionHandler.cs
+++ b/src/UglyToad.PdfPig/Encryption/EncryptionHandler.cs
@@ -2,8 +2,6 @@
 
 namespace UglyToad.PdfPig.Encryption
 {
-    using System;
-    using System.Collections.Generic;
     using System.IO;
     using System.Linq;
     using System.Security.Cryptography;

--- a/src/UglyToad.PdfPig/Encryption/RC4.cs
+++ b/src/UglyToad.PdfPig/Encryption/RC4.cs
@@ -1,7 +1,5 @@
 ﻿namespace UglyToad.PdfPig.Encryption
 {
-    using System;
-
     internal static class RC4
     {
         public static byte[] Encrypt(ReadOnlySpan<byte> key, ReadOnlySpan<byte> data)

--- a/src/UglyToad.PdfPig/Encryption/UserAccessPermissions.cs
+++ b/src/UglyToad.PdfPig/Encryption/UserAccessPermissions.cs
@@ -1,7 +1,5 @@
 ﻿namespace UglyToad.PdfPig.Encryption
 {
-    using System;
-
     [Flags]
     internal enum UserAccessPermissions : long
     {

--- a/src/UglyToad.PdfPig/Exceptions/PdfDocumentEncryptedException.cs
+++ b/src/UglyToad.PdfPig/Exceptions/PdfDocumentEncryptedException.cs
@@ -1,6 +1,5 @@
 ﻿namespace UglyToad.PdfPig.Exceptions
 {
-    using System;
 #if !NET
     using System.Runtime.Serialization;
 #endif

--- a/src/UglyToad.PdfPig/Filters/Ascii85Filter.cs
+++ b/src/UglyToad.PdfPig/Filters/Ascii85Filter.cs
@@ -1,7 +1,5 @@
 ﻿namespace UglyToad.PdfPig.Filters
 {
-    using System;
-    using System.Collections.Generic;
     using Core;
     using Tokens;
 

--- a/src/UglyToad.PdfPig/Filters/AsciiHexDecodeFilter.cs
+++ b/src/UglyToad.PdfPig/Filters/AsciiHexDecodeFilter.cs
@@ -1,6 +1,5 @@
 ﻿namespace UglyToad.PdfPig.Filters
 {
-    using System;
     using Core;
     using Tokens;
 

--- a/src/UglyToad.PdfPig/Filters/BitStream.cs
+++ b/src/UglyToad.PdfPig/Filters/BitStream.cs
@@ -1,7 +1,5 @@
 ﻿namespace UglyToad.PdfPig.Filters
 {
-    using System;
-
     internal ref struct BitStream
     {
         private readonly ReadOnlySpan<byte> data;

--- a/src/UglyToad.PdfPig/Filters/CcittFaxDecodeFilter.cs
+++ b/src/UglyToad.PdfPig/Filters/CcittFaxDecodeFilter.cs
@@ -1,6 +1,5 @@
 ﻿namespace UglyToad.PdfPig.Filters
 {
-    using System;
     using System.IO;
     using Tokens;
     using Util;

--- a/src/UglyToad.PdfPig/Filters/CcittFaxDecoderStream.cs
+++ b/src/UglyToad.PdfPig/Filters/CcittFaxDecoderStream.cs
@@ -1,6 +1,5 @@
 ﻿namespace UglyToad.PdfPig.Filters
 {
-    using System;
     using System.IO;
     using IO;
 

--- a/src/UglyToad.PdfPig/Filters/DctDecodeFilter.cs
+++ b/src/UglyToad.PdfPig/Filters/DctDecodeFilter.cs
@@ -1,6 +1,5 @@
 ﻿namespace UglyToad.PdfPig.Filters
 {
-    using System;
     using Tokens;
 
     internal class DctDecodeFilter : IFilter

--- a/src/UglyToad.PdfPig/Filters/DecodeParameterResolver.cs
+++ b/src/UglyToad.PdfPig/Filters/DecodeParameterResolver.cs
@@ -1,9 +1,7 @@
 ﻿namespace UglyToad.PdfPig.Filters
 {
-    using System;
-    using System.Collections.Generic;
     using Tokens;
-    using UglyToad.PdfPig.Util;
+    using Util;
 
     internal static class DecodeParameterResolver
     {

--- a/src/UglyToad.PdfPig/Filters/DefaultFilterProvider.cs
+++ b/src/UglyToad.PdfPig/Filters/DefaultFilterProvider.cs
@@ -1,11 +1,9 @@
 ﻿namespace UglyToad.PdfPig.Filters
 {
-    using System;
-    using System.Collections.Generic;
     using System.Linq;
     using Core;
     using Tokens;
-    using UglyToad.PdfPig.Util;
+    using Util;
 
     /// <inheritdoc />
     /// <summary>

--- a/src/UglyToad.PdfPig/Filters/FilterProviderWithLookup.cs
+++ b/src/UglyToad.PdfPig/Filters/FilterProviderWithLookup.cs
@@ -1,7 +1,5 @@
 ﻿namespace UglyToad.PdfPig.Filters
 {
-    using System;
-    using System.Collections.Generic;
     using System.Linq;
     using Core;
     using Parser.Parts;

--- a/src/UglyToad.PdfPig/Filters/FlateFilter.cs
+++ b/src/UglyToad.PdfPig/Filters/FlateFilter.cs
@@ -1,9 +1,8 @@
 ﻿namespace UglyToad.PdfPig.Filters
 {
-    using Fonts;
-    using System;
     using System.IO;
     using System.IO.Compression;
+    using Fonts;
     using Tokens;
     using Util;
 

--- a/src/UglyToad.PdfPig/Filters/IFilter.cs
+++ b/src/UglyToad.PdfPig/Filters/IFilter.cs
@@ -1,6 +1,5 @@
 ﻿namespace UglyToad.PdfPig.Filters
 {
-    using System;
     using Tokens;
 
     /// <summary>

--- a/src/UglyToad.PdfPig/Filters/IFilterProvider.cs
+++ b/src/UglyToad.PdfPig/Filters/IFilterProvider.cs
@@ -1,6 +1,5 @@
 ﻿namespace UglyToad.PdfPig.Filters
 {
-    using System.Collections.Generic;
     using Tokenization.Scanner;
     using Tokens;
 

--- a/src/UglyToad.PdfPig/Filters/Jbig2DecodeFilter.cs
+++ b/src/UglyToad.PdfPig/Filters/Jbig2DecodeFilter.cs
@@ -1,6 +1,5 @@
 ﻿namespace UglyToad.PdfPig.Filters
 {
-    using System;
     using Tokens;
 
     internal sealed class Jbig2DecodeFilter : IFilter

--- a/src/UglyToad.PdfPig/Filters/JpxDecodeFilter.cs
+++ b/src/UglyToad.PdfPig/Filters/JpxDecodeFilter.cs
@@ -1,6 +1,5 @@
 ﻿namespace UglyToad.PdfPig.Filters
 {
-    using System;
     using Tokens;
 
     internal class JpxDecodeFilter : IFilter

--- a/src/UglyToad.PdfPig/Filters/LzwFilter.cs
+++ b/src/UglyToad.PdfPig/Filters/LzwFilter.cs
@@ -2,8 +2,6 @@
 
 namespace UglyToad.PdfPig.Filters
 {
-    using System;
-    using System.Collections.Generic;
     using Tokens;
     using Util;
 

--- a/src/UglyToad.PdfPig/Filters/PngPredictor.cs
+++ b/src/UglyToad.PdfPig/Filters/PngPredictor.cs
@@ -1,7 +1,5 @@
 ﻿namespace UglyToad.PdfPig.Filters
 {
-    using System;
-    using System.Collections.Generic;
     using System.IO;
     using IO;
 

--- a/src/UglyToad.PdfPig/Filters/RunLengthFilter.cs
+++ b/src/UglyToad.PdfPig/Filters/RunLengthFilter.cs
@@ -1,6 +1,5 @@
 ﻿namespace UglyToad.PdfPig.Filters
 {
-    using System;
     using Tokens;
     using UglyToad.PdfPig.Core;
 

--- a/src/UglyToad.PdfPig/Functions/PdfFunctionType0.cs
+++ b/src/UglyToad.PdfPig/Functions/PdfFunctionType0.cs
@@ -1,11 +1,10 @@
 ﻿namespace UglyToad.PdfPig.Functions
 {
-    using System;
     using System.Collections;
     using System.IO;
     using System.Linq;
-    using UglyToad.PdfPig.Core;
-    using UglyToad.PdfPig.Tokens;
+    using Core;
+    using Tokens;
 
     internal sealed class PdfFunctionType0 : PdfFunction
     {

--- a/src/UglyToad.PdfPig/Functions/PdfFunctionType2.cs
+++ b/src/UglyToad.PdfPig/Functions/PdfFunctionType2.cs
@@ -1,6 +1,5 @@
 ﻿namespace UglyToad.PdfPig.Functions
 {
-    using System;
     using UglyToad.PdfPig.Tokens;
 
     /// <summary>

--- a/src/UglyToad.PdfPig/Functions/PdfFunctionType3.cs
+++ b/src/UglyToad.PdfPig/Functions/PdfFunctionType3.cs
@@ -1,7 +1,5 @@
 ﻿namespace UglyToad.PdfPig.Functions
 {
-    using System;
-    using System.Collections.Generic;
     using System.IO;
     using System.Linq;
     using UglyToad.PdfPig.Core;

--- a/src/UglyToad.PdfPig/Functions/PdfFunctionType4.cs
+++ b/src/UglyToad.PdfPig/Functions/PdfFunctionType4.cs
@@ -1,6 +1,5 @@
 ﻿namespace UglyToad.PdfPig.Functions
 {
-    using System;
     using System.Linq;
     using UglyToad.PdfPig.Core;
     using UglyToad.PdfPig.Functions.Type4;

--- a/src/UglyToad.PdfPig/Functions/Type4/ArithmeticOperators.cs
+++ b/src/UglyToad.PdfPig/Functions/Type4/ArithmeticOperators.cs
@@ -1,7 +1,5 @@
 ﻿namespace UglyToad.PdfPig.Functions.Type4
 {
-    using System;
-
     /// <summary>
     /// Provides the arithmetic operators such as "add" and "sub".
     /// </summary>

--- a/src/UglyToad.PdfPig/Functions/Type4/BitwiseOperators.cs
+++ b/src/UglyToad.PdfPig/Functions/Type4/BitwiseOperators.cs
@@ -1,8 +1,5 @@
 ﻿namespace UglyToad.PdfPig.Functions.Type4
 {
-    using System;
-    using System.Collections.Generic;
-
     internal sealed class BitwiseOperators
     {
         private BitwiseOperators()

--- a/src/UglyToad.PdfPig/Functions/Type4/ConditionalOperators.cs
+++ b/src/UglyToad.PdfPig/Functions/Type4/ConditionalOperators.cs
@@ -1,8 +1,5 @@
 ﻿namespace UglyToad.PdfPig.Functions.Type4
 {
-    using System;
-    using System.Collections.Generic;
-
     /// <summary>
     /// Provides the conditional operators such as "if" and "ifelse".
     /// </summary>

--- a/src/UglyToad.PdfPig/Functions/Type4/ExecutionContext.cs
+++ b/src/UglyToad.PdfPig/Functions/Type4/ExecutionContext.cs
@@ -1,8 +1,5 @@
 ﻿namespace UglyToad.PdfPig.Functions.Type4
 {
-    using System;
-    using System.Collections;
-    using System.Collections.Generic;
     using System.Linq;
 
     internal sealed class ExecutionContext

--- a/src/UglyToad.PdfPig/Functions/Type4/InstructionSequence.cs
+++ b/src/UglyToad.PdfPig/Functions/Type4/InstructionSequence.cs
@@ -1,7 +1,5 @@
 ﻿namespace UglyToad.PdfPig.Functions.Type4
 {
-    using System;
-    using System.Collections.Generic;
     using System.Linq;
 
     internal sealed class InstructionSequence

--- a/src/UglyToad.PdfPig/Functions/Type4/InstructionSequenceBuilder.cs
+++ b/src/UglyToad.PdfPig/Functions/Type4/InstructionSequenceBuilder.cs
@@ -1,6 +1,5 @@
 ﻿namespace UglyToad.PdfPig.Functions.Type4
 {
-    using System.Collections.Generic;
     using System.Globalization;
 
     /// <summary>

--- a/src/UglyToad.PdfPig/Functions/Type4/Operators.cs
+++ b/src/UglyToad.PdfPig/Functions/Type4/Operators.cs
@@ -1,7 +1,5 @@
 ﻿namespace UglyToad.PdfPig.Functions.Type4
 {
-    using System.Collections.Generic;
-
     /// <summary>
     /// This class provides all the supported operators.
     /// </summary>

--- a/src/UglyToad.PdfPig/Functions/Type4/RelationalOperators.cs
+++ b/src/UglyToad.PdfPig/Functions/Type4/RelationalOperators.cs
@@ -1,8 +1,5 @@
 ﻿namespace UglyToad.PdfPig.Functions.Type4
 {
-    using System;
-    using System.Collections.Generic;
-
     /// <summary>
     /// Provides the relational operators such as "eq" and "le".
     /// </summary>

--- a/src/UglyToad.PdfPig/Functions/Type4/StackOperators.cs
+++ b/src/UglyToad.PdfPig/Functions/Type4/StackOperators.cs
@@ -1,7 +1,5 @@
 ﻿namespace UglyToad.PdfPig.Functions.Type4
 {
-    using System;
-    using System.Collections.Generic;
     using System.Linq;
 
     /// <summary>

--- a/src/UglyToad.PdfPig/Geometry/ClipperLibrary/Clipper.cs
+++ b/src/UglyToad.PdfPig/Geometry/ClipperLibrary/Clipper.cs
@@ -74,9 +74,6 @@
 
 namespace UglyToad.PdfPig.Geometry.ClipperLibrary
 {
-    using System;
-    using System.Collections.Generic;
-
     internal class Clipper : ClipperBase
     {
         //InitOptions that can be passed to the constructor ...

--- a/src/UglyToad.PdfPig/Geometry/ClipperLibrary/ClipperBase.cs
+++ b/src/UglyToad.PdfPig/Geometry/ClipperLibrary/ClipperBase.cs
@@ -77,8 +77,6 @@
 
 namespace UglyToad.PdfPig.Geometry.ClipperLibrary
 {
-    using System.Collections.Generic;
-
     internal class ClipperBase
     {
         internal const double Horizontal = -3.4E+38;

--- a/src/UglyToad.PdfPig/Geometry/ClipperLibrary/ClipperException.cs
+++ b/src/UglyToad.PdfPig/Geometry/ClipperLibrary/ClipperException.cs
@@ -71,8 +71,6 @@
 *******************************************************************************/
 namespace UglyToad.PdfPig.Geometry.ClipperLibrary
 {
-    using System;
-
     internal class ClipperException : Exception
     {
         public ClipperException(string description) : base(description)

--- a/src/UglyToad.PdfPig/Geometry/ClipperLibrary/ClipperIntersectNode.cs
+++ b/src/UglyToad.PdfPig/Geometry/ClipperLibrary/ClipperIntersectNode.cs
@@ -74,8 +74,6 @@
 
 namespace UglyToad.PdfPig.Geometry.ClipperLibrary
 {
-    using System.Collections.Generic;
-
     internal class ClipperIntersectNode
     {
         internal ClipperTEdge Edge1;

--- a/src/UglyToad.PdfPig/Geometry/ClipperLibrary/ClipperOffset.cs
+++ b/src/UglyToad.PdfPig/Geometry/ClipperLibrary/ClipperOffset.cs
@@ -71,9 +71,6 @@
 *******************************************************************************/
 namespace UglyToad.PdfPig.Geometry.ClipperLibrary
 {
-    using System;
-    using System.Collections.Generic;
-
     internal class ClipperOffset
     {
         private const double DefArcTolerance = 0.25;

--- a/src/UglyToad.PdfPig/Geometry/ClipperLibrary/ClipperPolyNode.cs
+++ b/src/UglyToad.PdfPig/Geometry/ClipperLibrary/ClipperPolyNode.cs
@@ -74,8 +74,6 @@
 
 namespace UglyToad.PdfPig.Geometry.ClipperLibrary
 {
-    using System.Collections.Generic;
-
     internal class ClipperPolyTree : ClipperPolyNode
     {
         internal List<ClipperPolyNode> AllPolys = new List<ClipperPolyNode>();

--- a/src/UglyToad.PdfPig/Geometry/ClippingExtensions.cs
+++ b/src/UglyToad.PdfPig/Geometry/ClippingExtensions.cs
@@ -1,7 +1,5 @@
 ﻿namespace UglyToad.PdfPig.Geometry
 {
-    using System;
-    using System.Collections.Generic;
     using System.Linq;
     using ClipperLibrary;
     using Core;

--- a/src/UglyToad.PdfPig/Geometry/GeometryExtensions.cs
+++ b/src/UglyToad.PdfPig/Geometry/GeometryExtensions.cs
@@ -1,10 +1,8 @@
 ﻿namespace UglyToad.PdfPig.Geometry
 {
-    using Core;
-    using System;
-    using System.Collections.Generic;
     using System.Linq;
     using System.Text;
+    using Core;
     using UglyToad.PdfPig.Geometry.ClipperLibrary;
     using UglyToad.PdfPig.Graphics;
     using static UglyToad.PdfPig.Core.PdfSubpath;

--- a/src/UglyToad.PdfPig/Geometry/PdfVector.cs
+++ b/src/UglyToad.PdfPig/Geometry/PdfVector.cs
@@ -1,6 +1,5 @@
 ﻿namespace UglyToad.PdfPig.Geometry
 {
-    using System;
     using Core;
 
     internal readonly struct PdfVector

--- a/src/UglyToad.PdfPig/Geometry/UserSpaceUnit.cs
+++ b/src/UglyToad.PdfPig/Geometry/UserSpaceUnit.cs
@@ -1,6 +1,5 @@
 ﻿namespace UglyToad.PdfPig.Geometry
 {
-    using System;
     using System.Globalization;
 
     /// <summary>

--- a/src/UglyToad.PdfPig/Globals.cs
+++ b/src/UglyToad.PdfPig/Globals.cs
@@ -1,0 +1,2 @@
+﻿global using System;
+global using System.Collections.Generic;

--- a/src/UglyToad.PdfPig/Graphics/BaseStreamProcessor.cs
+++ b/src/UglyToad.PdfPig/Graphics/BaseStreamProcessor.cs
@@ -1,7 +1,5 @@
 ﻿namespace UglyToad.PdfPig.Graphics
 {
-    using System;
-    using System.Collections.Generic;
     using System.Diagnostics;
     using System.Linq;
 

--- a/src/UglyToad.PdfPig/Graphics/ColorSpaceContext.cs
+++ b/src/UglyToad.PdfPig/Graphics/ColorSpaceContext.cs
@@ -1,7 +1,5 @@
 ﻿namespace UglyToad.PdfPig.Graphics
 {
-    using System;
-    using System.Collections.Generic;
     using System.Linq;
     using Colors;
     using Content;

--- a/src/UglyToad.PdfPig/Graphics/Colors/CIEBasedColorSpaceTransformer.cs
+++ b/src/UglyToad.PdfPig/Graphics/Colors/CIEBasedColorSpaceTransformer.cs
@@ -1,6 +1,5 @@
 ﻿namespace UglyToad.PdfPig.Graphics.Colors
 {
-    using System;
     using UglyToad.PdfPig.Util;
 
     /// <summary>

--- a/src/UglyToad.PdfPig/Graphics/Colors/CMYKColor.cs
+++ b/src/UglyToad.PdfPig/Graphics/Colors/CMYKColor.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-
-namespace UglyToad.PdfPig.Graphics.Colors
+﻿namespace UglyToad.PdfPig.Graphics.Colors
 {
     /// <summary>
     /// A color with cyan, magenta, yellow and black (K) components.

--- a/src/UglyToad.PdfPig/Graphics/Colors/ColorSpaceDetails.cs
+++ b/src/UglyToad.PdfPig/Graphics/Colors/ColorSpaceDetails.cs
@@ -1,8 +1,6 @@
 ﻿namespace UglyToad.PdfPig.Graphics.Colors
 {
-    using System;
     using System.Collections.Concurrent;
-    using System.Collections.Generic;
     using System.Linq;
     using System.Runtime.InteropServices;
     using Tokens;

--- a/src/UglyToad.PdfPig/Graphics/Colors/ColorSpaceExtensions.cs
+++ b/src/UglyToad.PdfPig/Graphics/Colors/ColorSpaceExtensions.cs
@@ -1,6 +1,5 @@
 ﻿namespace UglyToad.PdfPig.Graphics.Colors
 {
-    using System;
     using Tokens;
 
     /// <summary>

--- a/src/UglyToad.PdfPig/Graphics/Colors/GrayColor.cs
+++ b/src/UglyToad.PdfPig/Graphics/Colors/GrayColor.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-
-namespace UglyToad.PdfPig.Graphics.Colors
+﻿namespace UglyToad.PdfPig.Graphics.Colors
 {
     /// <summary>
     /// A grayscale color with a single gray component.

--- a/src/UglyToad.PdfPig/Graphics/Colors/PatternColor.cs
+++ b/src/UglyToad.PdfPig/Graphics/Colors/PatternColor.cs
@@ -1,7 +1,5 @@
 ﻿namespace UglyToad.PdfPig.Graphics.Colors
 {
-    using System;
-    using System.Collections.Generic;
     using System.Linq;
     using UglyToad.PdfPig.Core;
     using UglyToad.PdfPig.Tokens;

--- a/src/UglyToad.PdfPig/Graphics/Colors/RGBColor.cs
+++ b/src/UglyToad.PdfPig/Graphics/Colors/RGBColor.cs
@@ -1,8 +1,5 @@
 ﻿namespace UglyToad.PdfPig.Graphics.Colors
 {
-    using System;
-    using System.Collections.Generic;
-
     /// <summary>
     /// A color with red, green and blue components.
     /// </summary>

--- a/src/UglyToad.PdfPig/Graphics/Colors/RGBWorkingSpace.cs
+++ b/src/UglyToad.PdfPig/Graphics/Colors/RGBWorkingSpace.cs
@@ -2,8 +2,6 @@
 
 namespace UglyToad.PdfPig.Graphics.Colors
 {
-    using System;
-
     // The RGB working space specifications below were obtained from: http://www.brucelindbloom.com/index.html?WorkingSpaceInfo.html
     internal class RGBWorkingSpace
     {

--- a/src/UglyToad.PdfPig/Graphics/ContentStreamProcessor.cs
+++ b/src/UglyToad.PdfPig/Graphics/ContentStreamProcessor.cs
@@ -2,8 +2,6 @@
 
 namespace UglyToad.PdfPig.Graphics
 {
-    using System;
-    using System.Collections.Generic;
     using Colors;
     using Content;
     using Filters;

--- a/src/UglyToad.PdfPig/Graphics/Core/LineDashPattern.cs
+++ b/src/UglyToad.PdfPig/Graphics/Core/LineDashPattern.cs
@@ -1,7 +1,5 @@
 ﻿namespace UglyToad.PdfPig.Graphics.Core
 {
-    using System;
-    using System.Collections.Generic;
     using System.Linq;
 
     /// <summary>

--- a/src/UglyToad.PdfPig/Graphics/IColorSpaceContext.cs
+++ b/src/UglyToad.PdfPig/Graphics/IColorSpaceContext.cs
@@ -1,6 +1,5 @@
 ﻿namespace UglyToad.PdfPig.Graphics
 {
-    using System.Collections.Generic;
     using Colors;
     using Tokens;
     using UglyToad.PdfPig.Core;

--- a/src/UglyToad.PdfPig/Graphics/IGraphicsStateOperationFactory.cs
+++ b/src/UglyToad.PdfPig/Graphics/IGraphicsStateOperationFactory.cs
@@ -1,6 +1,5 @@
 ﻿namespace UglyToad.PdfPig.Graphics
 {
-    using System.Collections.Generic;
     using Operations;
     using Tokens;
 

--- a/src/UglyToad.PdfPig/Graphics/IOperationContext.cs
+++ b/src/UglyToad.PdfPig/Graphics/IOperationContext.cs
@@ -1,8 +1,6 @@
 ﻿namespace UglyToad.PdfPig.Graphics
 {
     using PdfPig.Core;
-    using System;
-    using System.Collections.Generic;
     using Tokens;
     using UglyToad.PdfPig.Graphics.Core;
 

--- a/src/UglyToad.PdfPig/Graphics/InlineImageBuilder.cs
+++ b/src/UglyToad.PdfPig/Graphics/InlineImageBuilder.cs
@@ -1,7 +1,5 @@
 ﻿namespace UglyToad.PdfPig.Graphics
 {
-    using System;
-    using System.Collections.Generic;
     using System.Linq;
     using Content;
     using Core;

--- a/src/UglyToad.PdfPig/Graphics/MarkedContentStack.cs
+++ b/src/UglyToad.PdfPig/Graphics/MarkedContentStack.cs
@@ -1,7 +1,5 @@
 ﻿namespace UglyToad.PdfPig.Graphics
 {
-    using System;
-    using System.Collections.Generic;
     using Content;
     using Filters;
     using PdfPig.Core;

--- a/src/UglyToad.PdfPig/Graphics/OperationContextHelper.cs
+++ b/src/UglyToad.PdfPig/Graphics/OperationContextHelper.cs
@@ -1,6 +1,5 @@
 ﻿namespace UglyToad.PdfPig.Graphics
 {
-    using System;
     using System.Linq;
     using Content;
     using Geometry;

--- a/src/UglyToad.PdfPig/Graphics/Operations/General/SetColorRenderingIntent.cs
+++ b/src/UglyToad.PdfPig/Graphics/Operations/General/SetColorRenderingIntent.cs
@@ -1,6 +1,5 @@
 ﻿namespace UglyToad.PdfPig.Graphics.Operations.General
 {
-    using System;
     using System.IO;
     using Tokens;
     using UglyToad.PdfPig.Graphics.Core;

--- a/src/UglyToad.PdfPig/Graphics/Operations/General/SetLineCap.cs
+++ b/src/UglyToad.PdfPig/Graphics/Operations/General/SetLineCap.cs
@@ -1,6 +1,5 @@
 ﻿namespace UglyToad.PdfPig.Graphics.Operations.General
 {
-    using System;
     using System.IO;
     using Core;
 

--- a/src/UglyToad.PdfPig/Graphics/Operations/General/SetLineJoin.cs
+++ b/src/UglyToad.PdfPig/Graphics/Operations/General/SetLineJoin.cs
@@ -1,6 +1,5 @@
 ﻿namespace UglyToad.PdfPig.Graphics.Operations.General
 {
-    using System;
     using System.IO;
     using Core;
 

--- a/src/UglyToad.PdfPig/Graphics/Operations/InlineImages/BeginInlineImageData.cs
+++ b/src/UglyToad.PdfPig/Graphics/Operations/InlineImages/BeginInlineImageData.cs
@@ -1,7 +1,5 @@
 ﻿namespace UglyToad.PdfPig.Graphics.Operations.InlineImages
 {
-    using System;
-    using System.Collections.Generic;
     using System.IO;
     using Tokens;
     using UglyToad.PdfPig.Writer;

--- a/src/UglyToad.PdfPig/Graphics/Operations/InlineImages/EndInlineImage.cs
+++ b/src/UglyToad.PdfPig/Graphics/Operations/InlineImages/EndInlineImage.cs
@@ -1,7 +1,5 @@
 ﻿namespace UglyToad.PdfPig.Graphics.Operations.InlineImages
 {
-    using System;
-    using System.Collections.Generic;
     using System.IO;
 
     /// <inheritdoc />

--- a/src/UglyToad.PdfPig/Graphics/Operations/InvokeNamedXObject.cs
+++ b/src/UglyToad.PdfPig/Graphics/Operations/InvokeNamedXObject.cs
@@ -1,6 +1,5 @@
 ﻿namespace UglyToad.PdfPig.Graphics.Operations
 {
-    using System;
     using System.IO;
     using Tokens;
 

--- a/src/UglyToad.PdfPig/Graphics/Operations/OperationWriteHelper.cs
+++ b/src/UglyToad.PdfPig/Graphics/Operations/OperationWriteHelper.cs
@@ -1,10 +1,9 @@
 ﻿namespace UglyToad.PdfPig.Graphics.Operations
 {
-    using PdfPig.Core;
-    using System;
     using System.Buffers.Text;
     using System.IO;
     using System.Text;
+    using PdfPig.Core;
     using Util;
 
     internal static class OperationWriteHelper

--- a/src/UglyToad.PdfPig/Graphics/Operations/PaintShading.cs
+++ b/src/UglyToad.PdfPig/Graphics/Operations/PaintShading.cs
@@ -1,6 +1,5 @@
 ﻿namespace UglyToad.PdfPig.Graphics.Operations
 {
-    using System;
     using System.IO;
     using Tokens;
 

--- a/src/UglyToad.PdfPig/Graphics/Operations/SetNonStrokeColor.cs
+++ b/src/UglyToad.PdfPig/Graphics/Operations/SetNonStrokeColor.cs
@@ -1,6 +1,5 @@
 ﻿namespace UglyToad.PdfPig.Graphics.Operations
 {
-    using System.Collections.Generic;
     using System.IO;
     using System.Linq;
 

--- a/src/UglyToad.PdfPig/Graphics/Operations/SetNonStrokeColorAdvanced.cs
+++ b/src/UglyToad.PdfPig/Graphics/Operations/SetNonStrokeColorAdvanced.cs
@@ -1,6 +1,5 @@
 ﻿namespace UglyToad.PdfPig.Graphics.Operations
 {
-    using System.Collections.Generic;
     using System.IO;
     using System.Linq;
     using Tokens;

--- a/src/UglyToad.PdfPig/Graphics/Operations/SetNonStrokeColorSpace.cs
+++ b/src/UglyToad.PdfPig/Graphics/Operations/SetNonStrokeColorSpace.cs
@@ -1,6 +1,5 @@
 ﻿namespace UglyToad.PdfPig.Graphics.Operations
 {
-    using System;
     using System.IO;
     using Tokens;
     using Writer;

--- a/src/UglyToad.PdfPig/Graphics/Operations/SetStrokeColor.cs
+++ b/src/UglyToad.PdfPig/Graphics/Operations/SetStrokeColor.cs
@@ -1,6 +1,5 @@
 ﻿namespace UglyToad.PdfPig.Graphics.Operations
 {
-    using System.Collections.Generic;
     using System.IO;
     using System.Linq;
 

--- a/src/UglyToad.PdfPig/Graphics/Operations/SetStrokeColorAdvanced.cs
+++ b/src/UglyToad.PdfPig/Graphics/Operations/SetStrokeColorAdvanced.cs
@@ -1,6 +1,5 @@
 ﻿namespace UglyToad.PdfPig.Graphics.Operations
 {
-    using System.Collections.Generic;
     using System.IO;
     using System.Linq;
     using Tokens;

--- a/src/UglyToad.PdfPig/Graphics/Operations/SetStrokeColorSpace.cs
+++ b/src/UglyToad.PdfPig/Graphics/Operations/SetStrokeColorSpace.cs
@@ -1,6 +1,5 @@
 ﻿namespace UglyToad.PdfPig.Graphics.Operations
 {
-    using System;
     using System.IO;
     using Tokens;
     using Writer;

--- a/src/UglyToad.PdfPig/Graphics/Operations/SpecialGraphicsState/ModifyCurrentTransformationMatrix.cs
+++ b/src/UglyToad.PdfPig/Graphics/Operations/SpecialGraphicsState/ModifyCurrentTransformationMatrix.cs
@@ -1,6 +1,5 @@
 ﻿namespace UglyToad.PdfPig.Graphics.Operations.SpecialGraphicsState
 {
-    using System;
     using System.IO;
 
     /// <inheritdoc />

--- a/src/UglyToad.PdfPig/Graphics/Operations/SpecialGraphicsState/Pop.cs
+++ b/src/UglyToad.PdfPig/Graphics/Operations/SpecialGraphicsState/Pop.cs
@@ -1,6 +1,5 @@
 ﻿namespace UglyToad.PdfPig.Graphics.Operations.SpecialGraphicsState
 {
-    using System;
     using System.IO;
 
     /// <inheritdoc />

--- a/src/UglyToad.PdfPig/Graphics/Operations/TextPositioning/SetTextMatrix.cs
+++ b/src/UglyToad.PdfPig/Graphics/Operations/TextPositioning/SetTextMatrix.cs
@@ -1,6 +1,5 @@
 ﻿namespace UglyToad.PdfPig.Graphics.Operations.TextPositioning
 {
-    using System;
     using System.IO;
     using PdfPig.Core;
 

--- a/src/UglyToad.PdfPig/Graphics/Operations/TextShowing/ShowTextsWithPositioning.cs
+++ b/src/UglyToad.PdfPig/Graphics/Operations/TextShowing/ShowTextsWithPositioning.cs
@@ -1,7 +1,5 @@
 ﻿namespace UglyToad.PdfPig.Graphics.Operations.TextShowing
 {
-    using System;
-    using System.Collections.Generic;
     using System.IO;
     using Tokens;
     using Writer;

--- a/src/UglyToad.PdfPig/Graphics/Operations/TextState/SetFontAndSize.cs
+++ b/src/UglyToad.PdfPig/Graphics/Operations/TextState/SetFontAndSize.cs
@@ -1,6 +1,5 @@
 ﻿namespace UglyToad.PdfPig.Graphics.Operations.TextState
 {
-    using System;
     using System.Globalization;
     using System.IO;
     using Tokens;

--- a/src/UglyToad.PdfPig/Graphics/PdfPath.cs
+++ b/src/UglyToad.PdfPig/Graphics/PdfPath.cs
@@ -1,6 +1,5 @@
 ﻿namespace UglyToad.PdfPig.Graphics
 {
-    using System.Collections.Generic;
     using UglyToad.PdfPig.Core;
     using UglyToad.PdfPig.Graphics.Colors;
     using UglyToad.PdfPig.Graphics.Core;

--- a/src/UglyToad.PdfPig/Graphics/ReflectionGraphicsStateOperationFactory.cs
+++ b/src/UglyToad.PdfPig/Graphics/ReflectionGraphicsStateOperationFactory.cs
@@ -2,6 +2,8 @@ using UglyToad.PdfPig.Tokenization;
 
 namespace UglyToad.PdfPig.Graphics
 {
+    using System.Linq;
+    using System.Reflection;
     using Operations;
     using Operations.ClippingPaths;
     using Operations.Compatibility;
@@ -15,10 +17,6 @@ namespace UglyToad.PdfPig.Graphics
     using Operations.TextShowing;
     using Operations.TextState;
     using PdfPig.Core;
-    using System;
-    using System.Collections.Generic;
-    using System.Linq;
-    using System.Reflection;
     using Tokens;
     using Operations.PathPainting;
 

--- a/src/UglyToad.PdfPig/Graphics/XObjectContentRecord.cs
+++ b/src/UglyToad.PdfPig/Graphics/XObjectContentRecord.cs
@@ -1,6 +1,5 @@
 ﻿namespace UglyToad.PdfPig.Graphics
 {
-    using System;
     using Colors;
     using Core;
     using PdfPig.Core;

--- a/src/UglyToad.PdfPig/IO/RandomAccessBuffer.cs
+++ b/src/UglyToad.PdfPig/IO/RandomAccessBuffer.cs
@@ -2,8 +2,6 @@
 
 namespace UglyToad.PdfPig.IO
 {
-    using System;
-    using System.Collections.Generic;
     using System.IO;
 
     internal class RandomAccessBuffer : IDisposable

--- a/src/UglyToad.PdfPig/IO/StreamWrapper.cs
+++ b/src/UglyToad.PdfPig/IO/StreamWrapper.cs
@@ -1,6 +1,5 @@
 ﻿namespace UglyToad.PdfPig.IO
 {
-    using System;
     using System.IO;
 
     internal class StreamWrapper : Stream

--- a/src/UglyToad.PdfPig/Images/ColorSpaceDetailsByteConverter.cs
+++ b/src/UglyToad.PdfPig/Images/ColorSpaceDetailsByteConverter.cs
@@ -2,8 +2,6 @@
 {
     using Content;
     using Graphics.Colors;
-    using System;
-    using System.Linq;
 
     /// <summary>
     /// Utility for working with the bytes in <see cref="IPdfImage"/>s and converting according to their <see cref="ColorSpaceDetails"/>.s

--- a/src/UglyToad.PdfPig/Images/JpegHandler.cs
+++ b/src/UglyToad.PdfPig/Images/JpegHandler.cs
@@ -1,6 +1,5 @@
 ﻿namespace UglyToad.PdfPig.Images
 {
-    using System;
     using System.IO;
 
     internal static class JpegHandler

--- a/src/UglyToad.PdfPig/Images/Png/Adam7.cs
+++ b/src/UglyToad.PdfPig/Images/Png/Adam7.cs
@@ -1,7 +1,5 @@
 ﻿namespace UglyToad.PdfPig.Images.Png
 {
-    using System.Collections.Generic;
-
     internal static class Adam7
     {
         /// <summary>

--- a/src/UglyToad.PdfPig/Images/Png/Adler32Checksum.cs
+++ b/src/UglyToad.PdfPig/Images/Png/Adler32Checksum.cs
@@ -1,7 +1,5 @@
 ﻿namespace UglyToad.PdfPig.Images.Png
 {
-    using System;
-
     /// <summary>
     /// Used to calculate the Adler-32 checksum used for ZLIB data in accordance with 
     /// RFC 1950: ZLIB Compressed Data Format Specification.

--- a/src/UglyToad.PdfPig/Images/Png/ChunkHeader.cs
+++ b/src/UglyToad.PdfPig/Images/Png/ChunkHeader.cs
@@ -1,7 +1,5 @@
 ﻿namespace UglyToad.PdfPig.Images.Png
 {
-    using System;
-
     /// <summary>
     /// The header for a data chunk in a PNG file.
     /// </summary>

--- a/src/UglyToad.PdfPig/Images/Png/ColorType.cs
+++ b/src/UglyToad.PdfPig/Images/Png/ColorType.cs
@@ -1,7 +1,5 @@
 ﻿namespace UglyToad.PdfPig.Images.Png
 {
-    using System;
-
     /// <summary>
     /// Describes the interpretation of the image data.
     /// </summary>

--- a/src/UglyToad.PdfPig/Images/Png/Crc32.cs
+++ b/src/UglyToad.PdfPig/Images/Png/Crc32.cs
@@ -1,7 +1,5 @@
 ﻿namespace UglyToad.PdfPig.Images.Png
 {
-    using System;
-
     /// <summary>
     /// 32-bit Cyclic Redundancy Code used by the PNG for checking the data is intact.
     /// </summary>

--- a/src/UglyToad.PdfPig/Images/Png/Decoder.cs
+++ b/src/UglyToad.PdfPig/Images/Png/Decoder.cs
@@ -1,7 +1,5 @@
 ﻿namespace UglyToad.PdfPig.Images.Png
 {
-    using System;
-
     internal static class Decoder
     {
         public static (byte bytesPerPixel, byte samplesPerPixel) GetBytesAndSamplesPerPixel(ImageHeader header)

--- a/src/UglyToad.PdfPig/Images/Png/HeaderValidationResult.cs
+++ b/src/UglyToad.PdfPig/Images/Png/HeaderValidationResult.cs
@@ -1,7 +1,5 @@
 ﻿namespace UglyToad.PdfPig.Images.Png
 {
-    using System;
-
     internal readonly struct HeaderValidationResult
     {
         public static ReadOnlySpan<byte> ExpectedHeader => [

--- a/src/UglyToad.PdfPig/Images/Png/ImageHeader.cs
+++ b/src/UglyToad.PdfPig/Images/Png/ImageHeader.cs
@@ -1,8 +1,5 @@
 ﻿namespace UglyToad.PdfPig.Images.Png
 {
-    using System;
-    using System.Collections.Generic;
-
     /// <summary>
     /// The high level information about the image.
     /// </summary>

--- a/src/UglyToad.PdfPig/Images/Png/Palette.cs
+++ b/src/UglyToad.PdfPig/Images/Png/Palette.cs
@@ -1,7 +1,5 @@
 ﻿namespace UglyToad.PdfPig.Images.Png
 {
-    using System;
-
     internal sealed class Palette
     {
         public bool HasAlphaValues { get; private set; }

--- a/src/UglyToad.PdfPig/Images/Png/Pixel.cs
+++ b/src/UglyToad.PdfPig/Images/Png/Pixel.cs
@@ -1,7 +1,5 @@
 ﻿namespace UglyToad.PdfPig.Images.Png
 {
-    using System;
-
     /// <summary>
     /// A pixel in a <see cref="Png"/> image.
     /// </summary>

--- a/src/UglyToad.PdfPig/Images/Png/Png.cs
+++ b/src/UglyToad.PdfPig/Images/Png/Png.cs
@@ -1,6 +1,5 @@
 ﻿namespace UglyToad.PdfPig.Images.Png
 {
-    using System;
     using System.IO;
 
     /// <summary>

--- a/src/UglyToad.PdfPig/Images/Png/PngOpener.cs
+++ b/src/UglyToad.PdfPig/Images/Png/PngOpener.cs
@@ -1,6 +1,5 @@
 ﻿namespace UglyToad.PdfPig.Images.Png
 {
-    using System;
     using System.Buffers.Binary;
     using System.IO;
     using System.IO.Compression;

--- a/src/UglyToad.PdfPig/Images/Png/PngStreamWriteHelper.cs
+++ b/src/UglyToad.PdfPig/Images/Png/PngStreamWriteHelper.cs
@@ -1,6 +1,5 @@
 ﻿namespace UglyToad.PdfPig.Images.Png
 {
-    using System;
     using System.Buffers.Binary;
     using System.IO;
 

--- a/src/UglyToad.PdfPig/Images/Png/RawPngData.cs
+++ b/src/UglyToad.PdfPig/Images/Png/RawPngData.cs
@@ -1,8 +1,6 @@
 ﻿namespace UglyToad.PdfPig.Images.Png
 {
-    using System;
-
-/// <summary>
+    /// <summary>
     /// Provides convenience methods for indexing into a raw byte array to extract pixel values.
     /// </summary>
     internal sealed class RawPngData

--- a/src/UglyToad.PdfPig/Images/Png/StreamHelper.cs
+++ b/src/UglyToad.PdfPig/Images/Png/StreamHelper.cs
@@ -1,6 +1,5 @@
 ﻿namespace UglyToad.PdfPig.Images.Png
 {
-    using System;
     using System.Buffers.Binary;
     using System.IO;
 

--- a/src/UglyToad.PdfPig/Logging/ILog.cs
+++ b/src/UglyToad.PdfPig/Logging/ILog.cs
@@ -1,7 +1,5 @@
 ﻿namespace UglyToad.PdfPig.Logging
 {
-    using System;
-
     /// <summary>
     /// Logs internal messages from the PDF parsing process. Consumers can provide their own implementation
     /// in the <see cref="ParsingOptions"/> to intercept log messages.

--- a/src/UglyToad.PdfPig/Outline/BookmarkNode.cs
+++ b/src/UglyToad.PdfPig/Outline/BookmarkNode.cs
@@ -1,8 +1,5 @@
 ﻿namespace UglyToad.PdfPig.Outline
 {
-    using System;
-    using System.Collections.Generic;
-
     /// <summary>
     /// A node in the <see cref="Bookmarks"/> (also known as outlines) of a PDF document.
     /// </summary>

--- a/src/UglyToad.PdfPig/Outline/Bookmarks.cs
+++ b/src/UglyToad.PdfPig/Outline/Bookmarks.cs
@@ -1,6 +1,4 @@
-﻿using System.Collections.Generic;
-
-namespace UglyToad.PdfPig.Outline
+﻿namespace UglyToad.PdfPig.Outline
 {
     /// <summary>
     /// The bookmarks in a PDF document.

--- a/src/UglyToad.PdfPig/Outline/BookmarksProvider.cs
+++ b/src/UglyToad.PdfPig/Outline/BookmarksProvider.cs
@@ -5,7 +5,6 @@
     using Destinations;
     using Logging;
     using Parser.Parts;
-    using System.Collections.Generic;
     using Core;
     using Tokenization.Scanner;
     using Tokens;

--- a/src/UglyToad.PdfPig/Outline/Destinations/NamedDestinations.cs
+++ b/src/UglyToad.PdfPig/Outline/Destinations/NamedDestinations.cs
@@ -1,6 +1,5 @@
 ﻿namespace UglyToad.PdfPig.Outline.Destinations
 {
-    using System.Collections.Generic;
     using System.Diagnostics.CodeAnalysis;
     using Content;
     using Logging;

--- a/src/UglyToad.PdfPig/Outline/Destinations/NamedDestinationsProvider.cs
+++ b/src/UglyToad.PdfPig/Outline/Destinations/NamedDestinationsProvider.cs
@@ -1,6 +1,5 @@
 ﻿namespace UglyToad.PdfPig.Outline.Destinations
 {
-    using System.Collections.Generic;
     using System.Diagnostics.CodeAnalysis;
     using Content;
     using Logging;

--- a/src/UglyToad.PdfPig/Outline/DocumentBookmarkNode.cs
+++ b/src/UglyToad.PdfPig/Outline/DocumentBookmarkNode.cs
@@ -1,6 +1,5 @@
 ﻿namespace UglyToad.PdfPig.Outline
 {
-    using System.Collections.Generic;
     using Destinations;
 
     /// <inheritdoc />

--- a/src/UglyToad.PdfPig/Outline/EmbeddedBookmarkNode.cs
+++ b/src/UglyToad.PdfPig/Outline/EmbeddedBookmarkNode.cs
@@ -1,8 +1,6 @@
 ﻿namespace UglyToad.PdfPig.Outline
 {
     using Destinations;
-    using System;
-    using System.Collections.Generic;
 
     /// <inheritdoc />
     /// <summary>

--- a/src/UglyToad.PdfPig/Outline/ExternalBookmarkNode.cs
+++ b/src/UglyToad.PdfPig/Outline/ExternalBookmarkNode.cs
@@ -1,8 +1,6 @@
 ﻿namespace UglyToad.PdfPig.Outline
 {
     using Destinations;
-    using System;
-    using System.Collections.Generic;
 
     /// <inheritdoc />
     /// <summary>

--- a/src/UglyToad.PdfPig/Outline/UriBookmarkNode.cs
+++ b/src/UglyToad.PdfPig/Outline/UriBookmarkNode.cs
@@ -1,8 +1,5 @@
 ﻿namespace UglyToad.PdfPig.Outline
 {
-    using System;
-    using System.Collections.Generic;
-
     /// <inheritdoc />
     /// <summary>
     /// A node in the <see cref="Bookmarks" /> of a PDF document which corresponds

--- a/src/UglyToad.PdfPig/Parser/CatalogFactory.cs
+++ b/src/UglyToad.PdfPig/Parser/CatalogFactory.cs
@@ -1,6 +1,5 @@
 ﻿namespace UglyToad.PdfPig.Parser
 {
-    using System;
     using Content;
     using Core;
     using Logging;

--- a/src/UglyToad.PdfPig/Parser/FileStructure/CrossReferenceObjectOffsetValidator.cs
+++ b/src/UglyToad.PdfPig/Parser/FileStructure/CrossReferenceObjectOffsetValidator.cs
@@ -1,7 +1,5 @@
 ﻿namespace UglyToad.PdfPig.Parser.FileStructure
 {
-    using System;
-    using System.Collections.Generic;
     using Core;
     using CrossReference;
     using Logging;

--- a/src/UglyToad.PdfPig/Parser/FileStructure/CrossReferenceParser.cs
+++ b/src/UglyToad.PdfPig/Parser/FileStructure/CrossReferenceParser.cs
@@ -1,7 +1,5 @@
 ﻿namespace UglyToad.PdfPig.Parser.FileStructure
 {
-    using System;
-    using System.Collections.Generic;
     using System.Diagnostics.CodeAnalysis;
     using Core;
     using CrossReference;

--- a/src/UglyToad.PdfPig/Parser/FileStructure/CrossReferenceTableParser.cs
+++ b/src/UglyToad.PdfPig/Parser/FileStructure/CrossReferenceTableParser.cs
@@ -1,6 +1,5 @@
 ﻿namespace UglyToad.PdfPig.Parser.FileStructure
 {
-    using System;
     using System.Linq;
     using CrossReference;
     using Core;

--- a/src/UglyToad.PdfPig/Parser/FileStructure/FileHeaderParser.cs
+++ b/src/UglyToad.PdfPig/Parser/FileStructure/FileHeaderParser.cs
@@ -1,6 +1,5 @@
 ﻿namespace UglyToad.PdfPig.Parser.FileStructure
 {
-    using System;
     using System.Diagnostics.CodeAnalysis;
     using System.Globalization;
     using Content;

--- a/src/UglyToad.PdfPig/Parser/FileStructure/FileTrailerParser.cs
+++ b/src/UglyToad.PdfPig/Parser/FileStructure/FileTrailerParser.cs
@@ -1,7 +1,5 @@
 ﻿namespace UglyToad.PdfPig.Parser.FileStructure
 {
-    using System;
-    using System.Collections.Generic;
     using Core;
     using Tokenization.Scanner;
     using Tokens;

--- a/src/UglyToad.PdfPig/Parser/FileStructure/XrefOffsetValidator.cs
+++ b/src/UglyToad.PdfPig/Parser/FileStructure/XrefOffsetValidator.cs
@@ -1,7 +1,5 @@
 ﻿namespace UglyToad.PdfPig.Parser.FileStructure
 {
-    using System;
-    using System.Collections.Generic;
     using Core;
     using Logging;
     using Tokenization.Scanner;

--- a/src/UglyToad.PdfPig/Parser/IPageContentParser.cs
+++ b/src/UglyToad.PdfPig/Parser/IPageContentParser.cs
@@ -1,6 +1,5 @@
 ﻿namespace UglyToad.PdfPig.Parser
 {
-    using System.Collections.Generic;
     using Core;
     using Graphics.Operations;
     using Logging;

--- a/src/UglyToad.PdfPig/Parser/PageContentParser.cs
+++ b/src/UglyToad.PdfPig/Parser/PageContentParser.cs
@@ -1,7 +1,5 @@
 ﻿namespace UglyToad.PdfPig.Parser
 {
-    using System;
-    using System.Collections.Generic;
     using System.Diagnostics.CodeAnalysis;
     using Core;
     using Graphics;

--- a/src/UglyToad.PdfPig/Parser/PageFactory.cs
+++ b/src/UglyToad.PdfPig/Parser/PageFactory.cs
@@ -1,7 +1,5 @@
 ﻿namespace UglyToad.PdfPig.Parser
 {
-    using System;
-    using System.Collections.Generic;
     using Annotations;
     using Content;
     using Core;

--- a/src/UglyToad.PdfPig/Parser/ParsingCachingProviders.cs
+++ b/src/UglyToad.PdfPig/Parser/ParsingCachingProviders.cs
@@ -1,6 +1,5 @@
 ﻿namespace UglyToad.PdfPig.Parser
 {
-    using System;
     using Content;
 
     /// <summary>

--- a/src/UglyToad.PdfPig/Parser/Parts/BruteForceSearcher.cs
+++ b/src/UglyToad.PdfPig/Parser/Parts/BruteForceSearcher.cs
@@ -1,7 +1,5 @@
 ﻿namespace UglyToad.PdfPig.Parser.Parts
 {
-    using System;
-    using System.Collections.Generic;
     using System.Globalization;
     using System.Text;
     using Core;

--- a/src/UglyToad.PdfPig/Parser/Parts/CrossReference/CrossReferenceStreamFieldSize.cs
+++ b/src/UglyToad.PdfPig/Parser/Parts/CrossReference/CrossReferenceStreamFieldSize.cs
@@ -1,6 +1,5 @@
 ﻿namespace UglyToad.PdfPig.Parser.Parts.CrossReference
 {
-    using System;
     using Core;
     using Tokens;
     using Util;

--- a/src/UglyToad.PdfPig/Parser/Parts/CrossReference/CrossReferenceStreamParser.cs
+++ b/src/UglyToad.PdfPig/Parser/Parts/CrossReference/CrossReferenceStreamParser.cs
@@ -1,6 +1,5 @@
 ﻿namespace UglyToad.PdfPig.Parser.Parts.CrossReference
 {
-    using System.Collections.Generic;
     using Core;
     using Filters;
     using PdfPig.CrossReference;

--- a/src/UglyToad.PdfPig/Parser/Parts/CrossReference/TableSubsectionDefinition.cs
+++ b/src/UglyToad.PdfPig/Parser/Parts/CrossReference/TableSubsectionDefinition.cs
@@ -1,6 +1,5 @@
 ﻿namespace UglyToad.PdfPig.Parser.Parts.CrossReference
 {
-    using System;
     using System.Globalization;
     using Core;
     using Logging;

--- a/src/UglyToad.PdfPig/Parser/Parts/NameTreeParser.cs
+++ b/src/UglyToad.PdfPig/Parser/Parts/NameTreeParser.cs
@@ -2,8 +2,6 @@
 
 namespace UglyToad.PdfPig.Parser.Parts
 {
-    using System;
-    using System.Collections.Generic;
     using Tokenization.Scanner;
     using Tokens;
 

--- a/src/UglyToad.PdfPig/Parser/Parts/ObjectHelper.cs
+++ b/src/UglyToad.PdfPig/Parser/Parts/ObjectHelper.cs
@@ -1,6 +1,5 @@
 ﻿namespace UglyToad.PdfPig.Parser.Parts
 {
-    using System;
     using Core;
 
     internal static class ObjectHelper

--- a/src/UglyToad.PdfPig/Parser/PdfDocumentFactory.cs
+++ b/src/UglyToad.PdfPig/Parser/PdfDocumentFactory.cs
@@ -1,7 +1,5 @@
 ﻿namespace UglyToad.PdfPig.Parser
 {
-    using System;
-    using System.Collections.Generic;
     using System.Diagnostics.CodeAnalysis;
     using System.IO;
     using System.Linq;

--- a/src/UglyToad.PdfPig/ParsingOptions.cs
+++ b/src/UglyToad.PdfPig/ParsingOptions.cs
@@ -1,6 +1,5 @@
 ﻿namespace UglyToad.PdfPig
 {
-    using System.Collections.Generic;
     using Logging;
 
     /// <summary>

--- a/src/UglyToad.PdfPig/PdfDocument.cs
+++ b/src/UglyToad.PdfPig/PdfDocument.cs
@@ -1,7 +1,5 @@
 ﻿namespace UglyToad.PdfPig
 {
-    using System;
-    using System.Collections.Generic;
     using System.Diagnostics.CodeAnalysis;
     using System.IO;
     using AcroForms;

--- a/src/UglyToad.PdfPig/PdfExtensions.cs
+++ b/src/UglyToad.PdfPig/PdfExtensions.cs
@@ -1,7 +1,5 @@
 ﻿namespace UglyToad.PdfPig
 {
-    using System;
-    using System.Collections.Generic;
     using System.Diagnostics.CodeAnalysis;
     using Core;
     using Filters;

--- a/src/UglyToad.PdfPig/PdfFonts/CharStringStack.cs
+++ b/src/UglyToad.PdfPig/PdfFonts/CharStringStack.cs
@@ -1,7 +1,5 @@
 ﻿namespace UglyToad.PdfPig.PdfFonts
 {
-    using System;
-    using System.Collections.Generic;
     using System.Globalization;
     using System.Linq;
 

--- a/src/UglyToad.PdfPig/PdfFonts/CidFonts/CharacterIdentifierToGlyphIndexMap.cs
+++ b/src/UglyToad.PdfPig/PdfFonts/CidFonts/CharacterIdentifierToGlyphIndexMap.cs
@@ -1,7 +1,5 @@
 ﻿namespace UglyToad.PdfPig.PdfFonts.CidFonts
 {
-    using System;
-
     /// <summary>
     /// Specifies mapping from character identifiers to glyph indices.
     /// Can either be defined as a name in which case it must be Identity or a stream which defines the mapping.

--- a/src/UglyToad.PdfPig/PdfFonts/CidFonts/ICidFont.cs
+++ b/src/UglyToad.PdfPig/PdfFonts/CidFonts/ICidFont.cs
@@ -1,8 +1,6 @@
 ﻿namespace UglyToad.PdfPig.PdfFonts.CidFonts
 {
-    using System;
     using System.Diagnostics.CodeAnalysis;
-    using System.Collections.Generic;
     using Core;
     using Geometry;
     using Tokens;

--- a/src/UglyToad.PdfPig/PdfFonts/CidFonts/ICidFontProgram.cs
+++ b/src/UglyToad.PdfPig/PdfFonts/CidFonts/ICidFontProgram.cs
@@ -1,7 +1,5 @@
 ﻿namespace UglyToad.PdfPig.PdfFonts.CidFonts
 {
-    using System;
-    using System.Collections.Generic;
     using System.Diagnostics.CodeAnalysis;
     using Core;
 

--- a/src/UglyToad.PdfPig/PdfFonts/CidFonts/PdfCidCompactFontFormatFont.cs
+++ b/src/UglyToad.PdfPig/PdfFonts/CidFonts/PdfCidCompactFontFormatFont.cs
@@ -1,7 +1,5 @@
 ﻿namespace UglyToad.PdfPig.PdfFonts.CidFonts
 {
-    using System;
-    using System.Collections.Generic;
     using System.Diagnostics.CodeAnalysis;
     using Core;
     using Fonts;

--- a/src/UglyToad.PdfPig/PdfFonts/CidFonts/PdfCidTrueTypeFont.cs
+++ b/src/UglyToad.PdfPig/PdfFonts/CidFonts/PdfCidTrueTypeFont.cs
@@ -1,7 +1,5 @@
 ﻿namespace UglyToad.PdfPig.PdfFonts.CidFonts
 {
-    using System;
-    using System.Collections.Generic;
     using System.Diagnostics.CodeAnalysis;
     using Core;
     using Fonts.TrueType;

--- a/src/UglyToad.PdfPig/PdfFonts/CidFonts/Type0CidFont.cs
+++ b/src/UglyToad.PdfPig/PdfFonts/CidFonts/Type0CidFont.cs
@@ -1,7 +1,5 @@
 ﻿namespace UglyToad.PdfPig.PdfFonts.CidFonts
 {
-    using System;
-    using System.Collections.Generic;
     using System.Diagnostics.CodeAnalysis;
     using System.Linq;
     using Core;

--- a/src/UglyToad.PdfPig/PdfFonts/CidFonts/Type2CidFont.cs
+++ b/src/UglyToad.PdfPig/PdfFonts/CidFonts/Type2CidFont.cs
@@ -1,7 +1,5 @@
 ﻿namespace UglyToad.PdfPig.PdfFonts.CidFonts
 {
-    using System;
-    using System.Collections.Generic;
     using System.Diagnostics.CodeAnalysis;
     using System.Linq;
     using Core;

--- a/src/UglyToad.PdfPig/PdfFonts/CidFonts/VerticalWritingMetrics.cs
+++ b/src/UglyToad.PdfPig/PdfFonts/CidFonts/VerticalWritingMetrics.cs
@@ -1,6 +1,5 @@
 ﻿namespace UglyToad.PdfPig.PdfFonts.CidFonts
 {
-    using System.Collections.Generic;
     using Geometry;
 
     /// <summary>

--- a/src/UglyToad.PdfPig/PdfFonts/Cmap/CMap.cs
+++ b/src/UglyToad.PdfPig/PdfFonts/Cmap/CMap.cs
@@ -1,7 +1,5 @@
 ﻿namespace UglyToad.PdfPig.PdfFonts.Cmap
 {
-    using System;
-    using System.Collections.Generic;
     using System.Diagnostics.CodeAnalysis;
     using System.Linq;
     using Core;

--- a/src/UglyToad.PdfPig/PdfFonts/Cmap/CMapCache.cs
+++ b/src/UglyToad.PdfPig/PdfFonts/Cmap/CMapCache.cs
@@ -1,7 +1,5 @@
 ﻿namespace UglyToad.PdfPig.PdfFonts.Cmap
 {
-    using System;
-    using System.Collections.Generic;
     using System.Diagnostics.CodeAnalysis;
     using Core;
     using Parser;

--- a/src/UglyToad.PdfPig/PdfFonts/Cmap/CMapUtils.cs
+++ b/src/UglyToad.PdfPig/PdfFonts/Cmap/CMapUtils.cs
@@ -1,8 +1,5 @@
 ﻿namespace UglyToad.PdfPig.PdfFonts.Cmap
 {
-    using System;
-    using System.Collections.Generic;
-
     internal static class CMapUtils
     {
         public static int ToInt(this ReadOnlySpan<byte> data)

--- a/src/UglyToad.PdfPig/PdfFonts/Cmap/CharacterMapBuilder.cs
+++ b/src/UglyToad.PdfPig/PdfFonts/Cmap/CharacterMapBuilder.cs
@@ -2,11 +2,9 @@
 
 namespace UglyToad.PdfPig.PdfFonts.Cmap
 {
-    using Core;
-    using System;
-    using System.Collections.Generic;
     using System.Linq;
     using System.Text;
+    using Core;
 
     /// <summary>
     /// A mutable class used when parsing and generating a <see cref="CMap"/>.

--- a/src/UglyToad.PdfPig/PdfFonts/Cmap/CidRange.cs
+++ b/src/UglyToad.PdfPig/PdfFonts/Cmap/CidRange.cs
@@ -1,7 +1,5 @@
 ﻿namespace UglyToad.PdfPig.PdfFonts.Cmap
 {
-    using System;
-
     /// <summary>
     /// Associates the beginning and end of a range of character codes with the starting CID for the range.
     /// </summary>

--- a/src/UglyToad.PdfPig/PdfFonts/Cmap/CodespaceRange.cs
+++ b/src/UglyToad.PdfPig/PdfFonts/Cmap/CodespaceRange.cs
@@ -1,7 +1,5 @@
 ﻿namespace UglyToad.PdfPig.PdfFonts.Cmap
 {
-    using System;
-
     /// <summary>
     ///  A codespace range is specified by a pair of codes of some particular length giving the lower and upper bounds of that range.
     /// </summary>

--- a/src/UglyToad.PdfPig/PdfFonts/Composite/ToUnicodeCMap.cs
+++ b/src/UglyToad.PdfPig/PdfFonts/Composite/ToUnicodeCMap.cs
@@ -1,6 +1,5 @@
 ﻿namespace UglyToad.PdfPig.PdfFonts.Composite
 {
-    using System;
     using System.Diagnostics.CodeAnalysis;
     using Cmap;
     using Core;

--- a/src/UglyToad.PdfPig/PdfFonts/Composite/Type0Font.cs
+++ b/src/UglyToad.PdfPig/PdfFonts/Composite/Type0Font.cs
@@ -1,7 +1,5 @@
 ﻿namespace UglyToad.PdfPig.PdfFonts.Composite
 {
-    using System;
-    using System.Collections.Generic;
     using System.Diagnostics.CodeAnalysis;
     using CidFonts;
     using Cmap;

--- a/src/UglyToad.PdfPig/PdfFonts/FontDescriptorFlags.cs
+++ b/src/UglyToad.PdfPig/PdfFonts/FontDescriptorFlags.cs
@@ -1,7 +1,5 @@
 ﻿namespace UglyToad.PdfPig.PdfFonts
 {
-    using System;
-
     /// <summary>
     /// Specifies various characteristics of a font.
     /// </summary>

--- a/src/UglyToad.PdfPig/PdfFonts/FontFactory.cs
+++ b/src/UglyToad.PdfPig/PdfFonts/FontFactory.cs
@@ -1,7 +1,5 @@
 ﻿namespace UglyToad.PdfPig.PdfFonts
 {
-    using System;
-    using System.Collections.Generic;
     using Logging;
     using Parser.Handlers;
     using Tokens;

--- a/src/UglyToad.PdfPig/PdfFonts/IFont.cs
+++ b/src/UglyToad.PdfPig/PdfFonts/IFont.cs
@@ -1,6 +1,5 @@
 ﻿namespace UglyToad.PdfPig.PdfFonts
 {
-    using System.Collections.Generic;
     using System.Diagnostics.CodeAnalysis;
     using Core;
     using Tokens;

--- a/src/UglyToad.PdfPig/PdfFonts/Parser/CMapParser.cs
+++ b/src/UglyToad.PdfPig/PdfFonts/Parser/CMapParser.cs
@@ -1,7 +1,5 @@
 ﻿namespace UglyToad.PdfPig.PdfFonts.Parser
 {
-    using System;
-    using System.Collections.Generic;
     using System.Diagnostics.CodeAnalysis;
     using System.IO;
     using System.Linq;

--- a/src/UglyToad.PdfPig/PdfFonts/Parser/EncodingReader.cs
+++ b/src/UglyToad.PdfPig/PdfFonts/Parser/EncodingReader.cs
@@ -1,7 +1,5 @@
 ﻿namespace UglyToad.PdfPig.PdfFonts.Parser
 {
-    using System;
-    using System.Collections.Generic;
     using System.Diagnostics.CodeAnalysis;
     using Fonts;
     using Fonts.Encodings;

--- a/src/UglyToad.PdfPig/PdfFonts/Parser/Handlers/TrueTypeFontHandler.cs
+++ b/src/UglyToad.PdfPig/PdfFonts/Parser/Handlers/TrueTypeFontHandler.cs
@@ -1,7 +1,5 @@
 ﻿namespace UglyToad.PdfPig.PdfFonts.Parser.Handlers
 {
-    using System;
-    using System.Collections.Generic;
     using System.Diagnostics.CodeAnalysis;
     using System.Globalization;
     using System.Linq;

--- a/src/UglyToad.PdfPig/PdfFonts/Parser/Handlers/Type0FontHandler.cs
+++ b/src/UglyToad.PdfPig/PdfFonts/Parser/Handlers/Type0FontHandler.cs
@@ -1,6 +1,5 @@
 ﻿namespace UglyToad.PdfPig.PdfFonts.Parser.Handlers
 {
-    using System;
     using System.Diagnostics.CodeAnalysis;
     using CidFonts;
     using Cmap;

--- a/src/UglyToad.PdfPig/PdfFonts/Parser/Handlers/Type1FontHandler.cs
+++ b/src/UglyToad.PdfPig/PdfFonts/Parser/Handlers/Type1FontHandler.cs
@@ -11,7 +11,6 @@
     using Fonts.Type1.Parser;
     using PdfPig.Parser.Parts;
     using Simple;
-    using System;
     using Tokenization.Scanner;
     using Tokens;
 

--- a/src/UglyToad.PdfPig/PdfFonts/Parser/Handlers/Type3FontHandler.cs
+++ b/src/UglyToad.PdfPig/PdfFonts/Parser/Handlers/Type3FontHandler.cs
@@ -7,7 +7,6 @@
     using Fonts.Encodings;
     using PdfPig.Parser.Parts;
     using Simple;
-    using System;
     using Tokenization.Scanner;
     using Tokens;
     using Util;

--- a/src/UglyToad.PdfPig/PdfFonts/Parser/Parts/BaseFontCharacterParser.cs
+++ b/src/UglyToad.PdfPig/PdfFonts/Parser/Parts/BaseFontCharacterParser.cs
@@ -1,6 +1,5 @@
 ﻿namespace UglyToad.PdfPig.PdfFonts.Parser.Parts
 {
-    using System;
     using Cmap;
     using Tokenization.Scanner;
     using Tokens;

--- a/src/UglyToad.PdfPig/PdfFonts/Parser/Parts/BaseFontRangeParser.cs
+++ b/src/UglyToad.PdfPig/PdfFonts/Parser/Parts/BaseFontRangeParser.cs
@@ -1,8 +1,5 @@
 ﻿namespace UglyToad.PdfPig.PdfFonts.Parser.Parts
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Linq;
     using Cmap;
     using Fonts;
     using Tokenization.Scanner;

--- a/src/UglyToad.PdfPig/PdfFonts/Parser/Parts/CidCharacterParser.cs
+++ b/src/UglyToad.PdfPig/PdfFonts/Parser/Parts/CidCharacterParser.cs
@@ -1,7 +1,5 @@
 ﻿namespace UglyToad.PdfPig.PdfFonts.Parser.Parts
 {
-    using System;
-    using System.Collections.Generic;
     using Cmap;
     using Tokenization.Scanner;
     using Tokens;

--- a/src/UglyToad.PdfPig/PdfFonts/Parser/Parts/CidFontFactory.cs
+++ b/src/UglyToad.PdfPig/PdfFonts/Parser/Parts/CidFontFactory.cs
@@ -1,7 +1,5 @@
 ﻿namespace UglyToad.PdfPig.PdfFonts.Parser.Parts
 {
-    using System;
-    using System.Collections.Generic;
     using System.Diagnostics.CodeAnalysis;
     using CidFonts;
     using Core;
@@ -11,10 +9,10 @@
     using Fonts.TrueType;
     using Fonts.TrueType.Parser;
     using Geometry;
+    using Logging;
     using PdfPig.Parser.Parts;
     using Tokenization.Scanner;
     using Tokens;
-    using UglyToad.PdfPig.Logging;
     using Util;
 
     internal class CidFontFactory

--- a/src/UglyToad.PdfPig/PdfFonts/Parser/Parts/CodespaceRangeParser.cs
+++ b/src/UglyToad.PdfPig/PdfFonts/Parser/Parts/CodespaceRangeParser.cs
@@ -1,7 +1,5 @@
 ﻿namespace UglyToad.PdfPig.PdfFonts.Parser.Parts
 {
-    using System;
-    using System.Collections.Generic;
     using Cmap;
     using Tokenization.Scanner;
     using Tokens;

--- a/src/UglyToad.PdfPig/PdfFonts/Parser/Parts/FontDescriptorFactory.cs
+++ b/src/UglyToad.PdfPig/PdfFonts/Parser/Parts/FontDescriptorFactory.cs
@@ -1,6 +1,5 @@
 ﻿namespace UglyToad.PdfPig.PdfFonts.Parser.Parts
 {
-    using System;
     using Core;
     using Tokenization.Scanner;
     using Tokens;

--- a/src/UglyToad.PdfPig/PdfFonts/Simple/TrueTypeSimpleFont.cs
+++ b/src/UglyToad.PdfPig/PdfFonts/Simple/TrueTypeSimpleFont.cs
@@ -1,7 +1,5 @@
 ﻿namespace UglyToad.PdfPig.PdfFonts.Simple
 {
-    using System;
-    using System.Collections.Generic;
     using System.Diagnostics.CodeAnalysis;
     using System.Linq;
     using Cmap;

--- a/src/UglyToad.PdfPig/PdfFonts/Simple/TrueTypeStandard14FallbackSimpleFont.cs
+++ b/src/UglyToad.PdfPig/PdfFonts/Simple/TrueTypeStandard14FallbackSimpleFont.cs
@@ -1,7 +1,5 @@
 ﻿namespace UglyToad.PdfPig.PdfFonts.Simple
 {
-    using System;
-    using System.Collections.Generic;
     using System.Diagnostics.CodeAnalysis;
     using System.Linq;
     using Core;

--- a/src/UglyToad.PdfPig/PdfFonts/Simple/Type1FontSimple.cs
+++ b/src/UglyToad.PdfPig/PdfFonts/Simple/Type1FontSimple.cs
@@ -1,6 +1,5 @@
 ﻿namespace UglyToad.PdfPig.PdfFonts.Simple
 {
-    using System.Collections.Generic;
     using System.Diagnostics.CodeAnalysis;
     using System.Linq;
     using Cmap;

--- a/src/UglyToad.PdfPig/PdfFonts/Simple/Type1Standard14Font.cs
+++ b/src/UglyToad.PdfPig/PdfFonts/Simple/Type1Standard14Font.cs
@@ -1,8 +1,6 @@
 ﻿//// ReSharper disable CompareOfFloatsByEqualityOperator
 namespace UglyToad.PdfPig.PdfFonts.Simple
 {
-    using System;
-    using System.Collections.Generic;
     using System.Diagnostics;
     using System.Diagnostics.CodeAnalysis;
     using Core;

--- a/src/UglyToad.PdfPig/PdfFonts/Simple/Type3Font.cs
+++ b/src/UglyToad.PdfPig/PdfFonts/Simple/Type3Font.cs
@@ -1,6 +1,5 @@
 ﻿namespace UglyToad.PdfPig.PdfFonts.Simple
 {    
-    using System.Collections.Generic;
     using System.Diagnostics.CodeAnalysis;
     using Cmap;
     using Composite;

--- a/src/UglyToad.PdfPig/Structure.cs
+++ b/src/UglyToad.PdfPig/Structure.cs
@@ -1,6 +1,5 @@
 ﻿namespace UglyToad.PdfPig
 {
-    using System;
     using Content;
     using Core;
     using CrossReference;

--- a/src/UglyToad.PdfPig/Tokenization/Scanner/IPdfTokenScanner.cs
+++ b/src/UglyToad.PdfPig/Tokenization/Scanner/IPdfTokenScanner.cs
@@ -1,6 +1,5 @@
 ﻿namespace UglyToad.PdfPig.Tokenization.Scanner
 {
-    using System;
     using Core;
     using Tokens;
 

--- a/src/UglyToad.PdfPig/Tokenization/Scanner/ObjectLocationProvider.cs
+++ b/src/UglyToad.PdfPig/Tokenization/Scanner/ObjectLocationProvider.cs
@@ -1,7 +1,5 @@
 ﻿namespace UglyToad.PdfPig.Tokenization.Scanner
 {
-    using System;
-    using System.Collections.Generic;
     using System.Diagnostics.CodeAnalysis;
     using Core;
     using CrossReference;

--- a/src/UglyToad.PdfPig/Tokenization/Scanner/PdfTokenScanner.cs
+++ b/src/UglyToad.PdfPig/Tokenization/Scanner/PdfTokenScanner.cs
@@ -1,7 +1,5 @@
 ﻿namespace UglyToad.PdfPig.Tokenization.Scanner
 {
-    using System;
-    using System.Collections.Generic;
     using System.Diagnostics;
     using System.Diagnostics.CodeAnalysis;
     using System.Globalization;

--- a/src/UglyToad.PdfPig/Tokenization/Scanner/PossibleStreamEndLocation.cs
+++ b/src/UglyToad.PdfPig/Tokenization/Scanner/PossibleStreamEndLocation.cs
@@ -1,6 +1,5 @@
 ﻿namespace UglyToad.PdfPig.Tokenization.Scanner
 {
-    using System;
     using Tokens;
 
     /// <summary>

--- a/src/UglyToad.PdfPig/Util/Adler32Checksum.cs
+++ b/src/UglyToad.PdfPig/Util/Adler32Checksum.cs
@@ -1,7 +1,5 @@
 ﻿namespace UglyToad.PdfPig.Util
 {
-    using System;
-
     /// <summary>
     /// Used to calculate the Adler-32 checksum used for ZLIB data in accordance with 
     /// RFC 1950: ZLIB Compressed Data Format Specification.

--- a/src/UglyToad.PdfPig/Util/ColorSpaceDetailsParser.cs
+++ b/src/UglyToad.PdfPig/Util/ColorSpaceDetailsParser.cs
@@ -1,6 +1,5 @@
 ﻿namespace UglyToad.PdfPig.Util
 {
-    using System.Collections.Generic;
     using System.Diagnostics.CodeAnalysis;
     using System.Linq;
     using Content;

--- a/src/UglyToad.PdfPig/Util/DateFormatHelper.cs
+++ b/src/UglyToad.PdfPig/Util/DateFormatHelper.cs
@@ -1,6 +1,5 @@
 ﻿namespace UglyToad.PdfPig.Util
 {
-    using System;
     using System.Globalization;
 
     /// <summary>

--- a/src/UglyToad.PdfPig/Util/DefaultWordExtractor.cs
+++ b/src/UglyToad.PdfPig/Util/DefaultWordExtractor.cs
@@ -1,7 +1,5 @@
 ﻿namespace UglyToad.PdfPig.Util
 {
-    using System;
-    using System.Collections.Generic;
     using System.Linq;
     using Content;
 

--- a/src/UglyToad.PdfPig/Util/Diacritics.cs
+++ b/src/UglyToad.PdfPig/Util/Diacritics.cs
@@ -1,6 +1,5 @@
 ﻿namespace UglyToad.PdfPig.Util
 {
-    using System.Collections.Generic;
     using System.Diagnostics.CodeAnalysis;
     using System.Globalization;
 

--- a/src/UglyToad.PdfPig/Util/DictionaryTokenExtensions.cs
+++ b/src/UglyToad.PdfPig/Util/DictionaryTokenExtensions.cs
@@ -1,6 +1,5 @@
 ﻿namespace UglyToad.PdfPig.Util
 {
-    using System;
     using System.Diagnostics.CodeAnalysis;
     using Core;
     using Parser.Parts;

--- a/src/UglyToad.PdfPig/Util/EnumerableExtensions.cs
+++ b/src/UglyToad.PdfPig/Util/EnumerableExtensions.cs
@@ -1,11 +1,8 @@
 namespace UglyToad.PdfPig.Util
 {
-    using System;
-    using System.Collections.Generic;
     using System.Linq;
     using System.Linq.Expressions;
     using System.Reflection;
-
 
     internal static class EnumerableExtensions
     {

--- a/src/UglyToad.PdfPig/Util/Hex.cs
+++ b/src/UglyToad.PdfPig/Util/Hex.cs
@@ -1,7 +1,5 @@
 ﻿namespace UglyToad.PdfPig.Util
 {
-    using System;
-
     /**
      * Utility functions for hex encoding.
      *

--- a/src/UglyToad.PdfPig/Util/IWordExtractor.cs
+++ b/src/UglyToad.PdfPig/Util/IWordExtractor.cs
@@ -1,6 +1,5 @@
 ﻿namespace UglyToad.PdfPig.Util
 {
-    using System.Collections.Generic;
     using Content;
 
     /// <summary>

--- a/src/UglyToad.PdfPig/Util/InternalStringExtensions.cs
+++ b/src/UglyToad.PdfPig/Util/InternalStringExtensions.cs
@@ -1,7 +1,5 @@
 ﻿namespace UglyToad.PdfPig.Util
 {
-    using System;
-
     internal static class InternalStringExtensions
     {
         public static bool StartsWithOffset(this string value, ReadOnlySpan<char> start, int offset)

--- a/src/UglyToad.PdfPig/Util/Matrix3x3.cs
+++ b/src/UglyToad.PdfPig/Util/Matrix3x3.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections;
-using System.Collections.Generic;
+﻿using System.Collections;
 
 namespace UglyToad.PdfPig.Util
 {

--- a/src/UglyToad.PdfPig/Util/PatternParser.cs
+++ b/src/UglyToad.PdfPig/Util/PatternParser.cs
@@ -1,6 +1,5 @@
 ﻿namespace UglyToad.PdfPig.Util
 {
-    using System;
     using System.Linq;
     using UglyToad.PdfPig.Content;
     using UglyToad.PdfPig.Core;

--- a/src/UglyToad.PdfPig/Util/PdfFunctionParser.cs
+++ b/src/UglyToad.PdfPig/Util/PdfFunctionParser.cs
@@ -1,9 +1,6 @@
 ﻿namespace UglyToad.PdfPig.Util
 {
-    using System;
-    using System.Collections.Generic;
     using System.IO;
-    using System.Linq;
     using UglyToad.PdfPig.Filters;
     using UglyToad.PdfPig.Functions;
     using UglyToad.PdfPig.Parser.Parts;

--- a/src/UglyToad.PdfPig/Util/ShadingParser.cs
+++ b/src/UglyToad.PdfPig/Util/ShadingParser.cs
@@ -1,6 +1,5 @@
 ﻿namespace UglyToad.PdfPig.Util
 {
-    using System;
     using System.Linq;
     using UglyToad.PdfPig.Content;
     using UglyToad.PdfPig.Core;

--- a/src/UglyToad.PdfPig/Util/StackDictionary.cs
+++ b/src/UglyToad.PdfPig/Util/StackDictionary.cs
@@ -1,8 +1,6 @@
 ﻿// ReSharper disable InconsistentNaming
 namespace UglyToad.PdfPig.Util
 {
-    using System;
-    using System.Collections.Generic;
     using System.Diagnostics.CodeAnalysis;
 
     internal class StackDictionary<K, V>

--- a/src/UglyToad.PdfPig/Writer/Colors/OutputIntentsFactory.cs
+++ b/src/UglyToad.PdfPig/Writer/Colors/OutputIntentsFactory.cs
@@ -1,7 +1,5 @@
 ﻿namespace UglyToad.PdfPig.Writer.Colors
 {
-    using System;
-    using System.Collections.Generic;
     using Tokens;
 
     internal static class OutputIntentsFactory

--- a/src/UglyToad.PdfPig/Writer/Colors/ProfileStreamReader.cs
+++ b/src/UglyToad.PdfPig/Writer/Colors/ProfileStreamReader.cs
@@ -1,6 +1,5 @@
 ﻿namespace UglyToad.PdfPig.Writer.Colors
 {
-    using System;
     using System.IO;
     using System.Linq;
     using PdfFonts.Parser;

--- a/src/UglyToad.PdfPig/Writer/DataCompresser.cs
+++ b/src/UglyToad.PdfPig/Writer/DataCompresser.cs
@@ -1,6 +1,5 @@
 ﻿namespace UglyToad.PdfPig.Writer
 {
-    using System.Collections.Generic;
     using System.IO;
     using System.Linq;
     using Filters;

--- a/src/UglyToad.PdfPig/Writer/Fonts/Standard14WritingFont.cs
+++ b/src/UglyToad.PdfPig/Writer/Fonts/Standard14WritingFont.cs
@@ -1,7 +1,5 @@
 ﻿namespace UglyToad.PdfPig.Writer.Fonts
 {
-    using System;
-    using System.Collections.Generic;
     using System.Diagnostics;
     using System.Linq;
     using Core;

--- a/src/UglyToad.PdfPig/Writer/Fonts/ToUnicodeCMapBuilder.cs
+++ b/src/UglyToad.PdfPig/Writer/Fonts/ToUnicodeCMapBuilder.cs
@@ -1,7 +1,5 @@
 ﻿namespace UglyToad.PdfPig.Writer.Fonts
 {
-    using System;
-    using System.Collections.Generic;
     using System.IO;
     using Graphics.Operations;
     using Tokens;

--- a/src/UglyToad.PdfPig/Writer/Fonts/TrueTypeWritingFont.cs
+++ b/src/UglyToad.PdfPig/Writer/Fonts/TrueTypeWritingFont.cs
@@ -1,7 +1,5 @@
 ﻿namespace UglyToad.PdfPig.Writer.Fonts
 {
-    using System;
-    using System.Collections.Generic;
     using System.Linq;
     using Core;
     using PdfFonts;

--- a/src/UglyToad.PdfPig/Writer/IPdfStreamWriter.cs
+++ b/src/UglyToad.PdfPig/Writer/IPdfStreamWriter.cs
@@ -1,6 +1,5 @@
 ﻿namespace UglyToad.PdfPig.Writer
 {
-    using System;
     using System.IO;
     using Tokens;
 

--- a/src/UglyToad.PdfPig/Writer/ITokenWriter.cs
+++ b/src/UglyToad.PdfPig/Writer/ITokenWriter.cs
@@ -1,8 +1,7 @@
 ﻿namespace UglyToad.PdfPig.Writer
 {
-    using Core;
-    using System.Collections.Generic;
     using System.IO;
+    using Core;
     using Tokens;
 
     /// <summary>

--- a/src/UglyToad.PdfPig/Writer/NoTextTokenWriter.cs
+++ b/src/UglyToad.PdfPig/Writer/NoTextTokenWriter.cs
@@ -1,8 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
+﻿using System.Diagnostics.CodeAnalysis;
 using System.IO;
-using System.Linq;
 using UglyToad.PdfPig.Core;
 using UglyToad.PdfPig.Filters;
 using UglyToad.PdfPig.Graphics.Operations.TextShowing;

--- a/src/UglyToad.PdfPig/Writer/PdfA1ARuleBuilder.cs
+++ b/src/UglyToad.PdfPig/Writer/PdfA1ARuleBuilder.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections.Generic;
-using UglyToad.PdfPig.Tokens;
+﻿using UglyToad.PdfPig.Tokens;
 
 namespace UglyToad.PdfPig.Writer
 {

--- a/src/UglyToad.PdfPig/Writer/PdfABaselineRuleBuilder.cs
+++ b/src/UglyToad.PdfPig/Writer/PdfABaselineRuleBuilder.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Xml.Linq;
+﻿using System.Xml.Linq;
 using UglyToad.PdfPig.Tokens;
 using UglyToad.PdfPig.Writer.Colors;
 using UglyToad.PdfPig.Writer.Xmp;

--- a/src/UglyToad.PdfPig/Writer/PdfDedupStreamWriter.cs
+++ b/src/UglyToad.PdfPig/Writer/PdfDedupStreamWriter.cs
@@ -1,7 +1,5 @@
 ﻿namespace UglyToad.PdfPig.Writer
 {
-    using System;
-    using System.Collections.Generic;
     using System.IO;
     using Tokens;
 

--- a/src/UglyToad.PdfPig/Writer/PdfDocumentBuilder.cs
+++ b/src/UglyToad.PdfPig/Writer/PdfDocumentBuilder.cs
@@ -1,8 +1,6 @@
 ﻿
 namespace UglyToad.PdfPig.Writer
 {
-    using System;
-    using System.Collections.Generic;
     using System.IO;
     using System.Linq;
     using System.Runtime.CompilerServices;

--- a/src/UglyToad.PdfPig/Writer/PdfMerger.cs
+++ b/src/UglyToad.PdfPig/Writer/PdfMerger.cs
@@ -1,7 +1,5 @@
 ﻿namespace UglyToad.PdfPig.Writer
 {
-    using System;
-    using System.Collections.Generic;
     using System.IO;
     using Filters;
     using Logging;

--- a/src/UglyToad.PdfPig/Writer/PdfPageBuilder.cs
+++ b/src/UglyToad.PdfPig/Writer/PdfPageBuilder.cs
@@ -1,7 +1,5 @@
 ﻿namespace UglyToad.PdfPig.Writer
 {
-    using System;
-    using System.Collections.Generic;
     using System.IO;
     using System.Linq;
     using Content;

--- a/src/UglyToad.PdfPig/Writer/PdfStreamWriter.cs
+++ b/src/UglyToad.PdfPig/Writer/PdfStreamWriter.cs
@@ -2,8 +2,6 @@
 {
     using Core;
     using Graphics.Operations;
-    using System;
-    using System.Collections.Generic;
     using System.Globalization;
     using System.IO;
     using Tokens;

--- a/src/UglyToad.PdfPig/Writer/PdfTextRemover.cs
+++ b/src/UglyToad.PdfPig/Writer/PdfTextRemover.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
+﻿using System.IO;
 
 namespace UglyToad.PdfPig.Writer
 {

--- a/src/UglyToad.PdfPig/Writer/TokenWriter.cs
+++ b/src/UglyToad.PdfPig/Writer/TokenWriter.cs
@@ -1,15 +1,13 @@
 ﻿namespace UglyToad.PdfPig.Writer
 {
-    using Core;
-    using Graphics.Operations;
-    using System;
     using System.Buffers;
     using System.Buffers.Text;
-    using System.Collections.Generic;
     using System.Globalization;
     using System.IO;
     using System.Linq;
     using System.Text;
+    using Core;
+    using Graphics.Operations;
     using Tokens;
     using Util;
 

--- a/src/UglyToad.PdfPig/Writer/WriterUtil.cs
+++ b/src/UglyToad.PdfPig/Writer/WriterUtil.cs
@@ -1,7 +1,5 @@
 ﻿namespace UglyToad.PdfPig.Writer
 {
-    using System;
-    using System.Collections.Generic;
     using System.Diagnostics;
     using System.Linq;
     using Content;

--- a/src/UglyToad.PdfPig/Writer/Xmp/XmpWriter.cs
+++ b/src/UglyToad.PdfPig/Writer/Xmp/XmpWriter.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
+﻿using System.Linq;
 using System.Text;
 using System.Xml.Linq;
 using UglyToad.PdfPig.Tokens;

--- a/src/UglyToad.PdfPig/XObjects/XObjectFactory.cs
+++ b/src/UglyToad.PdfPig/XObjects/XObjectFactory.cs
@@ -1,7 +1,5 @@
 ﻿namespace UglyToad.PdfPig.XObjects
 {
-    using System;
-    using System.Collections.Generic;
     using System.Linq;
     using Content;
     using Core;

--- a/src/UglyToad.PdfPig/XObjects/XObjectImage.cs
+++ b/src/UglyToad.PdfPig/XObjects/XObjectImage.cs
@@ -1,7 +1,5 @@
 ﻿namespace UglyToad.PdfPig.XObjects
 {
-    using System;
-    using System.Collections.Generic;
     using System.Diagnostics.CodeAnalysis;
     using Content;
     using Core;


### PR DESCRIPTION
This PR tidies up the using statements in the main library by:

- Importing System & System.Collections.Generic into the global scope
- Removing various unused statements
- Fixing misordered statements