### PR TITLE
Update Github actions in the CI build

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@master
 
       - name: Set up dotnet core
-        uses: actions/setup-dotnet@v2
+        uses: actions/setup-dotnet@v4
         with:
           dotnet-version: | 
             2.1.x
@@ -21,7 +21,7 @@ jobs:
             8.0.x
 
       - name: Add msbuild to PATH
-        uses: microsoft/setup-msbuild@v1.0.2
+        uses: microsoft/setup-msbuild@v2
 
       # Build the release build
       - name: Build the solution


### PR DESCRIPTION
Just an attempt to sort these deprecation warnings in the CI builds:

![image](https://github.com/UglyToad/PdfPig/assets/1178570/bdc4def9-d1a9-4969-9af1-84c3671f516e)
