### PR TITLE
New GetText() option: NegativeGapAsWhitespace

### DIFF
--- a/src/UglyToad.PdfPig.DocumentLayoutAnalysis/TextExtractor/ContentOrderTextExtractor.cs
+++ b/src/UglyToad.PdfPig.DocumentLayoutAnalysis/TextExtractor/ContentOrderTextExtractor.cs
@@ -110,6 +110,11 @@
                     {
                         var gap = letter.StartBaseLine.X - previous.EndBaseLine.X;
 
+                        if (options.NegativeGapAsWhitespace)
+                        {
+                            gap = Math.Abs(gap);
+                        }
+
                         if (WhitespaceSizeStatistics.IsProbablyWhitespace(gap, previous))
                         {
                             sb.Append(" ");
@@ -178,6 +183,13 @@
             /// character. Default <see langword="false"/>.
             /// </summary>
             public bool ReplaceWhitespaceWithSpace { get; set; }
+
+            /// <summary>
+            /// When parsing PDF files with tables containing multiple lines in a cell or "merged" cells,
+            /// the separate words can appear out of horizontal order. This option can better predict the
+            //  spaces between the words. Default <see langword="false"/>.
+            /// </summary>
+            public bool NegativeGapAsWhitespace { get; set; }
         }
     }
 }


### PR DESCRIPTION
When parsing PDF files with tables containing multiple lines in a cell or "merged" cells, the separate words can appear out of horizontal order. This option can better predict the spaces between the words.