### PR TITLE
add nullability to core project

### DIFF
--- a/src/UglyToad.PdfPig.Core/ArrayPoolBufferWriter.cs
+++ b/src/UglyToad.PdfPig.Core/ArrayPoolBufferWriter.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Buffers;
+﻿using System.Buffers;
 
 namespace UglyToad.PdfPig.Core;
 

--- a/src/UglyToad.PdfPig.Core/IndirectReference.cs
+++ b/src/UglyToad.PdfPig.Core/IndirectReference.cs
@@ -71,7 +71,7 @@
         }
 
         /// <inheritdoc />
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             return obj is IndirectReference other && Equals(other);
         }

--- a/src/UglyToad.PdfPig.Core/OtherEncodings.cs
+++ b/src/UglyToad.PdfPig.Core/OtherEncodings.cs
@@ -16,7 +16,7 @@
         /// <summary>
         /// Convert the string to bytes using the ISO 8859-1 encoding.
         /// </summary>
-        public static byte[] StringAsLatin1Bytes(string s)
+        public static byte[]? StringAsLatin1Bytes(string? s)
         {
             if (s == null)
             {

--- a/src/UglyToad.PdfPig.Core/PdfDocEncoding.cs
+++ b/src/UglyToad.PdfPig.Core/PdfDocEncoding.cs
@@ -264,7 +264,7 @@
         /// Try to convert raw bytes to a PdfDocEncoding encoded string. If unsupported characters are encountered
         /// meaning we cannot safely round-trip the value to bytes this will instead return false.
         /// </summary>
-        public static bool TryConvertBytesToString(ReadOnlySpan<byte> bytes, out string result)
+        public static bool TryConvertBytesToString(ReadOnlySpan<byte> bytes, out string? result)
         {
             result = null;
             if (bytes.Length == 0)

--- a/src/UglyToad.PdfPig.Core/PdfLine.cs
+++ b/src/UglyToad.PdfPig.Core/PdfLine.cs
@@ -70,7 +70,7 @@
         /// <summary>
         /// Returns a value indicating whether this <see cref="PdfLine"/> is equal to a specified <see cref="PdfLine"/> .
         /// </summary>
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             return obj is PdfLine other && Equals(other);
         }

--- a/src/UglyToad.PdfPig.Core/PdfPoint.cs
+++ b/src/UglyToad.PdfPig.Core/PdfPoint.cs
@@ -83,7 +83,7 @@
         /// <summary>
         /// Returns a value indicating whether this <see cref="PdfPoint"/> is equal to a specified <see cref="PdfPoint"/> .
         /// </summary>
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             return obj is PdfPoint other && Equals(other);
         }

--- a/src/UglyToad.PdfPig.Core/PdfRectangle.cs
+++ b/src/UglyToad.PdfPig.Core/PdfRectangle.cs
@@ -177,7 +177,7 @@
         }
 
         /// <inheritdoc />
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             return obj is PdfRectangle other && Equals(other);
         }

--- a/src/UglyToad.PdfPig.Core/PdfSubpath.cs
+++ b/src/UglyToad.PdfPig.Core/PdfSubpath.cs
@@ -241,8 +241,8 @@
         public bool IsClosed()
         {
             var filteredCount = 0;
-            IPathCommand last = null;
-            IPathCommand first = null;
+            IPathCommand? last = null;
+            IPathCommand? first = null;
             for (int i = Commands.Count - 1; i >= 0; i--)
             {
                 var cmd = Commands[i];
@@ -376,14 +376,14 @@
         /// Gets a <see cref="PdfRectangle"/> which entirely contains the geometry of the defined path.
         /// </summary>
         /// <returns>For paths which don't define any geometry this returns <see langword="null"/>.</returns>
-        public static PdfRectangle? GetBoundingRectangle(IReadOnlyList<PdfSubpath> path)
+        public static PdfRectangle? GetBoundingRectangle(IReadOnlyList<PdfSubpath>? path)
         {
             if (path == null || path.Count == 0)
             {
                 return null;
             }
 
-            var bboxes = path.Select(x => x.GetBoundingRectangle()).Where(x => x.HasValue).Select(x => x.Value).ToList();
+            var bboxes = path.Select(x => x.GetBoundingRectangle()).Where(x => x.HasValue).Select(x => x!.Value).ToList();
             if (bboxes.Count == 0)
             {
                 return null;
@@ -433,7 +433,7 @@
             }
 
             /// <inheritdoc />
-            public override bool Equals(object obj)
+            public override bool Equals(object? obj)
             {
                 return (obj is Close);
             }
@@ -479,7 +479,7 @@
             }
 
             /// <inheritdoc />
-            public override bool Equals(object obj)
+            public override bool Equals(object? obj)
             {
                 if (obj is Move move)
                 {
@@ -545,7 +545,7 @@
             }
 
             /// <inheritdoc />
-            public override bool Equals(object obj)
+            public override bool Equals(object? obj)
             {
                 if (obj is Line line)
                 {
@@ -651,7 +651,7 @@
             }
 
             /// <inheritdoc />
-            public override bool Equals(object obj)
+            public override bool Equals(object? obj)
             {
                 if (obj is QuadraticBezierCurve curve)
                 {
@@ -809,7 +809,7 @@
             }
 
             /// <inheritdoc />
-            public override bool Equals(object obj)
+            public override bool Equals(object? obj)
             {
                 if (obj is CubicBezierCurve curve)
                 {
@@ -944,7 +944,7 @@
         /// <summary>
         /// Compares two <see cref="PdfSubpath"/>s for equality. Paths will only be considered equal if the commands which construct the paths are in the same order.
         /// </summary>
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             if (!(obj is PdfSubpath path) || Commands.Count != path.Commands.Count)
             {

--- a/src/UglyToad.PdfPig.Core/TransformationMatrix.cs
+++ b/src/UglyToad.PdfPig.Core/TransformationMatrix.cs
@@ -463,7 +463,7 @@
         }
 
         /// <inheritdoc />
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             return obj is TransformationMatrix other && Equals(other);
         }

--- a/src/UglyToad.PdfPig.Core/UglyToad.PdfPig.Core.csproj
+++ b/src/UglyToad.PdfPig.Core/UglyToad.PdfPig.Core.csproj
@@ -7,6 +7,8 @@
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
 		<SignAssembly>true</SignAssembly>
 		<AssemblyOriginatorKeyFile>..\pdfpig.snk</AssemblyOriginatorKeyFile>
+		<Nullable>enable</Nullable>
+        <WarningsAsErrors>nullable</WarningsAsErrors>
 	</PropertyGroup>
 	<ItemGroup Condition="'$(TargetFramework)'=='net462'">
 		<PackageReference Include="System.ValueTuple" Version="4.5.0" />

--- a/src/UglyToad.PdfPig.Core/Union.cs
+++ b/src/UglyToad.PdfPig.Core/Union.cs
@@ -89,7 +89,7 @@ namespace UglyToad.PdfPig.Core
             /// <inheritdoc />
             public override bool TryGetSecond(out B b)
             {
-                b = default(B);
+                b = default!;
                 return false;
             }
 
@@ -135,7 +135,7 @@ namespace UglyToad.PdfPig.Core
             /// <inheritdoc />
             public override bool TryGetFirst(out A a)
             {
-                a = default(A);
+                a = default!;
                 return false;
             }
 


### PR DESCRIPTION
Make `UglyToad.PdfPig.Core` support nullability. The change to `Union<A, B>` seems wrong to me but we have until 0.1.12 to fix this