### PR TITLE
Optimize cross reference object offset validation by avoiding nested loop

### DIFF
--- a/src/UglyToad.PdfPig.Core/IndirectReference.cs
+++ b/src/UglyToad.PdfPig.Core/IndirectReference.cs
@@ -6,7 +6,7 @@
     /// <summary>
     /// Used to uniquely identify and refer to objects in the PDF file.
     /// </summary>
-    public readonly struct IndirectReference
+    public readonly struct IndirectReference : IEquatable<IndirectReference>
     {
         /// <summary>
         /// A positive integer object number.
@@ -31,15 +31,15 @@
         }
 
         /// <inheritdoc />
+        public bool Equals(IndirectReference other)
+        {
+            return other.ObjectNumber == ObjectNumber && other.Generation == Generation;
+        }
+
+        /// <inheritdoc />
         public override bool Equals(object obj)
         {
-            if (obj is IndirectReference reference)
-            {
-                return reference.ObjectNumber == ObjectNumber
-                       && reference.Generation == Generation;
-            }
-
-            return false;
+            return obj is IndirectReference other && Equals(other);
         }
 
         /// <inheritdoc />

--- a/src/UglyToad.PdfPig/CrossReference/CrossReferenceTable.cs
+++ b/src/UglyToad.PdfPig/CrossReference/CrossReferenceTable.cs
@@ -49,7 +49,7 @@
             Trailer = trailer ?? throw new ArgumentNullException(nameof(trailer));
             CrossReferenceOffsets = crossReferenceOffsets ?? throw new ArgumentNullException(nameof(crossReferenceOffsets));
 
-            var result = new Dictionary<IndirectReference, long>();
+            var result = new Dictionary<IndirectReference, long>(capacity: objectOffsets.Count);
             foreach (var objectOffset in objectOffsets)
             {
                 result[objectOffset.Key] = objectOffset.Value;

--- a/src/UglyToad.PdfPig/Parser/FileStructure/CrossReferenceObjectOffsetValidator.cs
+++ b/src/UglyToad.PdfPig/Parser/FileStructure/CrossReferenceObjectOffsetValidator.cs
@@ -24,11 +24,11 @@
                 return true;
             }
 
-            var builderOffsets = new Dictionary<IndirectReference, long>();
-            
             var bruteForceOffsets = BruteForceSearcher.GetObjectLocations(bytes);
             if (bruteForceOffsets.Count > 0)
             {
+                var builderOffsets = new Dictionary<IndirectReference, long>();
+
                 // find all object streams
                 foreach (var entry in crossReferenceTable.ObjectOffsets)
                 {
@@ -39,11 +39,11 @@
                         // TODO: more validation of streams.
                         builderOffsets[entry.Key] = entry.Value;
                     }
+                }
 
-                    foreach (var item in bruteForceOffsets)
-                    {
-                        builderOffsets[item.Key] = item.Value;
-                    }
+                foreach (var item in bruteForceOffsets)
+                {
+                    builderOffsets[item.Key] = item.Value;
                 }
 
                 actualOffsets = builderOffsets;

--- a/src/UglyToad.PdfPig/Parser/FileStructure/CrossReferenceObjectOffsetValidator.cs
+++ b/src/UglyToad.PdfPig/Parser/FileStructure/CrossReferenceObjectOffsetValidator.cs
@@ -27,7 +27,8 @@
             var bruteForceOffsets = BruteForceSearcher.GetObjectLocations(bytes);
             if (bruteForceOffsets.Count > 0)
             {
-                var builderOffsets = new Dictionary<IndirectReference, long>();
+                // Pre-allocate capacity for at least the bruteForceOffsets, since we'll be adding all of them
+                var builderOffsets = new Dictionary<IndirectReference, long>(bruteForceOffsets.Count);
 
                 // find all object streams
                 foreach (var entry in crossReferenceTable.ObjectOffsets)


### PR DESCRIPTION
I've been using PdfPig for text extraction on various files.

Recently, I found 1 file which was taking ~23s to open. Profiling showed that the hotspot was:
```
Dictionary<IndirectReference, long>.TryInsert(...)
at CrossReferenceObjectOffsetValidator.ValidateCrossReferenceOffsets(...)
at CrossReferenceParser.Parse(...)
```

After the changes here, the time to open the document drops to just 3s!