### PR TITLE
fall back to times-roman as standard 14 font when lenient

### DIFF
--- a/src/UglyToad.PdfPig/Parser/PdfDocumentFactory.cs
+++ b/src/UglyToad.PdfPig/Parser/PdfDocumentFactory.cs
@@ -168,7 +168,11 @@
                 pdfScanner,
                 parsingOptions);
 
-            var type1Handler = new Type1FontHandler(pdfScanner, filterProvider, encodingReader);
+            var type1Handler = new Type1FontHandler(
+                pdfScanner,
+                filterProvider,
+                encodingReader,
+                parsingOptions.UseLenientParsing);
 
             var trueTypeHandler = new TrueTypeFontHandler(parsingOptions.Logger,
                 pdfScanner,


### PR DESCRIPTION
if parsing in lenient mode and encountering a malformed base name (in this case 'helveticai') we fallback to times-roman as the adobe font metrics file for a standard 14 font. this aligns with the behavior of pdfbox. we also log a more informative error in non-lenient modes

this fixes document 0000086.pdf from the corpus