### PR TITLE
Remove list from FileTrailerParser.GetStartXrefPosition()

### DIFF
--- a/src/UglyToad.PdfPig/Parser/FileStructure/FileTrailerParser.cs
+++ b/src/UglyToad.PdfPig/Parser/FileStructure/FileTrailerParser.cs
@@ -78,7 +78,8 @@
 
         private static long GetStartXrefPosition(IInputBytes bytes, int offsetFromEnd)
         {
-            var startXrefs = new List<int>();
+            int startXref = 0;
+            int startXrefsCount = 0;
 
             var index = 0;
 
@@ -106,8 +107,9 @@
 
                     if (index == StartXRefBytes.Length)
                     {
-                        // Add this "startxref" (position from the start of the document to the first 's').
-                        startXrefs.Add((int)bytes.CurrentOffset - StartXRefBytes.Length);
+                        // Set this "startxref" (position from the start of the document to the first 's').
+                        startXref = (int)bytes.CurrentOffset - StartXRefBytes.Length;
+                        startXrefsCount++;
 
                         // Continue scanning in case there are further "startxref"s. Not sure if this ever happens.
                         index = 0;
@@ -115,14 +117,14 @@
                 }
 
                 actualStartOffset = Math.Max(0, fileLength - (offsetFromEnd * multiple));
-            } while (startXrefs.Count == 0 && actualStartOffset > 0);
-            
-            if (startXrefs.Count == 0)
+            } while (startXrefsCount == 0 && actualStartOffset > 0);
+
+            if (startXrefsCount == 0)
             {
                 throw new PdfDocumentFormatException($"Could not find the startxref within the last {offsetFromEnd} characters.");
             }
 
-            return startXrefs[startXrefs.Count - 1];
+            return startXref;
         }
     }
 }


### PR DESCRIPTION
The logic here can be simplified and we do not need the list anymore