### PR TITLE
Default page number to 0 in ExplicitDestination when the Dest has no page number and fix #736

### DIFF
--- a/src/UglyToad.PdfPig.Tests/Integration/GithubIssuesTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Integration/GithubIssuesTests.cs
@@ -5,6 +5,19 @@
     public class GithubIssuesTests
     {
         [Fact]
+        public void Issue736()
+        {
+            var doc = IntegrationHelpers.GetDocumentPath("Approved_Document_B__fire_safety__volume_2_-_Buildings_other_than_dwellings__2019_edition_incorporating_2020_and_2022_amendments.pdf");
+
+            using (var document = PdfDocument.Open(doc, new ParsingOptions() { UseLenientParsing = true, SkipMissingFonts = true }))
+            {
+                Assert.True(document.TryGetBookmarks(out var bookmarks));
+                Assert.Single(bookmarks.Roots);
+                Assert.Equal(36, bookmarks.Roots[0].Children.Count);
+            }
+        }
+
+        [Fact]
         public void Issue693()
         {
             var doc = IntegrationHelpers.GetDocumentPath("reference-2-numeric-error.pdf");

--- a/src/UglyToad.PdfPig/Outline/Destinations/ExplicitDestination.cs
+++ b/src/UglyToad.PdfPig/Outline/Destinations/ExplicitDestination.cs
@@ -7,6 +7,7 @@
     {
         /// <summary>
         /// The page number (1-based) of the destination.
+        /// <para>A value of <c>0</c> means no page destination was available (i.e. an invalid explicit destination).</para>
         /// </summary>
         public int PageNumber { get; }
 

--- a/src/UglyToad.PdfPig/Outline/Destinations/NamedDestinationsProvider.cs
+++ b/src/UglyToad.PdfPig/Outline/Destinations/NamedDestinationsProvider.cs
@@ -136,11 +136,11 @@
             }
             else
             {
-                var errorMessage = $"{nameof(TryGetExplicitDestination)} No page number given in 'Dest': '{explicitDestinationArray}'.";
+                var errorMessage = $"{nameof(TryGetExplicitDestination)} No page number given in 'Dest': '{explicitDestinationArray}', defaulting to 0.";
 
                 log?.Error(errorMessage);
 
-                return false;
+                pageNumber = 0;
             }
 
             NameToken? destTypeToken = null;
@@ -148,6 +148,7 @@
             {
                 destTypeToken = explicitDestinationArray[1] as NameToken;
             }
+
             if (destTypeToken is null)
             {
                 var errorMessage = $"Missing name token as second argument to explicit destination: {explicitDestinationArray}.";


### PR DESCRIPTION
Default page number to 0 in `ExplicitDestination` when the `Dest` has no page number and fix #736 

NB: `ExplicitDestination.PageNumber` can now be 0.