### PR TITLE
Fix parsing of hexadecimal strings with odd number of characters

### DIFF
--- a/src/UglyToad.PdfPig.Tests/Tokens/HexTokenTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Tokens/HexTokenTests.cs
@@ -9,6 +9,8 @@
         [InlineData("61", "a")]
         [InlineData("0061", "a")]
         [InlineData("7465787420736f", "text so")]
+        [InlineData("6170", "ap")]
+        [InlineData("617", "ap")]
         public void MapsCorrectlyToString(string input, string expected)
         {
             var token = new HexToken(input.ToCharArray());

--- a/src/UglyToad.PdfPig.Tokens/HexToken.cs
+++ b/src/UglyToad.PdfPig.Tokens/HexToken.cs
@@ -63,7 +63,10 @@ namespace UglyToad.PdfPig.Tokens
                 throw new ArgumentNullException(nameof(characters));
             }
 
-            var bytes = new byte[characters.Length / 2];
+            // if the final character is missing, it is considered to be a 0, as per 7.3.4.3
+            // adding 1 to the characters array length ensure the size of the byte array is correct
+            // in all situations
+            var bytes = new byte[(characters.Length+1) / 2];
             int index = 0;
 
             for (var i = 0; i < characters.Length; i += 2)


### PR DESCRIPTION
Should fix #889 