### PR TITLE
Restore checking for correct image size in PngFromPdfImageFactory

### DIFF
--- a/src/UglyToad.PdfPig/Images/Png/PngFromPdfImageFactory.cs
+++ b/src/UglyToad.PdfPig/Images/Png/PngFromPdfImageFactory.cs
@@ -46,6 +46,11 @@
                         bytesPure[actualSize - 2] == ReadHelper.AsciiCarriageReturn &&
                         bytesPure[actualSize - 1] == ReadHelper.AsciiLineFeed);
 
+                if (!isCorrectlySized)
+                {
+                    return false;
+                }
+
                 if (image.ColorSpaceDetails.BaseType == ColorSpace.DeviceCMYK || numberOfComponents == 4)
                 {
                     int i = 0;


### PR DESCRIPTION
I don't see any reason why we would not check for that anymore. I missed it while reviewing https://github.com/UglyToad/PdfPig/commit/6d54355754a6778267ad4ba820cd0ceb74473988