### PR TITLE
Use ReadOnlyMemory<byte> in ShowText operators and implement MoveToNextLineShowTextWithSpacing parsing

### DIFF
--- a/src/UglyToad.PdfPig.Tokens/HexToken.cs
+++ b/src/UglyToad.PdfPig.Tokens/HexToken.cs
@@ -171,7 +171,7 @@ namespace UglyToad.PdfPig.Tokens
 #if NET8_0_OR_GREATER
             return Convert.ToHexString(Bytes);
 #else
-            return BitConverter.ToString(Bytes.ToArray()).Replace("-", string.Empty);
+            return BitConverter.ToString(_bytes).Replace("-", string.Empty);
 #endif
         }
     }

--- a/src/UglyToad.PdfPig/Graphics/Operations/TextShowing/MoveToNextLineShowText.cs
+++ b/src/UglyToad.PdfPig/Graphics/Operations/TextShowing/MoveToNextLineShowText.cs
@@ -25,7 +25,7 @@
         /// <summary>
         /// The text to show as hex bytes.
         /// </summary>
-        public byte[]? Bytes { get; }
+        public ReadOnlyMemory<byte> Bytes { get; }
 
         /// <summary>
         /// Create a new <see cref="MoveToNextLineShowText"/>.
@@ -40,7 +40,7 @@
         /// Create a new <see cref="MoveToNextLineShowText"/>.
         /// </summary>
         /// <param name="hexBytes">The bytes of the text to show.</param>
-        public MoveToNextLineShowText(byte[] hexBytes)
+        public MoveToNextLineShowText(ReadOnlyMemory<byte> hexBytes)
         {
             Bytes = hexBytes;
         }
@@ -50,7 +50,7 @@
         {
             var move = MoveToNextLine.Value;
 
-            var showText = Text != null ? new ShowText(Text) : new ShowText(Bytes!);
+            var showText = Text != null ? new ShowText(Text) : new ShowText(Bytes);
 
             move.Run(operationContext);
             showText.Run(operationContext);
@@ -59,14 +59,14 @@
         /// <inheritdoc />
         public void Write(Stream stream)
         {
-            if (Bytes is null)
+            if (Bytes.IsEmpty)
             {
                 stream.WriteText($"({Text}) {Symbol}");
                 stream.WriteNewLine();
             }
             else
             {
-                stream.WriteHex(Bytes);
+                stream.WriteHex(Bytes.Span);
                 stream.WriteWhiteSpace();
                 stream.WriteText(Symbol);
                 stream.WriteNewLine();

--- a/src/UglyToad.PdfPig/Graphics/Operations/TextShowing/MoveToNextLineShowTextWithSpacing.cs
+++ b/src/UglyToad.PdfPig/Graphics/Operations/TextShowing/MoveToNextLineShowTextWithSpacing.cs
@@ -31,7 +31,7 @@
         /// <summary>
         /// The bytes of the text.
         /// </summary>
-        public byte[]? Bytes { get; }
+        public ReadOnlyMemory<byte> Bytes { get; }
 
         /// <summary>
         /// The text to show.
@@ -57,7 +57,7 @@
         /// <param name="wordSpacing">The word spacing.</param>
         /// <param name="characterSpacing">The character spacing.</param>
         /// <param name="hexBytes">The bytes of the text to show.</param>
-        public MoveToNextLineShowTextWithSpacing(double wordSpacing, double characterSpacing, byte[] hexBytes)
+        public MoveToNextLineShowTextWithSpacing(double wordSpacing, double characterSpacing, ReadOnlyMemory<byte> hexBytes)
         {
             WordSpacing = wordSpacing;
             CharacterSpacing = characterSpacing;
@@ -86,9 +86,9 @@
             stream.WriteDouble(CharacterSpacing);
             stream.WriteWhiteSpace();
 
-            if (Bytes != null)
+            if (!Bytes.IsEmpty)
             {
-                stream.WriteHex(Bytes);
+                stream.WriteHex(Bytes.Span);
             }
             else
             {

--- a/src/UglyToad.PdfPig/Graphics/Operations/TextShowing/ShowText.cs
+++ b/src/UglyToad.PdfPig/Graphics/Operations/TextShowing/ShowText.cs
@@ -1,6 +1,7 @@
 ﻿namespace UglyToad.PdfPig.Graphics.Operations.TextShowing
 {
     using PdfPig.Core;
+    using System;
     using System.IO;
 
     /// <inheritdoc />
@@ -38,7 +39,7 @@
         /// <summary>
         /// The bytes of the string to show.
         /// </summary>
-        public byte[]? Bytes { get; }
+        public ReadOnlyMemory<byte> Bytes { get; }
 
         /// <summary>
         /// Create a new <see cref="ShowText"/>.
@@ -51,7 +52,7 @@
         /// <summary>
         /// Create a new <see cref="ShowText"/>.
         /// </summary>
-        public ShowText(byte[] hexBytes)
+        public ShowText(ReadOnlyMemory<byte> hexBytes)
         {
             Bytes = hexBytes;
         }
@@ -60,7 +61,6 @@
         public void Run(IOperationContext operationContext)
         {
             var input = new MemoryInputBytes(Text != null ? OtherEncodings.StringAsLatin1Bytes(Text) : Bytes);
-
             operationContext.ShowText(input);
         }
 
@@ -89,10 +89,9 @@
         /// <inheritdoc />
         public void Write(Stream stream)
         {
-             
-            if (Bytes != null)
+            if (!Bytes.IsEmpty)
             {
-                stream.WriteHex(Bytes);
+                stream.WriteHex(Bytes.Span);
             }
             else
             {

--- a/src/UglyToad.PdfPig/Graphics/ReflectionGraphicsStateOperationFactory.cs
+++ b/src/UglyToad.PdfPig/Graphics/ReflectionGraphicsStateOperationFactory.cs
@@ -343,14 +343,29 @@ namespace UglyToad.PdfPig.Graphics
                     {
                         return new MoveToNextLineShowText(snl.Data);
                     }
-                    else if (operands[0] is HexToken hnl)
+
+                    if (operands[0] is HexToken hnl)
                     {
-                        return new MoveToNextLineShowText(hnl.Bytes.ToArray());
+                        return new MoveToNextLineShowText(hnl.Memory);
                     }
-                    else
+
+                    throw new InvalidOperationException($"Tried to create a move to next line and show text operation with operand type: {operands[0]?.GetType().Name ?? "null"}");
+                case MoveToNextLineShowTextWithSpacing.Symbol:
+                    var wordSpacing = (NumericToken)operands[0];
+                    var charSpacing = (NumericToken)operands[1];
+                    var text = operands[2];
+
+                    if (text is StringToken stringToken)
                     {
-                        throw new InvalidOperationException($"Tried to create a move to next line and show text operation with operand type: {operands[0]?.GetType().Name ?? "null"}");
+                        return new MoveToNextLineShowTextWithSpacing(wordSpacing.Double, charSpacing.Double, stringToken.Data);
                     }
+
+                    if (text is HexToken hexToken)
+                    {
+                        return new MoveToNextLineShowTextWithSpacing(wordSpacing.Double, charSpacing.Double, hexToken.Memory);
+                    }
+
+                    throw new InvalidOperationException($"Tried to create a MoveToNextLineShowTextWithSpacing operation with operand type: {operands[2]?.GetType().Name ?? "null"}");
                 case MoveToNextLineWithOffset.Symbol:
                     return new MoveToNextLineWithOffset(OperandToDouble(operands[0]), OperandToDouble(operands[1]));
                 case MoveToNextLineWithOffsetSetLeading.Symbol:
@@ -364,7 +379,8 @@ namespace UglyToad.PdfPig.Graphics
                     {
                         return new SetNonStrokeColorAdvanced(operands.Take(operands.Count - 1).Select(x => ((NumericToken)x).Data).ToArray(), scnLowerPatternName);
                     }
-                    else if (operands.All(x => x is NumericToken))
+                    
+                    if (operands.All(x => x is NumericToken))
                     {
                         return new SetNonStrokeColorAdvanced(operands.Select(x => ((NumericToken)x).Data).ToArray());
                     }
@@ -425,14 +441,13 @@ namespace UglyToad.PdfPig.Graphics
                     {
                         return new ShowText(s.Data);
                     }
-                    else if (operands[0] is HexToken h)
+                    
+                    if (operands[0] is HexToken h)
                     {
-                        return new ShowText(h.Bytes.ToArray());
+                        return new ShowText(h.Memory);
                     }
-                    else
-                    {
-                        throw new InvalidOperationException($"Tried to create a show text operation with operand type: {operands[0]?.GetType().Name ?? "null"}");
-                    }
+                    
+                    throw new InvalidOperationException($"Tried to create a show text operation with operand type: {operands[0]?.GetType().Name ?? "null"}");
                 case ShowTextsWithPositioning.Symbol:
                     if (operands.Count == 0)
                     {


### PR DESCRIPTION
- Use ReadOnlyMemory<byte> in ShowText to avoid allocation with ToArray()
- Implement MoveToNextLineShowTextWithSpacing parsing to avoid reflection