### PR TITLE
Add HexToken case in OptionalContent parsing

### DIFF
--- a/src/UglyToad.PdfPig/Content/OptionalContentGroupElement.cs
+++ b/src/UglyToad.PdfPig/Content/OptionalContentGroupElement.cs
@@ -68,6 +68,10 @@ namespace UglyToad.PdfPig.Content
                     {
                         Name = nameStr.Data;
                     }
+                    else if (markedContentElement.Properties.TryGet(NameToken.Name, pdfTokenScanner, out HexToken? nameHex))
+                    {
+                        Name = nameHex.Data;
+                    }
                     else
                     {
                         throw new ArgumentException($"Cannot parse optional content's {nameof(Name)} from {nameof(markedContentElement.Properties)}. This is a required field.", nameof(markedContentElement.Properties));


### PR DESCRIPTION
Add HexToken case in OptionalContent parsing to fix excepition reported here: https://github.com/UglyToad/PdfPig/issues/266#issuecomment-2579540185