### PR TITLE
Allow rebuilding object offsets when objects do not have endobj token

### DIFF
--- a/src/UglyToad.PdfPig.Tests/Parser/Parts/BruteForceSearcherTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Parser/Parts/BruteForceSearcherTests.cs
@@ -233,6 +233,41 @@ endobj";
             Assert.Equal(TestDataOffsets, locations.Values);
         }
 
+        [Fact]
+        public void BruteForceSearcherFindsAllObjectsWhenMissingEndObj()
+        {
+            const string s = @"%PDF-1.7
+abcd
+
+1 0 obj
+<< /Type /Any >>
+
+2 0 obj
+<< /Type /Any >>
+
+%AZ 0 obj
+11 0 obj
+769
+endobj
+
+%%EOF";
+
+            var bytes = new MemoryInputBytes(OtherEncodings.StringAsLatin1Bytes(s));
+
+            var locations = BruteForceSearcher.GetObjectLocations(bytes);
+
+            Assert.Equal(3, locations.Count);
+
+            var expectedLocations = new long[]
+            {
+                s.IndexOf("1 0 obj", StringComparison.OrdinalIgnoreCase),
+                s.IndexOf("2 0 obj", StringComparison.OrdinalIgnoreCase),
+                s.IndexOf("11 0 obj", StringComparison.OrdinalIgnoreCase)
+            };
+
+            Assert.Equal(expectedLocations, locations.Values);
+        }
+
         private static string GetStringAt(IInputBytes bytes, long location)
         {
             bytes.Seek(location);

--- a/src/UglyToad.PdfPig/Parser/Parts/BruteForceSearcher.cs
+++ b/src/UglyToad.PdfPig/Parser/Parts/BruteForceSearcher.cs
@@ -156,7 +156,7 @@
 
                 currentlyInObject = true;
 
-                currentOffset++;
+                currentOffset += objBuffer.Length;
 
                 bytes.Seek(currentOffset);
                 loopProtection = 0;

--- a/src/UglyToad.PdfPig/Parser/Parts/BruteForceSearcher.cs
+++ b/src/UglyToad.PdfPig/Parser/Parts/BruteForceSearcher.cs
@@ -82,6 +82,31 @@
                             currentOffset++;
                         }
                     }
+                    else if (ReadHelper.IsWhitespace(bytes.CurrentByte))
+                    {
+                        var next = bytes.Peek();
+                        if (next.HasValue && next.Value == 'o')
+                        {
+                            if (ReadHelper.IsString(bytes, " obj"))
+                            {
+                                currentlyInObject = false;
+                                currentOffset--;
+                                loopProtection = 0;
+                            }
+                            else
+                            {
+                                bytes.MoveNext();
+                                currentOffset++;
+                                loopProtection = 0;
+                            }
+                        }
+                        else
+                        {
+                            bytes.MoveNext();
+                            currentOffset++;
+                            loopProtection = 0;
+                        }
+                    }
                     else
                     {
                         bytes.MoveNext();


### PR DESCRIPTION
Should fix #893