### PR TITLE
rework numeric tokenizer hot path

### DIFF
--- a/src/UglyToad.PdfPig.Tests/Tokenization/NumericTokenizerTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Tokenization/NumericTokenizerTests.cs
@@ -29,6 +29,7 @@
         public static IEnumerable<object[]> ValidNumberTestData => new []
         {
             new object[] {"0", 0},
+            new object[] {"0003", 3},
             new object[] {"1", 1},
             new object[] {"2", 2},
             new object[] {"3", 3},
@@ -55,19 +56,29 @@
             new object[] { "4.", 4},
             new object[] { "-.002", -0.002},
             new object[] { "0.0", 0},
-            new object[] {"1.57e3", 1570}
+            new object[] {"1.57e3", 1570},
+            new object[] {"1.57e-3", 0.00157, 0.0000001},
+            new object[] {"1.24e1", 12.4},
+            new object[] { "1.457E2", 145.7 }
         };
 
         [Theory]
         [MemberData(nameof(ValidNumberTestData))]
-        public void ParsesValidNumbers(string s, double expected)
+        public void ParsesValidNumbers(string s, double expected, double? tolerance = null)
         {
             var input = StringBytesTestConverter.Convert(s);
 
             var result = tokenizer.TryTokenize(input.First, input.Bytes, out var token);
 
             Assert.True(result);
-            Assert.Equal(expected, AssertNumericToken(token).Data);
+            if (tolerance.HasValue)
+            {
+                Assert.Equal(expected, AssertNumericToken(token).Data, tolerance: tolerance.Value);
+            }
+            else
+            {
+                Assert.Equal(expected, AssertNumericToken(token).Data);
+            }
         }
 
         [Fact]


### PR DESCRIPTION
the existing numeric tokenizer involved allocations and string parsing. since the number formats in pdf files are fairly predictable we can improve this substantially

this ends up being somewhere between 2-3 times faster in my benchmarks on a subset of numeric data from PDF files:

```
| Method | Mean      | Error     | StdDev    |
|------- |----------:|----------:|----------:|
| PigOld | 13.684 us | 0.2333 us | 0.2182 us |
| PigNew |  5.963 us | 0.0990 us | 0.0877 us |

| Method | Mean      | Error     | StdDev    |
|------- |----------:|----------:|----------:|
| PigOld | 14.806 us | 0.2098 us | 0.1962 us |
| PigNew |  6.230 us | 0.1205 us | 0.1127 us |
```

Based on tracing for opening ~350 documents the tokenize method here was called approximately 16.2 million times so is definitely a hot path. Real world performance impact may be different.