### PR TITLE
skip single letter final blocks

### DIFF
--- a/src/UglyToad.PdfPig.Tests/Filters/Ascii85FilterTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Filters/Ascii85FilterTests.cs
@@ -34,10 +34,39 @@ O<DJ+*.@<*K0@<6L(Df-\0Ec5e;DffZ(EZee.Bl.9pF""AGXBPCsi + DGm >@3BB / F * &OCAfu2 
                 text);
         }
 
-        [Fact]
-        public void ReplacesZWithEmptyBytes()
+        [Theory]
+        [InlineData("BE", "h")]
+        [InlineData("BOq", "he")]
+        [InlineData("BOtu", "hel")]
+        [InlineData("BOu!r", "hell")]
+        [InlineData("BOu!rDZ", "hello")]
+        [InlineData("BOu!rD]f", "hello ")]
+        [InlineData("BOu!rD]j6", "hello w")]
+        [InlineData("BOu!rD]j7B", "hello wo")]
+        [InlineData("BOu!rD]j7BEW", "hello wor")]
+        [InlineData("BOu!rD]j7BEbk", "hello worl")]
+        [InlineData("BOu!rD]j7BEbo7", "hello world")]
+        [InlineData("BOu!rD]j7BEbo80", "hello world!")]
+        public void DecodesHelloWorld(string encoded, string decoded)
         {
-            var bytes = Encoding.ASCII.GetBytes("9jqo^zBlbD-");
+            var result = filter.Decode(
+                Encoding.ASCII.GetBytes(encoded),
+                dictionary,
+                TestFilterProvider.Instance,
+                0);
+
+            Assert.Equal(decoded, Encoding.ASCII.GetString(result.ToArray()));
+        }
+
+        [Theory]
+        [InlineData("9jqo^zBlbD-", "Man \0\0\0\0is d")]
+        [InlineData("", "")]
+        [InlineData("z", "\0\0\0\0")]
+        [InlineData("zz", "\0\0\0\0\0\0\0\0")]
+        [InlineData("zzz", "\0\0\0\0\0\0\0\0\0\0\0\0")]
+        public void ReplacesZWithEmptyBytes(string encoded, string decoded)
+        {
+            var bytes = Encoding.ASCII.GetBytes(encoded);
 
             var result = filter.Decode(bytes, dictionary, TestFilterProvider.Instance, 1);
 
@@ -47,7 +76,7 @@ O<DJ+*.@<*K0@<6L(Df-\0Ec5e;DffZ(EZee.Bl.9pF""AGXBPCsi + DGm >@3BB / F * &OCAfu2 
             string text = Encoding.ASCII.GetString(result.Span);
 #endif
 
-            Assert.Equal("Man \0\0\0\0is d", text);
+            Assert.Equal(decoded, text);
         }
         
         [Fact]
@@ -60,14 +89,17 @@ O<DJ+*.@<*K0@<6L(Df-\0Ec5e;DffZ(EZee.Bl.9pF""AGXBPCsi + DGm >@3BB / F * &OCAfu2 
             Assert.Throws<InvalidOperationException>(action);
         }
 
-        [Fact]
-        public void SingleCharacterLastThrows()
+        [Theory]
+        [InlineData("@rH:%B", "cool")]
+        [InlineData("A~>", "")]
+        [InlineData("@rH:%A~>", "cool")]
+        public void SingleCharacterLastIgnores(string encoded, string decoded)
         {
-            var bytes = Encoding.ASCII.GetBytes("9jqo^B");
+            var bytes = Encoding.ASCII.GetBytes(encoded);
 
-            Action action = () => filter.Decode(bytes, dictionary, TestFilterProvider.Instance, 1);
+            var result = filter.Decode(bytes, dictionary, TestFilterProvider.Instance, 1);
 
-            Assert.Throws<ArgumentOutOfRangeException>(action);
+            Assert.Equal(decoded, Encoding.ASCII.GetString(result.ToArray()));
         }
 
         private const string PdfContent = @"1 0 obj


### PR DESCRIPTION
thanks for the reviews @BobLd, I'm not sure how long I'm back for but have a little motivation again at the moment

this change attempts a fix for #782 but without reference documents I'm not certain this is the actual fix

this aligns our decoder with the behavior of pdfbox and c (https://github.com/dcurrie/ascii85/tree/master) implementations where single character final blocks are ignored rather than being written. also makes the error more informative in case it is ever encountered again.

also adds more test cases for ASCII85.

it is possible this is hiding the problem and will move the error elsewhere but this matches the implementation behavior of the 2 reference implementations.

one other potential source for the error is if pdf supports '<~' as a start of data marker which i can't find in the spec but wikipedia says might be possible? https://en.wikipedia.org/wiki/Ascii85#Adobe_version however the source for this is a single implementation in a language I don't understand.

without documents to trigger the error i think this is the best fix for now