### PR TITLE
[Test] Enable trimming and AOT analysis for the whole project.

### DIFF
--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -1,0 +1,6 @@
+<Project>
+  <PropertyGroup Condition="'$(IsTestProject)' != 'true'">
+    <IsTrimmable Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">true</IsTrimmable>
+    <IsAotCompatible Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">true</IsAotCompatible>
+  </PropertyGroup>
+</Project>

--- a/src/UglyToad.PdfPig.DocumentLayoutAnalysis/Export/AltoXmlTextExporter.cs
+++ b/src/UglyToad.PdfPig.DocumentLayoutAnalysis/Export/AltoXmlTextExporter.cs
@@ -95,6 +95,9 @@
         /// </summary>
         /// <param name="document">The document to extract page layouts from.</param>
         /// <param name="includePaths">Draw PdfPaths present in the page.</param>
+#if NET6_0_OR_GREATER
+        [RequiresUnreferencedCode("Members from AltoDocument may be trimmed if not referenced directly")]
+#endif
         public string Get(PdfDocument document, bool includePaths = false)
         {
             var altoDocument = CreateAltoDocument("unknown");
@@ -106,6 +109,9 @@
         /// Get the Alto (XML) string of the page layout. Excludes <see cref="T:UglyToad.PdfPig.Geometry.PdfSubpath" />s.
         /// </summary>
         /// <param name="page">The page to export the XML layout for.</param>
+#if NET6_0_OR_GREATER
+        [RequiresUnreferencedCode("Members from PageXmlDocument may be trimmed if not referenced directly")]
+#endif
         public string Get(Page page) => Get(page, false);
 
         /// <summary>
@@ -113,6 +119,9 @@
         /// </summary>
         /// <param name="page">The page to export the XML layout for.</param>
         /// <param name="includePaths">Whether the output should include the PdfPaths present in the page.</param>
+#if NET6_0_OR_GREATER
+        [RequiresUnreferencedCode("Members from AltoDocument may be trimmed if not referenced directly")]
+#endif
         public string Get(Page page, bool includePaths)
         {
             var document = CreateAltoDocument("unknown");
@@ -356,6 +365,9 @@
             };
         }
 
+#if NET6_0_OR_GREATER
+        [RequiresUnreferencedCode("Members from AltoDocument may be trimmed if not referenced directly")]
+#endif
         private string Serialize(AltoDocument altoDocument)
         {
             var serializer = new XmlSerializer(typeof(AltoDocument));

--- a/src/UglyToad.PdfPig.DocumentLayoutAnalysis/Export/AltoXmlTextExporter.cs
+++ b/src/UglyToad.PdfPig.DocumentLayoutAnalysis/Export/AltoXmlTextExporter.cs
@@ -4,6 +4,7 @@
     using Content;
     using DocumentLayoutAnalysis;
     using System;
+    using System.Diagnostics.CodeAnalysis;
     using System.Globalization;
     using System.Linq;
     using System.Xml;
@@ -377,6 +378,9 @@
         /// <summary>
         /// Deserialize an <see cref="AltoDocument"/> from a given Alto format XML document.
         /// </summary>
+#if NET6_0_OR_GREATER
+        [RequiresUnreferencedCode("Members from AltoDocument may be trimmed if not referenced directly")]
+#endif
         public static AltoDocument Deserialize(string xmlPath)
         {
             var serializer = new XmlSerializer(typeof(AltoDocument));

--- a/src/UglyToad.PdfPig.DocumentLayoutAnalysis/Export/PageXmlTextExporter.cs
+++ b/src/UglyToad.PdfPig.DocumentLayoutAnalysis/Export/PageXmlTextExporter.cs
@@ -10,6 +10,7 @@
     using ReadingOrderDetector;
     using System;
     using System.Collections.Generic;
+    using System.Diagnostics.CodeAnalysis;
     using System.Linq;
     using System.Xml;
     using System.Xml.Serialization;
@@ -105,6 +106,9 @@
         /// Get the PAGE-XML (XML) string of the pages layout. Excludes PdfPaths.
         /// </summary>
         /// <param name="page"></param>
+#if NET6_0_OR_GREATER
+        [RequiresUnreferencedCode("Members from PageXmlDocument may be trimmed if not referenced directly")]
+#endif
         public string Get(Page page)
         {
             return Get(page, false);
@@ -115,6 +119,9 @@
         /// </summary>
         /// <param name="page"></param>
         /// <param name="includePaths">Draw PdfPaths present in the page.</param>
+#if NET6_0_OR_GREATER
+        [RequiresUnreferencedCode("Members from PageXmlDocument may be trimmed if not referenced directly")]
+#endif
         public string Get(Page page, bool includePaths)
         {
             PageXmlData data = new PageXmlData();
@@ -373,6 +380,9 @@
             };
         }
 
+#if NET6_0_OR_GREATER
+        [RequiresUnreferencedCode("Members from PageXmlDocument may be trimmed if not referenced directly")]
+#endif
         private string Serialize(PageXmlDocument pageXmlDocument)
         {
             XmlSerializer serializer = new XmlSerializer(typeof(PageXmlDocument));
@@ -395,6 +405,9 @@
         /// <summary>
         /// Deserialize an <see cref="PageXmlDocument"/> from a given PAGE format XML document.
         /// </summary>
+#if NET6_0_OR_GREATER
+        [RequiresUnreferencedCode("Members from PageXmlDocument may be trimmed if not referenced directly")]
+#endif
         public static PageXmlDocument Deserialize(string xmlPath)
         {
             XmlSerializer serializer = new XmlSerializer(typeof(PageXmlDocument));

--- a/src/UglyToad.PdfPig.sln
+++ b/src/UglyToad.PdfPig.sln
@@ -10,6 +10,7 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{C55738D2-3165-4D03-9CE2-10A2E2EEC465}"
 	ProjectSection(SolutionItems) = preProject
 		.editorconfig = .editorconfig
+		Directory.Build.targets = Directory.Build.targets
 	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "UglyToad.PdfPig.Fonts", "UglyToad.PdfPig.Fonts\UglyToad.PdfPig.Fonts.csproj", "{BBC8F94C-6E94-43FF-AB2E-47FF3C2B999F}"


### PR DESCRIPTION
Enable both trimming and AOT analysis for the whole solution, to see if it finds any more possible issues on top of the ReflectionStateGraphicsFactory situaiton.

Running it locally, I get this set of additional warnings:

![image](https://github.com/UglyToad/PdfPig/assets/1178570/7f926629-500d-4873-a7d5-ae6ebeaf7ded)

I'm not sure If those can all be fixed inside the library, or if it might need the functions to be attributed so that the issues get reported to external callers (I haven't looked at it in any more details than this)