### PR TITLE
use correct bounding boxes for standard 14 glyphs #850

### DIFF
--- a/src/UglyToad.PdfPig.Tests/Integration/RotationAndCroppingTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Integration/RotationAndCroppingTests.cs
@@ -14,7 +14,7 @@
                 Assert.Equal(792, page.Height); // Due to cropping
                 var minX = page.Letters.Select(l => l.GlyphRectangle.Left).Min();
                 var maxX = page.Letters.Select(l => l.GlyphRectangle.Right).Max();
-                Assert.Equal(72, minX, 0);  // If cropping is not applied correctly, these values will be off
+                Assert.Equal(74, minX, 0);  // If cropping is not applied correctly, these values will be off
                 Assert.Equal(540, maxX, 0); // If cropping is not applied correctly, these values will be off
                 // The page is cropped at 
                 Assert.NotNull(page.Content);

--- a/src/UglyToad.PdfPig/PdfFonts/Simple/Type1Standard14Font.cs
+++ b/src/UglyToad.PdfPig/PdfFonts/Simple/Type1Standard14Font.cs
@@ -3,7 +3,6 @@ namespace UglyToad.PdfPig.PdfFonts.Simple
 {
     using System;
     using System.Collections.Generic;
-    using System.Diagnostics;
     using System.Diagnostics.CodeAnalysis;
     using Core;
     using Fonts;
@@ -84,36 +83,31 @@ namespace UglyToad.PdfPig.PdfFonts.Simple
 
         public CharacterBoundingBox GetBoundingBox(int characterCode)
         {
-            var boundingBox = GetBoundingBoxInGlyphSpace(characterCode);
+            var (boundingBox, advanceWidth) = GetBoundingBoxInGlyphSpace(characterCode);
 
             boundingBox = fontMatrix.Transform(boundingBox);
+            advanceWidth = fontMatrix.TransformX(advanceWidth);
 
-            return new CharacterBoundingBox(boundingBox, boundingBox.Width);
+            return new CharacterBoundingBox(boundingBox, advanceWidth);
         }
 
-        private PdfRectangle GetBoundingBoxInGlyphSpace(int characterCode)
+        private (PdfRectangle bounds, double advanceWidth) GetBoundingBoxInGlyphSpace(int characterCode)
         {
             var name = encoding.GetName(characterCode);
 
             if (!standardFontMetrics.CharacterMetrics.TryGetValue(name, out var metrics))
             {
-                return new PdfRectangle(0, 0, 250, 0);
+                return (new PdfRectangle(0, 0, 250, 0), 250);
             }
 
             var x = metrics.Width.X;
-            var y = metrics.Width.Y;
 
             if (metrics.Width.X == 0 && metrics.BoundingBox.Width > 0)
             {
                 x = metrics.BoundingBox.Width;
             }
 
-            if (metrics.Width.Y == 0 && metrics.BoundingBox.Height > 0)
-            {
-                y = metrics.BoundingBox.Height;
-            }
-
-            return new PdfRectangle(0, 0, x, y);
+            return (metrics.BoundingBox, x);
         }
 
         public TransformationMatrix GetFontMatrix()


### PR DESCRIPTION
previously every bounding box for type 1 standard 14 fonts was assumed to start at 0,0 and ignored the bounding box data in the font metrics file. now we correctly read the glyph bounding box while preserving the existing advance width values for advancing the renderer position