### PR TITLE
move last uncovered operators to switch statement

### DIFF
--- a/src/UglyToad.PdfPig.Tests/Graphics/Operations/GraphicsStateOperationTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Graphics/Operations/GraphicsStateOperationTests.cs
@@ -68,12 +68,20 @@
         [Fact]
         public void ReflectionGraphicsStateOperationFactoryKnowsAllOperations()
         {
-            var operationsField = typeof(ReflectionGraphicsStateOperationFactory).GetField("operations", BindingFlags.NonPublic | BindingFlags.Static);
-            var operationDictionary = operationsField.GetValue(null) as IReadOnlyDictionary<string, Type>;
-            Assert.NotNull(operationDictionary);
+            var operationsField = typeof(ReflectionGraphicsStateOperationFactory)
+                .GetField("Operations", BindingFlags.NonPublic | BindingFlags.Static);
+
+            Assert.NotNull(operationsField);
+
+            var operationDictionaryRaw = operationsField.GetValue(null) as IReadOnlyDictionary<string, Type>;
+
+            Assert.NotNull(operationDictionaryRaw);
+
+            var operationDictionary = new Dictionary<string, Type>(operationDictionaryRaw!.ToDictionary(x => x.Key, x => x.Value));
 
             var allOperations = GetOperationTypes();
-            Assert.Equal(allOperations.Count(), operationDictionary.Count);
+
+            Assert.Equal(allOperations.Count, operationDictionary.Count);
 
             var mapped = allOperations.Select(o =>
             {
@@ -84,14 +92,14 @@
             Assert.Equivalent(operationDictionary, mapped, strict: true);
         }
 
-        private static IEnumerable<Type> GetOperationTypes()
+        private static IReadOnlyList<Type> GetOperationTypes()
         {
             var assembly = Assembly.GetAssembly(typeof(IGraphicsStateOperation));
 
             var operationTypes = assembly.GetTypes().Where(x => typeof(IGraphicsStateOperation).IsAssignableFrom(x)
                                                                 && !x.IsInterface);
 
-            return operationTypes;
+            return operationTypes.ToList();
         }
 
         private static object[] GetConstructorParameters(ParameterInfo[] parameters)

--- a/src/UglyToad.PdfPig/Graphics/Operations/InlineImages/BeginInlineImageData.cs
+++ b/src/UglyToad.PdfPig/Graphics/Operations/InlineImages/BeginInlineImageData.cs
@@ -1,65 +1,64 @@
-﻿namespace UglyToad.PdfPig.Graphics.Operations.InlineImages
+﻿namespace UglyToad.PdfPig.Graphics.Operations.InlineImages;
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Tokens;
+using Writer;
+
+/// <inheritdoc />
+/// <summary>
+/// Begin the image data for an inline image object. 
+/// </summary>
+public class BeginInlineImageData : IGraphicsStateOperation
 {
-    using System;
-    using System.Collections.Generic;
-    using System.IO;
-    using Tokens;
-    using UglyToad.PdfPig.Writer;
+    /// <summary>
+    /// The symbol for this operation in a stream.
+    /// </summary>
+    public const string Symbol = "ID";
+        
+    /// <inheritdoc />
+    public string Operator => Symbol;
+
+    /// <summary>
+    /// The key-value pairs which specify attributes of the following image.
+    /// </summary>
+    public IReadOnlyDictionary<NameToken, IToken> Dictionary { get; }
+
+    /// <summary>
+    /// Create a new <see cref="BeginInlineImageData"/>.
+    /// </summary>
+    public BeginInlineImageData(IReadOnlyDictionary<NameToken, IToken> dictionary)
+    {
+        Dictionary = dictionary ?? throw new ArgumentNullException(nameof(dictionary));
+    }
 
     /// <inheritdoc />
-    /// <summary>
-    /// Begin the image data for an inline image object. 
-    /// </summary>
-    public class BeginInlineImageData : IGraphicsStateOperation
+    public void Run(IOperationContext operationContext)
     {
-        /// <summary>
-        /// The symbol for this operation in a stream.
-        /// </summary>
-        public const string Symbol = "ID";
-        
-        /// <inheritdoc />
-        public string Operator => Symbol;
+        operationContext.SetInlineImageProperties(Dictionary);
+    }
 
-        /// <summary>
-        /// The key-value pairs which specify attributes of the following image.
-        /// </summary>
-        public IReadOnlyDictionary<NameToken, IToken> Dictionary { get; }
-
-        /// <summary>
-        /// Create a new <see cref="BeginInlineImageData"/>.
-        /// </summary>
-        public BeginInlineImageData(IReadOnlyDictionary<NameToken, IToken> dictionary)
+    /// <inheritdoc />
+    public void Write(Stream stream)
+    {
+        var tokenWriter = TokenWriter.Instance;
+        foreach (var item in Dictionary)
         {
-            Dictionary = dictionary ?? throw new ArgumentNullException(nameof(dictionary));
-        }
+            var name = item.Key;
+            var value = item.Value;
 
-        /// <inheritdoc />
-        public void Run(IOperationContext operationContext)
-        {
-            operationContext.SetInlineImageProperties(Dictionary);
-        }
-
-        /// <inheritdoc />
-        public void Write(Stream stream)
-        {
-            var tokenWriter = TokenWriter.Instance;
-            foreach (var item in Dictionary)
-            {
-                var name = item.Key;
-                var value = item.Value;
-
-                stream.WriteText($"{name} ");
-                tokenWriter.WriteToken(value, stream);
-                stream.WriteNewLine();
-            }
-            stream.WriteText(Symbol);
+            stream.WriteText($"{name} ");
+            tokenWriter.WriteToken(value, stream);
             stream.WriteNewLine();
         }
+        stream.WriteText(Symbol);
+        stream.WriteNewLine();
+    }
 
-        /// <inheritdoc />
-        public override string ToString()
-        {
-            return Symbol;
-        }
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return Symbol;
     }
 }


### PR DESCRIPTION
in order to remove reflection from the core content stream operators construction we ensure all types covered by the operations dictionary have corresponding switch statement support. this moves the remaining 2 operators to the switch statement. fix for #1062

The integration tests will catch anything we missed but according to Gemini this covers all the remaining types.