### PR TITLE
Improve TryReadStream with simplification & fix of Stream Invalid Length cutting off Streams

### DIFF
--- a/src/UglyToad.PdfPig/Tokenization/Scanner/PdfTokenScanner.cs
+++ b/src/UglyToad.PdfPig/Tokenization/Scanner/PdfTokenScanner.cs
@@ -446,14 +446,14 @@
                 dataLength -= 2;
             }
 
-            Span<byte> data = new byte[dataLength];
+            Memory<byte> data = new byte[dataLength];
 
             inputBytes.Seek(streamDataStart);
-            inputBytes.Read(data);
+            inputBytes.Read(data.Span);
 
             inputBytes.Seek(streamDataEnd);
 
-            stream = new StreamToken(streamDictionaryToken, data.ToArray());
+            stream = new StreamToken(streamDictionaryToken, data);
 
             return true;
         }


### PR DESCRIPTION
- Fix of Stream invalid Length issue causing stream data being cut off: fix https://github.com/UglyToad/PdfPig/issues/809

- Improve Stream Token read performance by:
  -  simplifying TryReadStream(), avoiding use of MemoryStream, with benefice of already existing Memory Span of "inputBytes"
  - removing the unecessary List<>