### PR TITLE
Use a fixed list of operations in ReflectionGraphicsStateOperationFac…

### DIFF
--- a/src/UglyToad.PdfPig.Tests/Graphics/Operations/GraphicsStateOperationTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Graphics/Operations/GraphicsStateOperationTests.cs
@@ -4,6 +4,7 @@
     using PdfPig.Graphics.Operations;
     using PdfPig.Graphics.Operations.InlineImages;
     using PdfPig.Tokens;
+    using UglyToad.PdfPig.Graphics;
 
     public class GraphicsStateOperationTests
     {
@@ -61,6 +62,26 @@
                     operation.Write(memoryStream);
                 }
             }
+        }
+
+        // Test that ReflectionGraphicsStateOperationFactory.operations contains all supported graphics operations
+        [Fact]
+        public void ReflectionGraphicsStateOperationFactoryKnowsAllOperations()
+        {
+            var operationsField = typeof(ReflectionGraphicsStateOperationFactory).GetField("operations", BindingFlags.NonPublic | BindingFlags.Static);
+            var operationDictionary = operationsField.GetValue(null) as IReadOnlyDictionary<string, Type>;
+            Assert.NotNull(operationDictionary);
+
+            var allOperations = GetOperationTypes();
+            Assert.Equal(allOperations.Count(), operationDictionary.Count);
+
+            var mapped = allOperations.Select(o =>
+            {
+                var symbol = o.GetField("Symbol").GetValue(null)!.ToString()!;
+                return new KeyValuePair<string, Type>(symbol, o);
+            });
+
+            Assert.Equivalent(operationDictionary, mapped, strict: true);
         }
 
         private static IEnumerable<Type> GetOperationTypes()


### PR DESCRIPTION
…tory rather than searching via reflection.

The simple approach discussed in #790 , to just use a fix list of operations rather than doing anything clever.

It's a draft for comments, and because we might be able to add tests to ```GraphicsStateOperationTests``` to compare the fixed list with all the types it finds via ```GetOperationTypes()```