### PR TITLE
Conditionalize the formatter based serialization bits in InvalidFontF…

### DIFF
--- a/src/UglyToad.PdfPig.Fonts/InvalidFontFormatException.cs
+++ b/src/UglyToad.PdfPig.Fonts/InvalidFontFormatException.cs
@@ -1,14 +1,18 @@
 ﻿namespace UglyToad.PdfPig.Fonts
 {
     using System;
+#if !NET
     using System.Runtime.Serialization;
+#endif
 
     /// <summary>
     /// The exception thrown when an error is encountered parsing a font from the PDF document.
     /// This occurs where the format of the font program or dictionary does not meet the specification.
     /// </summary>
     /// <inheritdoc cref="Exception"/>
+#if !NET
     [Serializable]
+#endif
     public class InvalidFontFormatException : Exception
     {
         /// <inheritdoc />
@@ -26,11 +30,13 @@
         {
         }
 
+#if !NET
         /// <inheritdoc />
         protected InvalidFontFormatException(
             SerializationInfo info,
             StreamingContext context) : base(info, context)
         {
         }
+#endif
     }
 }


### PR DESCRIPTION
…ormatException

I was getting warnings about this when building #832 and I notice that the other custom exceptions have been updated to only include the ```Serializable``` bits when ```!NET``` - is there a reason for this one to be different?