### PR TITLE
Fix "Nightly Release" pipeline following csproj changes

### DIFF
--- a/tools/set-version.ps1
+++ b/tools/set-version.ps1
@@ -9,7 +9,7 @@ $projs = Get-ChildItem "$root/../src" -Recurse | Where-Object { $_.extension -eq
 $projs | ForEach-Object {
   $xml = New-Object XML
   $xml.Load($_.FullName)
-  $xml.Project.PropertyGroup[0].Version = $version
+  $xml.Project.PropertyGroup.Version = $version
   $xml.Save($_.FullName)
 }
 


### PR DESCRIPTION
The `csproj`s now have only a single `<PropertyGroup>` and it looks like we cannot access them by array index anymore.