### PR TITLE
fix off-by-one and optimize brute force xref search #1078

### DIFF
--- a/src/UglyToad.PdfPig.Tests/Util/CircularByteBufferTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Util/CircularByteBufferTests.cs
@@ -1,0 +1,47 @@
+﻿namespace UglyToad.PdfPig.Tests.Util;
+
+using PdfPig.Util;
+using System;
+
+public class CircularByteBufferTests
+{
+    [Fact]
+    public void CanExceedCapacity()
+    {
+        var buffer = new CircularByteBuffer(3);
+
+        var input = "123456"u8;
+        for (var i = 0; i < input.Length; i++)
+        {
+            buffer.Add(input[i]);
+        }
+
+        Assert.True(buffer.IsCurrentlyEqual("456"));
+
+        Assert.True("456"u8.SequenceEqual(buffer.AsSpan()));
+
+        Assert.True(buffer.EndsWith("6"));
+        Assert.True(buffer.EndsWith("56"));
+        Assert.True(buffer.EndsWith("456"));
+        Assert.False(buffer.EndsWith("3456"));
+    }
+
+    [Fact]
+    public void CanUndershootCapacity()
+    {
+        var buffer = new CircularByteBuffer(9);
+
+        var input = "123456"u8;
+        for (var i = 0; i < input.Length; i++)
+        {
+            buffer.Add(input[i]);
+        }
+
+        Assert.True(buffer.IsCurrentlyEqual("123456"));
+
+        Assert.True(buffer.EndsWith("3456"));
+        Assert.False(buffer.EndsWith("123"));
+
+        Assert.True("123456"u8.SequenceEqual(buffer.AsSpan()));
+    }
+}

--- a/src/UglyToad.PdfPig/Util/CircularByteBuffer.cs
+++ b/src/UglyToad.PdfPig/Util/CircularByteBuffer.cs
@@ -1,0 +1,90 @@
+﻿namespace UglyToad.PdfPig.Util;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+internal class CircularByteBuffer(int size)
+{
+    private readonly byte[] buffer = new byte[size];
+
+    private int start;
+    private int count;
+
+    public void Add(byte b)
+    {
+        var insertionPosition = (start + count) % buffer.Length;
+
+        buffer[insertionPosition] = b;
+        if (count < buffer.Length)
+        {
+            count++;
+        }
+        else
+        {
+            start = (start + 1) % buffer.Length;
+        }
+    }
+
+    public bool EndsWith(string s)
+    {
+        if (s.Length > count)
+        {
+            return false;
+        }
+
+        for (var i = 0; i < s.Length; i++)
+        {
+            var str = s[i];
+
+            var inBuffer = count - (s.Length - i);
+
+            var buff = buffer[IndexToBufferIndex(inBuffer)];
+
+            if (buff != str)
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    public bool IsCurrentlyEqual(string s)
+    {
+        if (s.Length > buffer.Length)
+        {
+            return false;
+        }
+
+        for (var i = 0; i < s.Length; i++)
+        {
+            var b = (byte)s[i];
+            var buff = buffer[IndexToBufferIndex(i)];
+
+            if (b != buff)
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    public ReadOnlySpan<byte> AsSpan()
+    {
+        Span<byte> tmp = new byte[count];
+        for (int i = 0; i < count; i++)
+        {
+            tmp[i] = buffer[IndexToBufferIndex(i)];
+        }
+
+        return tmp;
+    }
+
+    public override string ToString()
+    {
+        return Encoding.ASCII.GetString(AsSpan());
+    }
+
+    private int IndexToBufferIndex(int i) => (start + i) % buffer.Length;
+}


### PR DESCRIPTION
when performing a brute force xref search we were ending up off-by-one, update the search to use a ring buffer to reduce seeking and fix xref detection

I want to do some more testing around this since I don't understand how the existing code ever worked, but I'll let the CI tests run overnight. I'm going away for a week now, potentially more.