### PR TITLE
Improve IFilter memory allocation

### DIFF
--- a/src/UglyToad.PdfPig.Core/MemoryHelper.cs
+++ b/src/UglyToad.PdfPig.Core/MemoryHelper.cs
@@ -1,0 +1,25 @@
+﻿namespace UglyToad.PdfPig.Core
+{
+    using System;
+    using System.IO;
+    using System.Runtime.InteropServices;
+
+    /// <summary>
+    /// Memory extensions.
+    /// </summary>
+    public static class MemoryHelper
+    {
+        /// <summary>
+        /// Gets a read-only <see cref="MemoryStream"/> from a ReadOnlyMemory&lt;byte&gt;.
+        /// </summary>
+        public static MemoryStream AsReadOnlyMemoryStream(this ReadOnlyMemory<byte> memory)
+        {
+            if (MemoryMarshal.TryGetArray(memory, out ArraySegment<byte> array))
+            {
+                return new MemoryStream(array.Array!, array.Offset, array.Count, false);
+            }
+
+            return new MemoryStream(memory.ToArray(), false);
+        }
+    }
+}

--- a/src/UglyToad.PdfPig.Tests/Graphics/TestOperationContext.cs
+++ b/src/UglyToad.PdfPig.Tests/Graphics/TestOperationContext.cs
@@ -180,7 +180,7 @@
         {
         }
 
-        public void EndInlineImage(ReadOnlyMemory<byte> bytes)
+        public void EndInlineImage(Memory<byte> bytes)
         {
         }
 

--- a/src/UglyToad.PdfPig.Tests/Integration/FilterTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Integration/FilterTests.cs
@@ -62,7 +62,7 @@
         {
             public bool IsSupported => false;
 
-            public ReadOnlyMemory<byte> Decode(ReadOnlySpan<byte> input, DictionaryToken streamDictionary, IFilterProvider filterProvider, int filterIndex)
+            public Memory<byte> Decode(Memory<byte> input, DictionaryToken streamDictionary, IFilterProvider filterProvider, int filterIndex)
             {
                 throw new NotImplementedException();
             }

--- a/src/UglyToad.PdfPig.Tests/TestPdfImage.cs
+++ b/src/UglyToad.PdfPig.Tests/TestPdfImage.cs
@@ -17,9 +17,9 @@
 
         public int BitsPerComponent { get; set; } = 8;
 
-        public ReadOnlyMemory<byte> RawMemory { get; }
+        public Memory<byte> RawMemory { get; }
 
-        public ReadOnlySpan<byte> RawBytes => RawMemory.Span;
+        public Span<byte> RawBytes => RawMemory.Span;
 
         public RenderingIntent RenderingIntent { get; set; } = RenderingIntent.RelativeColorimetric;
 
@@ -35,11 +35,11 @@
 
         public ColorSpaceDetails ColorSpaceDetails { get; set; }
 
-        public ReadOnlyMemory<byte> DecodedBytes { get; set; }
+        public Memory<byte> DecodedBytes { get; set; }
 
         public IPdfImage? MaskImage { get; }
 
-        public bool TryGetBytesAsMemory(out ReadOnlyMemory<byte> bytes)
+        public bool TryGetBytesAsMemory(out Memory<byte> bytes)
         {
             bytes = DecodedBytes;
             return !bytes.IsEmpty;

--- a/src/UglyToad.PdfPig.Tokenization/Scanner/CoreTokenScanner.cs
+++ b/src/UglyToad.PdfPig.Tokenization/Scanner/CoreTokenScanner.cs
@@ -208,7 +208,7 @@
                         // Special case handling for inline images.
                         var imageData = ReadInlineImageData();
                         isInInlineImage = false;
-                        CurrentToken = new InlineImageDataToken(new ReadOnlyMemory<byte>([..imageData]));
+                        CurrentToken = new InlineImageDataToken(new Memory<byte>([..imageData]));
                         hasBytePreRead = false;
                         return true;
                     }

--- a/src/UglyToad.PdfPig.Tokens/InlineImageDataToken.cs
+++ b/src/UglyToad.PdfPig.Tokens/InlineImageDataToken.cs
@@ -5,16 +5,16 @@
     /// <summary>
     /// Inline image data is used to embed images in PDF content streams. The content is wrapped by ID and ED tags in a BI operation.
     /// </summary>
-    public sealed class InlineImageDataToken : IDataToken<ReadOnlyMemory<byte>>
+    public sealed class InlineImageDataToken : IDataToken<Memory<byte>>
     {
         /// <inheritdoc />
-        public ReadOnlyMemory<byte> Data { get; }
+        public Memory<byte> Data { get; }
 
         /// <summary>
         /// Create a new <see cref="InlineImageDataToken"/>.
         /// </summary>
         /// <param name="data"></param>
-        public InlineImageDataToken(ReadOnlyMemory<byte> data)
+        public InlineImageDataToken(Memory<byte> data)
         {
             Data = data;
         }

--- a/src/UglyToad.PdfPig.Tokens/StreamToken.cs
+++ b/src/UglyToad.PdfPig.Tokens/StreamToken.cs
@@ -6,7 +6,7 @@
     /// A stream consists of a dictionary followed by zero or more bytes bracketed between the keywords stream and endstream.
     /// The bytes may be compressed by application of zero or more filters which are run in the order specified in the <see cref="StreamDictionary"/>.
     /// </summary>
-    public class StreamToken : IDataToken<ReadOnlyMemory<byte>>
+    public sealed class StreamToken : IDataToken<Memory<byte>>
     {
         /// <summary>
         /// The dictionary specifying the length of the stream, any applied compression filters and additional information.
@@ -16,7 +16,7 @@
         /// <summary>
         /// The compressed byte data of the stream.
         /// </summary>
-        public ReadOnlyMemory<byte> Data { get; }
+        public Memory<byte> Data { get; }
 
         /// <summary>
         /// Create a new <see cref="StreamToken"/>.
@@ -34,7 +34,7 @@
         /// </summary>
         /// <param name="streamDictionary">The stream dictionary.</param>
         /// <param name="data">The stream data.</param>
-        public StreamToken(DictionaryToken streamDictionary, ReadOnlyMemory<byte> data)
+        public StreamToken(DictionaryToken streamDictionary, Memory<byte> data)
         {
             StreamDictionary = streamDictionary ?? throw new ArgumentNullException(nameof(streamDictionary));
             Data = data;

--- a/src/UglyToad.PdfPig/Content/IPdfImage.cs
+++ b/src/UglyToad.PdfPig/Content/IPdfImage.cs
@@ -37,12 +37,12 @@
         /// <summary>
         /// The encoded memory of the image with all filters still applied.
         /// </summary>
-        ReadOnlyMemory<byte> RawMemory { get; }
+        Memory<byte> RawMemory { get; }
 
         /// <summary>
         /// The encoded memory span of the image with all filters still applied.
         /// </summary>
-        ReadOnlySpan<byte> RawBytes { get; }
+        Span<byte> RawBytes { get; }
 
         /// <summary>
         /// The color rendering intent to be used when rendering the image.
@@ -104,7 +104,7 @@
         /// Get the decoded memory of the image if applicable. For JPEG images and some other types the
         /// <see cref="RawMemory"/> should be used directly.
         /// </summary>
-        bool TryGetBytesAsMemory(out ReadOnlyMemory<byte> memory);
+        bool TryGetBytesAsMemory(out Memory<byte> memory);
 
         /// <summary>
         /// Try to convert the image to PNG. Doesn't support conversion of JPG to PNG.

--- a/src/UglyToad.PdfPig/Content/InlineImage.cs
+++ b/src/UglyToad.PdfPig/Content/InlineImage.cs
@@ -16,7 +16,7 @@
     /// </summary>
     public class InlineImage : IPdfImage
     {
-        private readonly Lazy<ReadOnlyMemory<byte>>? memoryFactory;
+        private readonly Lazy<Memory<byte>>? memoryFactory;
 
         /// <inheritdoc />
         public PdfRectangle Bounds { get; }
@@ -49,10 +49,10 @@
         public bool Interpolate { get; }
 
         /// <inheritdoc />
-        public ReadOnlyMemory<byte> RawMemory { get; }
+        public Memory<byte> RawMemory { get; }
 
         /// <inheritdoc />
-        public ReadOnlySpan<byte> RawBytes => RawMemory.Span;
+        public Span<byte> RawBytes => RawMemory.Span;
 
         /// <inheritdoc />
         public ColorSpaceDetails ColorSpaceDetails { get; }
@@ -71,7 +71,7 @@
             RenderingIntent renderingIntent,
             bool interpolate,
             IReadOnlyList<double> decode,
-            ReadOnlyMemory<byte> rawMemory,
+            Memory<byte> rawMemory,
             ILookupFilterProvider filterProvider,
             IReadOnlyList<NameToken> filterNames,
             DictionaryToken streamDictionary,
@@ -103,13 +103,13 @@
                 }
             }
 
-            memoryFactory = supportsFilters ? new Lazy<ReadOnlyMemory<byte>>(() =>
+            memoryFactory = supportsFilters ? new Lazy<Memory<byte>>(() =>
             {
                 var b = RawMemory;
                 for (var i = 0; i < filters.Count; i++)
                 {
                     var filter = filters[i];
-                    b = filter.Decode(b.Span, streamDictionary, filterProvider, i);
+                    b = filter.Decode(b, streamDictionary, filterProvider, i);
                 }
 
                 return b;
@@ -119,7 +119,7 @@
         }
 
         /// <inheritdoc />
-        public bool TryGetBytesAsMemory(out ReadOnlyMemory<byte> bytes)
+        public bool TryGetBytesAsMemory(out Memory<byte> bytes)
         {
             bytes = null;
             if (memoryFactory is null)

--- a/src/UglyToad.PdfPig/Filters/AsciiHexDecodeFilter.cs
+++ b/src/UglyToad.PdfPig/Filters/AsciiHexDecodeFilter.cs
@@ -28,26 +28,27 @@
         public bool IsSupported { get; } = true;
 
         /// <inheritdoc />
-        public ReadOnlyMemory<byte> Decode(ReadOnlySpan<byte> input, DictionaryToken streamDictionary, IFilterProvider filterProvider, int filterIndex)
+        public Memory<byte> Decode(Memory<byte> input, DictionaryToken streamDictionary, IFilterProvider filterProvider, int filterIndex)
         {
             Span<byte> pair = stackalloc byte[2];
+            Span<byte> inputSpan = input.Span;
             var index = 0;
 
             using var writer = new ArrayPoolBufferWriter<byte>(input.Length);
 
             for (var i = 0; i < input.Length; i++)
             {
-                if (input[i] == '>')
+                if (inputSpan[i] == '>')
                 {
                     break;
                 }
 
-                if (IsWhitespace(input[i]) || input[i] == '<')
+                if (IsWhitespace(inputSpan[i]) || inputSpan[i] == '<')
                 {
                     continue;
                 }
 
-                pair[index] = input[i];
+                pair[index] = inputSpan[i];
                 index++;
 
                 if (index == 2)
@@ -86,7 +87,7 @@
                 throw new InvalidOperationException("Invalid character encountered in hex encoded stream: " + (char)hexBytes[0]);
             }
 
-            var value = (byte) (first * 16 + second);
+            var value = (byte)(first * 16 + second);
 
             writer.Write(value);
         }

--- a/src/UglyToad.PdfPig/Filters/DctDecodeFilter.cs
+++ b/src/UglyToad.PdfPig/Filters/DctDecodeFilter.cs
@@ -13,7 +13,7 @@
         public bool IsSupported { get; } = false;
 
         /// <inheritdoc />
-        public ReadOnlyMemory<byte> Decode(ReadOnlySpan<byte> input, DictionaryToken streamDictionary, IFilterProvider filterProvider, int filterIndex)
+        public Memory<byte> Decode(Memory<byte> input, DictionaryToken streamDictionary, IFilterProvider filterProvider, int filterIndex)
         {
             throw new NotSupportedException("The DST (Discrete Cosine Transform) Filter indicates data is encoded in JPEG format. " +
                                             "This filter is not currently supported but the raw data can be supplied to JPEG supporting libraries.");

--- a/src/UglyToad.PdfPig/Filters/IFilter.cs
+++ b/src/UglyToad.PdfPig/Filters/IFilter.cs
@@ -21,6 +21,6 @@
         /// <param name="filterProvider">The filter provider.</param>
         /// <param name="filterIndex">The position of this filter in the pipeline used to encode data.</param>
         /// <returns>The decoded bytes.</returns>
-        ReadOnlyMemory<byte> Decode(ReadOnlySpan<byte> input, DictionaryToken streamDictionary, IFilterProvider filterProvider, int filterIndex);
+        Memory<byte> Decode(Memory<byte> input, DictionaryToken streamDictionary, IFilterProvider filterProvider, int filterIndex);
     }
 }

--- a/src/UglyToad.PdfPig/Filters/Jbig2DecodeFilter.cs
+++ b/src/UglyToad.PdfPig/Filters/Jbig2DecodeFilter.cs
@@ -13,7 +13,7 @@
         public bool IsSupported { get; } = false;
 
         /// <inheritdoc />
-        public ReadOnlyMemory<byte> Decode(ReadOnlySpan<byte> input, DictionaryToken streamDictionary, IFilterProvider filterProvider, int filterIndex)
+        public Memory<byte> Decode(Memory<byte> input, DictionaryToken streamDictionary, IFilterProvider filterProvider, int filterIndex)
         {
             throw new NotSupportedException("The JBIG2 Filter for monochrome image data is not currently supported. " +
                                             "Try accessing the raw compressed data directly.");

--- a/src/UglyToad.PdfPig/Filters/JpxDecodeFilter.cs
+++ b/src/UglyToad.PdfPig/Filters/JpxDecodeFilter.cs
@@ -13,7 +13,7 @@
         public bool IsSupported { get; } = false;
 
         /// <inheritdoc />
-        public ReadOnlyMemory<byte> Decode(ReadOnlySpan<byte> input, DictionaryToken streamDictionary, IFilterProvider filterProvider, int filterIndex)
+        public Memory<byte> Decode(Memory<byte> input, DictionaryToken streamDictionary, IFilterProvider filterProvider, int filterIndex)
         {
             throw new NotSupportedException("The JPX Filter (JPEG2000) for image data is not currently supported. " +
                                             "Try accessing the raw compressed data directly.");

--- a/src/UglyToad.PdfPig/Filters/LzwFilter.cs
+++ b/src/UglyToad.PdfPig/Filters/LzwFilter.cs
@@ -29,7 +29,7 @@ namespace UglyToad.PdfPig.Filters
         public bool IsSupported { get; } = true;
 
         /// <inheritdoc />
-        public ReadOnlyMemory<byte> Decode(ReadOnlySpan<byte> input, DictionaryToken streamDictionary, IFilterProvider filterProvider, int filterIndex)
+        public Memory<byte> Decode(Memory<byte> input, DictionaryToken streamDictionary, IFilterProvider filterProvider, int filterIndex)
         {
             var parameters = DecodeParameterResolver.GetFilterParameters(streamDictionary, filterIndex);
 
@@ -39,7 +39,7 @@ namespace UglyToad.PdfPig.Filters
 
             if (predictor > 1)
             {
-                var decompressed = Decode(input, earlyChange == 1);
+                var decompressed = Decode(input.Span, earlyChange == 1);
 
                 var colors = Math.Min(parameters.GetIntOrDefault(NameToken.Colors, DefaultColors), 32);
                 var bitsPerComponent = parameters.GetIntOrDefault(NameToken.BitsPerComponent, DefaultBitsPerComponent);
@@ -48,7 +48,7 @@ namespace UglyToad.PdfPig.Filters
                 return PngPredictor.Decode(decompressed, predictor, colors, bitsPerComponent, columns);
             }
 
-            return Decode(input, earlyChange == 1);
+            return Decode(input.Span, earlyChange == 1);
         }
 
         private static byte[] Decode(ReadOnlySpan<byte> input, bool isEarlyChange)

--- a/src/UglyToad.PdfPig/Filters/RunLengthFilter.cs
+++ b/src/UglyToad.PdfPig/Filters/RunLengthFilter.cs
@@ -16,14 +16,16 @@
         public bool IsSupported { get; } = true;
 
         /// <inheritdoc />
-        public ReadOnlyMemory<byte> Decode(ReadOnlySpan<byte> input, DictionaryToken streamDictionary, IFilterProvider filterProvider, int filterIndex)
+        public Memory<byte> Decode(Memory<byte> input, DictionaryToken streamDictionary, IFilterProvider filterProvider, int filterIndex)
         {
             using var output = new ArrayPoolBufferWriter<byte>(input.Length);
 
+            Span<byte> inputSpan = input.Span;
+            
             var i = 0;
             while (i < input.Length)
             {
-                var runLength = input[i];
+                var runLength = inputSpan[i];
 
                 if (runLength == EndOfDataLength)
                 {
@@ -39,7 +41,7 @@
                     {
                         i++;
 
-                        output.Write(input[i]);
+                        output.Write(inputSpan[i]);
 
                         rangeToWriteLiterally--;
                     }
@@ -52,7 +54,7 @@
                 {
                     var numberOfTimesToCopy = 257 - runLength;
 
-                    var byteToCopy = input[i + 1];
+                    var byteToCopy = inputSpan[i + 1];
 
                     output.GetSpan(numberOfTimesToCopy).Slice(0, numberOfTimesToCopy).Fill(byteToCopy);
                     output.Advance(numberOfTimesToCopy);

--- a/src/UglyToad.PdfPig/Functions/PdfFunctionType4.cs
+++ b/src/UglyToad.PdfPig/Functions/PdfFunctionType4.cs
@@ -1,7 +1,7 @@
 ﻿namespace UglyToad.PdfPig.Functions
 {
     using System;
-    using System.Linq;
+    using System.Text;
     using UglyToad.PdfPig.Core;
     using UglyToad.PdfPig.Functions.Type4;
     using UglyToad.PdfPig.Tokens;
@@ -20,8 +20,7 @@
         internal PdfFunctionType4(StreamToken function, ArrayToken domain, ArrayToken range)
             : base(function, domain, range)
         {
-            byte[] bytes = FunctionStream!.Data.ToArray();
-            string str = OtherEncodings.Iso88591.GetString(bytes);
+            string str = OtherEncodings.Iso88591.GetString(FunctionStream!.Data.Span);
             this.instructions = InstructionSequenceBuilder.Parse(str);
         }
 

--- a/src/UglyToad.PdfPig/Graphics/BaseStreamProcessor.cs
+++ b/src/UglyToad.PdfPig/Graphics/BaseStreamProcessor.cs
@@ -833,7 +833,7 @@
         }
 
         /// <inheritdoc/>
-        public virtual void EndInlineImage(ReadOnlyMemory<byte> bytes)
+        public virtual void EndInlineImage(Memory<byte> bytes)
         {
             if (InlineImageBuilder is null)
             {

--- a/src/UglyToad.PdfPig/Graphics/IOperationContext.cs
+++ b/src/UglyToad.PdfPig/Graphics/IOperationContext.cs
@@ -159,7 +159,7 @@
         /// <summary>
         /// Indicates that the current inline image is complete.
         /// </summary>
-        void EndInlineImage(ReadOnlyMemory<byte> bytes);
+        void EndInlineImage(Memory<byte> bytes);
 
         /// <summary>
         /// Modify the clipping rule of the current path.

--- a/src/UglyToad.PdfPig/Graphics/InlineImageBuilder.cs
+++ b/src/UglyToad.PdfPig/Graphics/InlineImageBuilder.cs
@@ -1,10 +1,8 @@
 ﻿namespace UglyToad.PdfPig.Graphics
 {
     using System;
-    using System.Collections;
     using System.Collections.Generic;
     using System.Linq;
-    using System.Xml.Linq;
     using Content;
     using Core;
     using Filters;
@@ -27,7 +25,7 @@
         /// <summary>
         /// Inline image bytes.
         /// </summary>
-        public ReadOnlyMemory<byte> Bytes { get; internal set; }
+        public Memory<byte> Bytes { get; internal set; }
 
         internal InlineImage CreateInlineImage(
             in TransformationMatrix transformationMatrix,

--- a/src/UglyToad.PdfPig/Graphics/Operations/InlineImages/EndInlineImage.cs
+++ b/src/UglyToad.PdfPig/Graphics/Operations/InlineImages/EndInlineImage.cs
@@ -1,7 +1,6 @@
 ﻿namespace UglyToad.PdfPig.Graphics.Operations.InlineImages
 {
     using System;
-    using System.Collections.Generic;
     using System.IO;
 
     /// <inheritdoc />
@@ -18,7 +17,7 @@
         /// <summary>
         /// The raw data for the inline image which should be interpreted according to the corresponding <see cref="BeginInlineImageData.Dictionary"/>.
         /// </summary>
-        public ReadOnlyMemory<byte> ImageData { get; }
+        public Memory<byte> ImageData { get; }
         
         /// <inheritdoc />
         public string Operator => Symbol;
@@ -27,7 +26,7 @@
         /// Create a new <see cref="EndInlineImage"/> operation.
         /// </summary>
         /// <param name="imageData">The raw byte data of this image.</param>
-        public EndInlineImage(ReadOnlyMemory<byte> imageData)
+        public EndInlineImage(Memory<byte> imageData)
         {
             ImageData = imageData;
         }

--- a/src/UglyToad.PdfPig/PdfExtensions.cs
+++ b/src/UglyToad.PdfPig/PdfExtensions.cs
@@ -55,14 +55,14 @@
         /// <summary>
         /// Get the decoded data from this stream.
         /// </summary>
-        public static ReadOnlyMemory<byte> Decode(this StreamToken stream, IFilterProvider filterProvider)
+        public static Memory<byte> Decode(this StreamToken stream, IFilterProvider filterProvider)
         {
             var filters = filterProvider.GetFilters(stream.StreamDictionary);
 
             var transform = stream.Data;
             for (var i = 0; i < filters.Count; i++)
             {
-                transform = filters[i].Decode(transform.Span, stream.StreamDictionary, filterProvider, i);
+                transform = filters[i].Decode(transform, stream.StreamDictionary, filterProvider, i);
             }
 
             return transform;
@@ -71,14 +71,14 @@
         /// <summary>
         /// Get the decoded data from this stream.
         /// </summary>
-        public static ReadOnlyMemory<byte> Decode(this StreamToken stream, ILookupFilterProvider filterProvider, IPdfTokenScanner scanner)
+        public static Memory<byte> Decode(this StreamToken stream, ILookupFilterProvider filterProvider, IPdfTokenScanner scanner)
         {
             var filters = filterProvider.GetFilters(stream.StreamDictionary, scanner);
 
             var transform = stream.Data;
             for (var i = 0; i < filters.Count; i++)
             {
-                transform = filters[i].Decode(transform.Span, stream.StreamDictionary, filterProvider, i);
+                transform = filters[i].Decode(transform, stream.StreamDictionary, filterProvider, i);
             }
 
             return transform;

--- a/src/UglyToad.PdfPig/PdfFonts/Parser/Handlers/TrueTypeFontHandler.cs
+++ b/src/UglyToad.PdfPig/PdfFonts/Parser/Handlers/TrueTypeFontHandler.cs
@@ -115,7 +115,7 @@
                 {
                     var toUnicode = DirectObjectFinder.Get<StreamToken>(toUnicodeObj, pdfScanner);
 
-                    if (toUnicode.Decode(filterProvider, pdfScanner) is ReadOnlyMemory<byte> decodedUnicodeCMap)
+                    if (toUnicode?.Decode(filterProvider, pdfScanner) is { } decodedUnicodeCMap)
                     {
                         toUnicodeCMap = CMapCache.Parse(new MemoryInputBytes(decodedUnicodeCMap));
                     }

--- a/src/UglyToad.PdfPig/PdfFonts/Parser/Handlers/Type0FontHandler.cs
+++ b/src/UglyToad.PdfPig/PdfFonts/Parser/Handlers/Type0FontHandler.cs
@@ -75,7 +75,7 @@
 
                 if (DirectObjectFinder.TryGet<StreamToken>(toUnicodeValue, scanner, out var toUnicodeStream))
                 {
-                    if (toUnicodeStream?.Decode(filterProvider, scanner) is ReadOnlyMemory<byte> decodedUnicodeCMap)
+                    if (toUnicodeStream?.Decode(filterProvider, scanner) is { } decodedUnicodeCMap)
                     {
                         toUnicodeCMap = CMapCache.Parse(new MemoryInputBytes(decodedUnicodeCMap));
                     }

--- a/src/UglyToad.PdfPig/PdfFonts/Parser/Handlers/Type1FontHandler.cs
+++ b/src/UglyToad.PdfPig/PdfFonts/Parser/Handlers/Type1FontHandler.cs
@@ -93,7 +93,7 @@
             {
                 var toUnicode = DirectObjectFinder.Get<StreamToken>(toUnicodeObj, pdfScanner);
 
-                if (toUnicode?.Decode(filterProvider, pdfScanner) is ReadOnlyMemory<byte> decodedUnicodeCMap)
+                if (toUnicode?.Decode(filterProvider, pdfScanner) is { } decodedUnicodeCMap)
                 {
                     toUnicodeCMap = CMapCache.Parse(new MemoryInputBytes(decodedUnicodeCMap));
                 }

--- a/src/UglyToad.PdfPig/PdfFonts/Parser/Handlers/Type3FontHandler.cs
+++ b/src/UglyToad.PdfPig/PdfFonts/Parser/Handlers/Type3FontHandler.cs
@@ -49,7 +49,7 @@
             {
                 var toUnicode = DirectObjectFinder.Get<StreamToken>(toUnicodeObj, scanner);
 
-                if (toUnicode?.Decode(filterProvider, scanner) is ReadOnlyMemory<byte> decodedUnicodeCMap)
+                if (toUnicode?.Decode(filterProvider, scanner) is { } decodedUnicodeCMap)
                 {
                     toUnicodeCMap = CMapCache.Parse(new MemoryInputBytes(decodedUnicodeCMap));
                 }

--- a/src/UglyToad.PdfPig/XObjects/XObjectFactory.cs
+++ b/src/UglyToad.PdfPig/XObjects/XObjectFactory.cs
@@ -144,7 +144,7 @@
             }
             
             var streamToken = new StreamToken(dictionary, xObject.Stream.Data); // Needed as Resolve(pdfScanner) was called on the dictionary
-            var decodedBytes = supportsFilters ? new Lazy<ReadOnlyMemory<byte>>(() => streamToken.Decode(filterProvider, pdfScanner))
+            var decodedBytes = supportsFilters ? new Lazy<Memory<byte>>(() => streamToken.Decode(filterProvider, pdfScanner))
                 : null;
 
             var decode = Array.Empty<double>();

--- a/src/UglyToad.PdfPig/XObjects/XObjectImage.cs
+++ b/src/UglyToad.PdfPig/XObjects/XObjectImage.cs
@@ -16,7 +16,7 @@
     /// </summary>
     public class XObjectImage : IPdfImage
     {
-        private readonly Lazy<ReadOnlyMemory<byte>>? memoryFactory;
+        private readonly Lazy<Memory<byte>>? memoryFactory;
 
         /// <inheritdoc />
         public PdfRectangle Bounds { get; }
@@ -56,10 +56,10 @@
         public DictionaryToken ImageDictionary { get; }
 
         /// <inheritdoc />
-        public ReadOnlyMemory<byte> RawMemory { get; }
+        public Memory<byte> RawMemory { get; }
 
         /// <inheritdoc />
-        public ReadOnlySpan<byte> RawBytes => RawMemory.Span;
+        public Span<byte> RawBytes => RawMemory.Span;
 
         /// <inheritdoc />
         public ColorSpaceDetails? ColorSpaceDetails { get; }
@@ -80,8 +80,8 @@
             bool interpolate,
             IReadOnlyList<double> decode,
             DictionaryToken imageDictionary,
-            ReadOnlyMemory<byte> rawMemory,
-            Lazy<ReadOnlyMemory<byte>>? bytes,
+            Memory<byte> rawMemory,
+            Lazy<Memory<byte>>? bytes,
             ColorSpaceDetails? colorSpaceDetails,
             IPdfImage? softMaskImage)
         {
@@ -102,7 +102,7 @@
         }
 
         /// <inheritdoc />
-        public bool TryGetBytesAsMemory(out ReadOnlyMemory<byte> bytes)
+        public bool TryGetBytesAsMemory(out Memory<byte> bytes)
         {
             bytes = null;
             if (memoryFactory is null)


### PR DESCRIPTION
Improve memory allocation by changing IFilter.Decode() signature to use Memory<byte> instead of ReadOnlyMemory/ReadOnlySpan

## Benchmark

source: https://github.com/BobLd/UglyToad.PdfPig.Benchmarks/tree/pull/1052

| Method             | Job        | NuGetReferences                         | Mean         | Error      | StdDev     | Gen0       | Gen1       | Gen2       | Allocated  |
|------------------- |----------- |---------------------------------------- |-------------:|-----------:|-----------:|-----------:|-----------:|-----------:|-----------:|
| MOZILLA_10225_0    | Job-JTMEAG | PdfPig 0.1.11-alpha-20250528-5b566      | 7,420.196 ms | 17.1473 ms | 15.2006 ms | 51000.0000 | 40000.0000 | 35000.0000 | 2234.42 MB |
| MOZILLA_10225_0    | Job-RWXYCG | PdfPig 0.1.11 (new) | 7,338.888 ms | 18.3865 ms | 17.1988 ms | 44000.0000 | 34000.0000 | 28000.0000 | 2134.64 MB |
| fseprd1102849      | Job-JTMEAG | PdfPig 0.1.11-alpha-20250528-5b566      |   310.853 ms |  6.1579 ms |  7.5625 ms | 12000.0000 |  9000.0000 |  5000.0000 |  212.02 MB |
| fseprd1102849      | Job-RWXYCG | PdfPig 0.1.11 (new) |   313.710 ms |  6.1995 ms |  9.6518 ms | 12000.0000 |  9000.0000 |  5000.0000 |  210.13 MB |
| cat_genetics_bobld | Job-JTMEAG | PdfPig 0.1.11-alpha-20250528-5b566      |     6.196 ms |  0.0744 ms |  0.0696 ms |   328.1250 |   164.0625 |   164.0625 |    6.05 MB |
| cat_genetics_bobld | Job-RWXYCG | PdfPig 0.1.11 (new) |     6.062 ms |  0.1113 ms |  0.1041 ms |   328.1250 |   164.0625 |   164.0625 |    6.01 MB |