### PR TITLE
Fix warnings about "type 'K' cannot be used as type parameter 'TKey' in the generic type or method 'Dictionary<TKey, TValue>'"

### DIFF
--- a/src/UglyToad.PdfPig/PdfFonts/Cmap/CMapUtils.cs
+++ b/src/UglyToad.PdfPig/PdfFonts/Cmap/CMapUtils.cs
@@ -16,7 +16,7 @@
             return code;
         }
 
-        public static void PutAll<TKey, TValue>(this Dictionary<TKey, TValue> target, IReadOnlyDictionary<TKey, TValue> source)
+        public static void PutAll<TKey, TValue>(this Dictionary<TKey, TValue> target, IReadOnlyDictionary<TKey, TValue> source) where TKey : notnull
         {
             foreach (var pair in source)
             {

--- a/src/UglyToad.PdfPig/Util/StackDictionary.cs
+++ b/src/UglyToad.PdfPig/Util/StackDictionary.cs
@@ -5,7 +5,7 @@ namespace UglyToad.PdfPig.Util
     using System.Collections.Generic;
     using System.Diagnostics.CodeAnalysis;
 
-    internal class StackDictionary<K, V>
+    internal class StackDictionary<K, V> where K : notnull
     {
         private readonly List<Dictionary<K, V>> values = new List<Dictionary<K, V>>();
 


### PR DESCRIPTION
Fix warnings about "type 'K' cannot be used as type parameter 'TKey' in the generic type or method 'Dictionary<TKey, TValue>'"