### PR TITLE
when writing content to an existing page inverse any global transform #614

### DIFF
--- a/src/UglyToad.PdfPig/Writer/PdfContentTransformationReader.cs
+++ b/src/UglyToad.PdfPig/Writer/PdfContentTransformationReader.cs
@@ -1,0 +1,36 @@
+﻿namespace UglyToad.PdfPig.Writer;
+
+using Core;
+using Graphics.Operations;
+using Graphics.Operations.SpecialGraphicsState;
+using System;
+using System.Collections.Generic;
+
+internal static class PdfContentTransformationReader
+{
+    public static TransformationMatrix? GetGlobalTransform(IEnumerable<IGraphicsStateOperation> operations)
+    {
+        TransformationMatrix? activeMatrix = null;
+        var stackDepth = 0;
+        foreach (var operation in operations)
+        {
+            if (operation is ModifyCurrentTransformationMatrix cm)
+            {
+                if (stackDepth == 0 && cm.Value.Length == 6)
+                {
+                    activeMatrix = TransformationMatrix.FromArray(cm.Value);
+                }
+            }
+            else if (operation is Push push)
+            {
+                stackDepth++;
+            }
+            else if (operation is Pop pop)
+            {
+                stackDepth--;
+            }
+        }
+
+        return activeMatrix;
+    }
+}


### PR DESCRIPTION
#614 

when adding a page to a builder from an existing document using either addpage or copyfrom methods the added page's content stream can contain a global transform matrix change that will subsequently change all the locations of any modifications made by the user. here whenever using an existing stream we apply the inverse of any active transformation matrix

there could be a bug here where if you use 'copy from' with a global transform active, we then apply the inverse, and you use 'copy from' again to the same destination page our inverse transform is now active and could potentially affect the second stream, but I don't think it will

this code isn't very clean but I think it will be sufficient for now until we can have a bigger refactor of this whole area