### PR TITLE
fix #670 by ignoring duplicate endstream definitions

### DIFF
--- a/src/UglyToad.PdfPig/Tokenization/Scanner/PdfTokenScanner.cs
+++ b/src/UglyToad.PdfPig/Tokenization/Scanner/PdfTokenScanner.cs
@@ -268,6 +268,12 @@
                     {
                         token = trimmedDuplicatedEndTokens[0];
                     }
+                    else if (readTokens[0] is StreamToken str
+                             && readTokens.Skip(1).All(x => x is OperatorToken op && op.Equals(OperatorToken.EndStream)))
+                    {
+                        // If a stream token is followed by "endstream" operator tokens just skip the following duplicated tokens.
+                        token = str;
+                    }
                     else
                     {
                         token = readTokens[readTokens.Count - 1];


### PR DESCRIPTION
when parsing a stream object with multiple `endstream` tokens the last parsed token was selected instead of the actual stream token so instead we just skip all following tokens if the first is a stream and the following tokens are `endstream` operators only

Example file contained something like:

```
12 0 obj
<< /Length 6 >>
stream
123456endstream
endstream
endobj
```

If the length is incorrect the stream parsing is still broken as in #1074 but this fixes the reported bug.