### PR TITLE
net80: Support decrypting AES data where only IV is present

### DIFF
--- a/src/UglyToad.PdfPig.Tests/Integration/EncryptedDocumentTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Integration/EncryptedDocumentTests.cs
@@ -53,6 +53,15 @@
                 Assert.NotNull(document.Information.Producer);
             }
         }
+        
+        [Fact]
+        public void CanReadDocumentWithEmptyStringEncryptedWithAESEncryptionAndOnlyIV()
+        {
+            using (var document = PdfDocument.Open(IntegrationHelpers.GetSpecificTestDocumentPath("r4_aes_empty_string.pdf")))
+            {
+                Assert.Empty(document.Information.Producer);
+            }
+        }
 
         private static string GetPath() => IntegrationHelpers.GetSpecificTestDocumentPath(FileName);
     }

--- a/src/UglyToad.PdfPig.Tests/Integration/SpecificTestDocuments/r4_aes_empty_string.pdf
+++ b/src/UglyToad.PdfPig.Tests/Integration/SpecificTestDocuments/r4_aes_empty_string.pdf
@@ -1,0 +1,37 @@
+%PDF-1.6
+%����
+1 0 obj
+<< /Pages 3 0 R /Type /Catalog >>
+endobj
+2 0 obj
+<< /Producer <03bc09515c7aad3ceab79dbea68b7802> >>
+endobj
+3 0 obj
+<< /Count 1 /Kids [ 4 0 R ] /MediaBox [ 0 0 595 792 ] /Type /Pages >>
+endobj
+4 0 obj
+<< /Contents 5 0 R /Parent 3 0 R /Resources << >> /Type /Page >>
+endobj
+5 0 obj
+<< /Length 96 /Filter /FlateDecode >>
+stream
+TnH,έۻy�P0��oX̡��xbh���v��� ����
+�
+&j����D�+?���╠���k|l��BI����GT���˵st���`ʃendstream
+endobj
+6 0 obj
+<< /CF << /StdCF << /AuthEvent /DocOpen /CFM /AESV2 /Length 16 >> >> /Filter /Standard /Length 128 /O <566fa873ee33c797cd3b904fdadf814afa34df9a38f6ed41b984e2c6da2aa6f5> /P -4 /R 4 /StmF /StdCF /StrF /StdCF /U <5b93af90588464e45bf20276ec6af5a10122456a91bae5134273a6db134c87c4> /V 4 >>
+endobj
+xref
+0 7
+0000000000 65535 f 
+0000000023 00000 n 
+0000000072 00000 n 
+0000000138 00000 n 
+0000000223 00000 n 
+0000000303 00000 n 
+0000000544 00000 n 
+trailer << /Info 2 0 R /Root 1 0 R /Size 7 /ID [<5f94b739445b583b745423be6658e8fb><5f94b739445b583b745423be6658e8fb>] /Encrypt 6 0 R >>
+startxref
+843
+%%EOF

--- a/src/UglyToad.PdfPig/Encryption/AesEncryptionHelper.cs
+++ b/src/UglyToad.PdfPig/Encryption/AesEncryptionHelper.cs
@@ -27,7 +27,12 @@
                 aes.IV = iv;
 
 #if NET8_0_OR_GREATER
-                return aes.DecryptCbc(data.AsSpan(iv.Length), iv, PaddingMode.PKCS7);
+                var encryptedData = data.AsSpan(iv.Length);
+                if (encryptedData.IsEmpty)
+                {
+                    return [];
+                }
+                return aes.DecryptCbc(encryptedData, iv, PaddingMode.PKCS7);
 #else
                 var buffer = new byte[256];
 


### PR DESCRIPTION
Should fix #891 