### PR TITLE
Further performance improvements in DocstrumBoundingBoxes

### DIFF
--- a/src/UglyToad.PdfPig.DocumentLayoutAnalysis/PageSegmenter/DocstrumBoundingBoxes.cs
+++ b/src/UglyToad.PdfPig.DocumentLayoutAnalysis/PageSegmenter/DocstrumBoundingBoxes.cs
@@ -467,6 +467,19 @@
             }
 
             // Get middle points
+
+#if NET6_0_OR_GREATER
+            Span<PdfPoint> ps = stackalloc PdfPoint[] { j.Point1, j.Point2, Aj.Value, Bj.Value };
+
+            if (dXj != 0)
+            {
+                ps.Sort(PdfPointXYComparer.Instance);
+            }
+            else if (dYj != 0)
+            {
+                ps.Sort(PdfPointYComparer.Instance);
+            }
+#else
             PdfPoint[] ps = [j.Point1, j.Point2, Aj.Value, Bj.Value];
 
             if (dXj != 0)
@@ -477,6 +490,7 @@
             {
                 Array.Sort(ps, PdfPointYComparer.Instance);
             }
+#endif
 
             PdfPoint Cj = ps[1];
             PdfPoint Dj = ps[2];


### PR DESCRIPTION
As a side note, we should aim not create an array and sort it at all. This is doable as there are only 4 points to compare