### PR TITLE
remove debug asserts causing test failures

### DIFF
--- a/src/UglyToad.PdfPig/Tokenization/Scanner/PdfTokenScanner.cs
+++ b/src/UglyToad.PdfPig/Tokenization/Scanner/PdfTokenScanner.cs
@@ -164,8 +164,6 @@
                         return true;
                     }
 
-                    // This should never happen.
-                    Debug.Assert(false, "Encountered a start object 'obj' operator before the end of the previous object.");
                     return false;
                 }
 
@@ -191,9 +189,7 @@
                 
                         return true;
                     }
-                
-                    // This should never happen.
-                    Debug.Assert(false, $"Encountered a '{coreTokenScanner.CurrentToken}' operator before the end of the previous object.");
+
                     return false;
                 }
 


### PR DESCRIPTION
we encountered a fence constructed in the middle of a field for an unknown reason so we demolished it. i think this was intended to catch flaws in the parser logic but the reality is in a pdf anything can happen so we no longer want to catch these issues and this restores a green test run in debug mode.

fix for #915