### PR TITLE
Update the dependencies in UglyToad.PdfPig.Package

### DIFF
--- a/tools/UglyToad.PdfPig.Package/UglyToad.PdfPig.Package.csproj
+++ b/tools/UglyToad.PdfPig.Package/UglyToad.PdfPig.Package.csproj
@@ -28,8 +28,12 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <WarningsAsErrors />
   </PropertyGroup>
-  <ItemGroup Condition="'$(TargetFramework)'=='net451' OR '$(TargetFramework)'=='net452' OR '$(TargetFramework)'=='net46' OR '$(TargetFramework)'=='net461' OR '$(TargetFramework)'=='net462' OR '$(TargetFramework)'=='net47'">
+  <ItemGroup Condition="'$(TargetFramework)'=='net462'">
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)'=='net462' OR '$(TargetFramework)'=='net471' OR '$(TargetFramework)'=='netstandard2.0'">
+    <PackageReference Include="Microsoft.Bcl.HashCode" Version="1.1.1" />
+    <PackageReference Include="System.Memory" Version="4.5.5" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\UglyToad.PdfPig.Core\UglyToad.PdfPig.Core.csproj" PrivateAssets="all" />


### PR DESCRIPTION
As it stands, the nightly build doesn't have any other deps than System.ValueTuple:

![image](https://github.com/UglyToad/PdfPig/assets/1178570/1f92b47f-6568-4535-95c3-7b28e119b376)

If I try to use that from a brand new / clean .NET Framework 4.7.1 project, I get this error:

![image](https://github.com/UglyToad/PdfPig/assets/1178570/50703bcc-f2a7-4f0c-8c6a-d7f2c477c767)

So - I think the NuGet package should have a reference to System.Memory on TFMs other than .NET6/8 ?

Edit - Looks like it needs Microsoft.Bcl.HashCode as well