### PR TITLE
handle additional broken pdf files in the common crawl set

### DIFF
--- a/src/UglyToad.PdfPig.Fonts/CompactFontFormat/Charsets/CompactFontFormatCharset.cs
+++ b/src/UglyToad.PdfPig.Fonts/CompactFontFormat/Charsets/CompactFontFormatCharset.cs
@@ -32,7 +32,7 @@
 
         public virtual string GetNameByStringId(int stringId)
         {
-            return GlyphIdToStringIdAndName.SingleOrDefault(x => x.Value.stringId == stringId).Value.name;
+            return GlyphIdToStringIdAndName.FirstOrDefault(x => x.Value.stringId == stringId).Value.name;
         }
 
         public virtual int GetStringIdByGlyphId(int glyphId)

--- a/src/UglyToad.PdfPig/PdfFonts/FontFactory.cs
+++ b/src/UglyToad.PdfPig/PdfFonts/FontFactory.cs
@@ -44,6 +44,25 @@
                 return handler.Generate(dictionary);
             }
 
+            // Try simple font recovery:
+            NameToken[] orderedFallbacks = [NameToken.Type1, NameToken.TrueType];
+            foreach (var fallback in orderedFallbacks)
+            {
+                if (!handlers.TryGetValue(fallback, out handler))
+                {
+                    continue;
+                }
+
+                try
+                {
+                    return handler.Generate(dictionary);
+                }
+                catch (Exception ex)
+                {
+                    log?.Error($"Tried to parse font as fallback type: {fallback}", ex);
+                }
+            }
+
             throw new NotImplementedException($"Parsing not implemented for fonts of type: {subtype}, please submit a pull request or an issue.");
         }
     }


### PR DESCRIPTION
- a file contained 2 indices pointing to '.notdef' for the character name so we just take the first rather than requiring a single
- a file contained '/' (empty name) as the subtype declaration, so we fall back to trying type 1 and truetype parsing in this situation

with these changes we can now parse the 6000 files from `0000` to `0005` in the corpus with the exception of corrupt files and files with corrupt xrefs which we can't currently recover from but are possible to parse in some readers:

- 0005634.pdf
- 0002973.pdf

https://digitalcorpora.s3.amazonaws.com/s3_browser.html#corpora/files/CC-MAIN-2021-31-PDF-UNTRUNCATED/zipfiles/0000-0999/