### PR TITLE
Simplify PdfRectangle width and height computation and fix tests

### DIFF
--- a/src/UglyToad.PdfPig.Tests/Core/PdfSubpathTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Core/PdfSubpathTests.cs
@@ -4,8 +4,8 @@
 
     public class PdfSubpathTests
     {
-        private static readonly DoubleComparer DoubleComparer = new DoubleComparer(3);
-        private static readonly DoubleComparer PreciseDoubleComparer = new DoubleComparer(6);
+        private static readonly DoubleComparer DoubleComparer = new DoubleComparer(0.001);
+        private static readonly DoubleComparer PreciseDoubleComparer = new DoubleComparer(0.000001);
         private static readonly PointComparer PointComparer = new PointComparer(DoubleComparer);
 
         #region data

--- a/src/UglyToad.PdfPig.Tests/Dla/DistancesTest.cs
+++ b/src/UglyToad.PdfPig.Tests/Dla/DistancesTest.cs
@@ -5,8 +5,8 @@
 
     public class DistancesTest
     {
-        private static readonly DoubleComparer DoubleComparer = new DoubleComparer(3);
-        private static readonly DoubleComparer PreciseDoubleComparer = new DoubleComparer(6);
+        private static readonly DoubleComparer DoubleComparer = new DoubleComparer(0.001);
+        private static readonly DoubleComparer PreciseDoubleComparer = new DoubleComparer(0.000001);
         private static readonly PointComparer PointComparer = new PointComparer(DoubleComparer);
 
         #region data

--- a/src/UglyToad.PdfPig.Tests/Dla/KdTreeTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Dla/KdTreeTests.cs
@@ -5,8 +5,8 @@
 
     public class KdTreeTests
     {
-        private static readonly DoubleComparer DoubleComparer = new DoubleComparer(3);
-        private static readonly DoubleComparer PreciseDoubleComparer = new DoubleComparer(6);
+        private static readonly DoubleComparer DoubleComparer = new DoubleComparer(0.001);
+        private static readonly DoubleComparer PreciseDoubleComparer = new DoubleComparer(0.000001);
         private static readonly PointComparer PointComparer = new PointComparer(DoubleComparer);
 
         #region data

--- a/src/UglyToad.PdfPig.Tests/Dla/MathExtensionsTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Dla/MathExtensionsTests.cs
@@ -4,8 +4,8 @@
  
     public class MathExtensionsTests
     {
-        private static readonly DoubleComparer DoubleComparer = new DoubleComparer(3);
-        private static readonly DoubleComparer PreciseDoubleComparer = new DoubleComparer(6);
+        private static readonly DoubleComparer DoubleComparer = new DoubleComparer(0.001);
+        private static readonly DoubleComparer PreciseDoubleComparer = new DoubleComparer(0.000001);
         private static readonly PointComparer PointComparer = new PointComparer(DoubleComparer);
 
         #region data

--- a/src/UglyToad.PdfPig.Tests/Fonts/SystemFonts/Linux.cs
+++ b/src/UglyToad.PdfPig.Tests/Fonts/SystemFonts/Linux.cs
@@ -64,10 +64,10 @@ namespace UglyToad.PdfPig.Tests.Fonts.SystemFonts
 
                     var current = page.Letters[i];
 
-                    Assert.Equal(expectedData.TopLeft.X, current.GlyphRectangle.TopLeft.X, 7);
-                    Assert.Equal(expectedData.TopLeft.Y, current.GlyphRectangle.TopLeft.Y, 7);
-                    Assert.Equal(expectedData.Width, current.GlyphRectangle.Width, 7);
-                    Assert.Equal(expectedData.Height, current.GlyphRectangle.Height, 7);
+                    Assert.Equal(expectedData.TopLeft.X, current.GlyphRectangle.TopLeft.X, 6);
+                    Assert.Equal(expectedData.TopLeft.Y, current.GlyphRectangle.TopLeft.Y, 6);
+                    Assert.Equal(expectedData.Width, current.GlyphRectangle.Width, 6);
+                    Assert.Equal(expectedData.Height, current.GlyphRectangle.Height, 6);
                     Assert.Equal(expectedData.Rotation, current.GlyphRectangle.Rotation, 3);
                 }
             }

--- a/src/UglyToad.PdfPig.Tests/Fonts/TrueType/Parser/TrueTypeFontParserTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Fonts/TrueType/Parser/TrueTypeFontParserTests.cs
@@ -142,7 +142,7 @@ namespace UglyToad.PdfPig.Tests.Fonts.TrueType.Parser
 
             Assert.Equal("Andada Regular", name);
 
-            Assert.Equal(1.001999, font.TableRegister.HeaderTable.Revision, new DoubleComparer(5));
+            Assert.Equal(1.001999, font.TableRegister.HeaderTable.Revision, new DoubleComparer(0.00001));
 
             Assert.Equal(11, font.TableRegister.HeaderTable.Flags);
 

--- a/src/UglyToad.PdfPig.Tests/Fonts/Type1/Type1CharStringParserTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Fonts/Type1/Type1CharStringParserTests.cs
@@ -8,7 +8,7 @@
         [Fact]
         public void CorrectBoundingBoxesFlexPoints()
         {
-            var pointComparer = new PointComparer(new DoubleComparer(3));
+            var pointComparer = new PointComparer(new DoubleComparer(0.001));
 
             var filePath = IntegrationHelpers.GetDocumentPath("data.pdf");
 

--- a/src/UglyToad.PdfPig.Tests/Geometry/BezierCurveTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Geometry/BezierCurveTests.cs
@@ -6,8 +6,8 @@
 
     public class CubicBezierCurveTests
     {
-        private static readonly DoubleComparer DoubleComparer = new DoubleComparer(3);
-        private static readonly DoubleComparer PreciseDoubleComparer = new DoubleComparer(6);
+        private static readonly DoubleComparer DoubleComparer = new DoubleComparer(0.001);
+        private static readonly DoubleComparer PreciseDoubleComparer = new DoubleComparer(0.000001);
         private static readonly PointComparer PointComparer = new PointComparer(DoubleComparer);
 
         #region data

--- a/src/UglyToad.PdfPig.Tests/Geometry/PdfLineTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Geometry/PdfLineTests.cs
@@ -5,8 +5,8 @@
 
     public class PdfLineTests
     {
-        private static readonly DoubleComparer DoubleComparer = new DoubleComparer(3);
-        private static readonly DoubleComparer PreciseDoubleComparer = new DoubleComparer(6);
+        private static readonly DoubleComparer DoubleComparer = new DoubleComparer(0.001);
+        private static readonly DoubleComparer PreciseDoubleComparer = new DoubleComparer(0.000001);
         private static readonly PointComparer PointComparer = new PointComparer(DoubleComparer);
 
         #region data

--- a/src/UglyToad.PdfPig.Tests/Geometry/PdfPointTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Geometry/PdfPointTests.cs
@@ -5,8 +5,8 @@
 
     public class PdfPointTests
     {
-        private static readonly DoubleComparer DoubleComparer = new DoubleComparer(3);
-        private static readonly DoubleComparer PreciseDoubleComparer = new DoubleComparer(6);
+        private static readonly DoubleComparer DoubleComparer = new DoubleComparer(0.001);
+        private static readonly DoubleComparer PreciseDoubleComparer = new DoubleComparer(0.000001);
         private static readonly PointComparer PointComparer = new PointComparer(DoubleComparer);
 
         #region data

--- a/src/UglyToad.PdfPig.Tests/Geometry/PdfRectangleTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Geometry/PdfRectangleTests.cs
@@ -3,12 +3,11 @@
     using Content;
     using PdfPig.Geometry;
     using PdfPig.Core;
-    using System.Drawing;
 
     public class PdfRectangleTests
     {
-        private static readonly DoubleComparer DoubleComparer = new DoubleComparer(3);
-        private static readonly DoubleComparer PreciseDoubleComparer = new DoubleComparer(6);
+        private static readonly DoubleComparer DoubleComparer = new DoubleComparer(0.001);
+        private static readonly DoubleComparer PreciseDoubleComparer = new DoubleComparer(0.000001);
         private static readonly PointComparer PointComparer = new PointComparer(DoubleComparer);
         private static readonly PdfRectangle UnitRectangle = new PdfRectangle(new PdfPoint(0, 0), new PdfPoint(1, 1));
 
@@ -1460,6 +1459,11 @@
                     new PdfPoint(79.72935886126837, 162.40175959739133),
                     new PdfPoint(36.31110596050322, 137.33421959739135),
                     new PdfPoint(61.57811596050321, 93.57047452204044)
+                },
+                new double[]
+                {
+                    50.135079999999988, // width
+                    50.53402 // height
                 }
             },
             new object[]
@@ -1475,6 +1479,11 @@
                     new PdfPoint(355.93382538513987, -509.2927859424674),
                     new PdfPoint(291.2932316380764, -201.33455131845915),
                     new PdfPoint(123.95226520870021, -236.45950727688313)
+                },
+                new double[]
+                {
+                    314.66916060000005,
+                    170.98760649999997
                 }
             },
             new object[]
@@ -1490,6 +1499,11 @@
                     new PdfPoint(748.3932365836752, 221.98391118471883),
                     new PdfPoint(-70.46470122718794, 247.50297212341658),
                     new PdfPoint(-79.61250178788342, -46.03248047926875)
+                },
+                new double[]
+                {
+                    819.255482,
+                    293.67796
                 }
             },
             new object[]
@@ -1505,6 +1519,11 @@
                     new PdfPoint(-62.47760759065051, 323.00991498515555),
                     new PdfPoint(227.9582036948802, 613.4457262706862),
                     new PdfPoint(-120.22754499429334, 961.6314749598598)
+                },
+                new double[]
+                {
+                    410.73826331883026,
+                    492.4090080212593
                 }
             },
             new object[]
@@ -1520,6 +1539,11 @@
                     new PdfPoint(956.4918489990248, 290.16467735562713),
                     new PdfPoint(1243.8589223186318, 2.797604036020175),
                     new PdfPoint(1163.8416408097196, -77.21967747289204)
+                },
+                new double[]
+                {
+                    406.39841246805167,
+                    113.16152473412956
                 }
             }
         };
@@ -1646,7 +1670,7 @@
             Assert.Equal(new PdfPoint(-1, 1), rotated.TopRight);
 
             Assert.Equal(1, rotated.Width, PreciseDoubleComparer);
-            Assert.Equal(-1, rotated.Height, PreciseDoubleComparer);
+            Assert.Equal(1, rotated.Height, PreciseDoubleComparer);
             Assert.Equal(90, rotated.Rotation, PreciseDoubleComparer);
         }
 
@@ -1662,20 +1686,28 @@
             Assert.Equal(new PdfPoint(0, -1), rotated.TopLeft);
             Assert.Equal(new PdfPoint(-1, -1), rotated.TopRight);
 
-            Assert.Equal(-1, rotated.Width, PreciseDoubleComparer);
-            Assert.Equal(-1, rotated.Height, PreciseDoubleComparer);
+            Assert.Equal(1, rotated.Width, PreciseDoubleComparer);
+            Assert.Equal(1, rotated.Height, PreciseDoubleComparer);
             Assert.Equal(180, rotated.Rotation, PreciseDoubleComparer);
         }
 
         [Theory]
         [MemberData(nameof(RotateData))]
-        public void Rotate(double[][] data, PdfPoint[] expected)
+        public void Rotate(double[][] data, PdfPoint[] expected, double[] expectedSize)
         {
             var points = data[0];
             var angle = data[1][0];
 
+            double width = expectedSize[0];
+            double height = expectedSize[1];
+
             var rect = new PdfRectangle(points[0], points[1], points[2], points[3]);
+            Assert.Equal(width, rect.Width, PreciseDoubleComparer);
+            Assert.Equal(height, rect.Height, PreciseDoubleComparer);
+
             var rectR = TransformationMatrix.GetRotationMatrix(angle).Transform(rect);
+            Assert.Equal(width, rectR.Width, PreciseDoubleComparer);
+            Assert.Equal(height, rectR.Height, PreciseDoubleComparer);
 
             Assert.Equal(expected[0], rectR.BottomRight, PointComparer);
             Assert.Equal(expected[1], rectR.TopRight, PointComparer);

--- a/src/UglyToad.PdfPig.Tests/Geometry/PdfSubpathLineTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Geometry/PdfSubpathLineTests.cs
@@ -6,8 +6,8 @@
 
     public class PdfSubpathLineTests
     {
-        private static readonly DoubleComparer DoubleComparer = new DoubleComparer(3);
-        private static readonly DoubleComparer PreciseDoubleComparer = new DoubleComparer(6);
+        private static readonly DoubleComparer DoubleComparer = new DoubleComparer(0.001);
+        private static readonly DoubleComparer PreciseDoubleComparer = new DoubleComparer(0.000001);
         private static readonly PointComparer PointComparer = new PointComparer(DoubleComparer);
 
         private static Line CreateLine(double x1, double y1, double x2, double y2)

--- a/src/UglyToad.PdfPig.Tests/Integration/SinglePageLibreOfficeImages.cs
+++ b/src/UglyToad.PdfPig.Tests/Integration/SinglePageLibreOfficeImages.cs
@@ -20,7 +20,7 @@
         [Fact]
         public void ImagesHaveCorrectDimensionsAndLocations()
         {
-            var doubleComparer = new DoubleComparer(1);
+            var doubleComparer = new DoubleComparer(0.1);
 
             using (var document = PdfDocument.Open(GetFilePath(), ParsingOptions.LenientParsingOff))
             {


### PR DESCRIPTION
- Simplify PdfRectangle width and height computation (not sure why I did not use this simple method in the first place)
- Fix DoubleComparer precision in tests (we need to pass the actual precision, not the decimal place)