### PR TITLE
Draft release on master build

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -1,4 +1,4 @@
-name: Build and test
+name: Build, test and publish draft
 
 on:
   push:
@@ -10,7 +10,7 @@ jobs:
   build:
     runs-on: windows-2022
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
 
       - name: Set up dotnet core
         uses: actions/setup-dotnet@v4
@@ -29,3 +29,14 @@ jobs:
 
       - name: Run the tests
         run: dotnet test -c Release src/UglyToad.PdfPig.sln
+
+      - name: Update draft release
+        if: github.ref == 'refs/heads/master'
+        uses: softprops/action-gh-release@v2
+        with:
+          draft: true
+          name: "Draft release"
+          tag_name: "unreleased" # fixed tag so this one draft is updated
+          generate_release_notes: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -1,0 +1,48 @@
+name: Release Publish
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: write
+  packages: write
+
+jobs:
+  build_and_publish_release:
+    runs-on: windows-2022
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up dotnet core
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: |
+            2.1.x
+            6.0.x
+            8.0.x
+            9.0.x
+
+      - name: Add msbuild to PATH
+        uses: microsoft/setup-msbuild@v2
+
+      - name: Run tests
+        run: dotnet test -c Release src/UglyToad.PdfPig.sln
+
+      - name: Build package
+        run: dotnet pack -c Release -o package tools/UglyToad.PdfPig.Package/UglyToad.PdfPig.Package.csproj -p:IncludeSymbols=true -p:SymbolPackageFormat=snupkg
+
+      - name: Publish to NuGet
+        run: dotnet nuget push **/*.nupkg --api-key ${{secrets.NUGET_API_KEY}} --source https://api.nuget.org/v3/index.json
+
+      - name: Increment version after release
+        run: |
+          $newVer = .\tools\get-next-main-version.ps1
+          .\tools\set-version.ps1 $newVer
+          git config user.name "github-actions"
+          git config user.email "github-actions@github.com"
+          git commit -am "Increment version to $newVer"
+          git push

--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Increment version after release
         run: |
           $newVer = .\tools\get-next-main-version.ps1
-          .\tools\set-version.ps1 $newVer
+          .\tools\set-version.ps1 $newVer -UpdateAssemblyAndFileVersion
           git config user.name "github-actions"
           git config user.email "github-actions@github.com"
           git commit -am "Increment version to $newVer"

--- a/src/UglyToad.PdfPig.Core/UglyToad.PdfPig.Core.csproj
+++ b/src/UglyToad.PdfPig.Core/UglyToad.PdfPig.Core.csproj
@@ -2,12 +2,12 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net462;net471;net6.0;net8.0;net9.0</TargetFrameworks>
     <LangVersion>12</LangVersion>
-    <Version>0.1.12-alpha001</Version>
+    <Version>0.1.12</Version>
     <IsTestProject>False</IsTestProject>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\pdfpig.snk</AssemblyOriginatorKeyFile>
-		<Nullable>enable</Nullable>
+    <Nullable>enable</Nullable>
     <WarningsAsErrors>nullable</WarningsAsErrors>
   </PropertyGroup>
   <ItemGroup Condition="'$(TargetFramework)'=='net462'">

--- a/src/UglyToad.PdfPig.DocumentLayoutAnalysis/UglyToad.PdfPig.DocumentLayoutAnalysis.csproj
+++ b/src/UglyToad.PdfPig.DocumentLayoutAnalysis/UglyToad.PdfPig.DocumentLayoutAnalysis.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net462;net471;net6.0;net8.0;net9.0</TargetFrameworks>
     <LangVersion>12</LangVersion>
-    <Version>0.1.12-alpha001</Version>
+    <Version>0.1.12</Version>
     <IsTestProject>False</IsTestProject>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <SignAssembly>true</SignAssembly>

--- a/src/UglyToad.PdfPig.Fonts/UglyToad.PdfPig.Fonts.csproj
+++ b/src/UglyToad.PdfPig.Fonts/UglyToad.PdfPig.Fonts.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net462;net471;net6.0;net8.0;net9.0</TargetFrameworks>
     <LangVersion>12</LangVersion>
-    <Version>0.1.12-alpha001</Version>
+    <Version>0.1.12</Version>
     <IsTestProject>False</IsTestProject>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <SignAssembly>true</SignAssembly>

--- a/src/UglyToad.PdfPig.Tokenization/UglyToad.PdfPig.Tokenization.csproj
+++ b/src/UglyToad.PdfPig.Tokenization/UglyToad.PdfPig.Tokenization.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net462;net471;net6.0;net8.0;net9.0</TargetFrameworks>
     <LangVersion>12</LangVersion>
-    <Version>0.1.12-alpha001</Version>
+    <Version>0.1.12</Version>
     <IsTestProject>False</IsTestProject>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <SignAssembly>true</SignAssembly>

--- a/src/UglyToad.PdfPig.Tokens/UglyToad.PdfPig.Tokens.csproj
+++ b/src/UglyToad.PdfPig.Tokens/UglyToad.PdfPig.Tokens.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net462;net471;net6.0;net8.0;net9.0</TargetFrameworks>
     <LangVersion>12</LangVersion>
-    <Version>0.1.12-alpha001</Version>
+    <Version>0.1.12</Version>
     <IsTestProject>False</IsTestProject>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <SignAssembly>true</SignAssembly>

--- a/src/UglyToad.PdfPig/UglyToad.PdfPig.csproj
+++ b/src/UglyToad.PdfPig/UglyToad.PdfPig.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net462;net471;net6.0;net8.0;net9.0</TargetFrameworks>
     <LangVersion>12</LangVersion>
-    <Version>0.1.12-alpha001</Version>
+    <Version>0.1.12</Version>
     <IsTestProject>False</IsTestProject>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <SignAssembly>true</SignAssembly>

--- a/tools/UglyToad.PdfPig.Package/UglyToad.PdfPig.Package.csproj
+++ b/tools/UglyToad.PdfPig.Package/UglyToad.PdfPig.Package.csproj
@@ -11,7 +11,7 @@
     <PackageTags>PDF;Reader;Document;Adobe;PDFBox;PdfPig;pdf-extract;pdf-to-text;pdf;file;text;C#;dotnet;.NET</PackageTags>
     <RepositoryUrl>https://github.com/UglyToad/PdfPig</RepositoryUrl>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <Version>0.1.12-alpha001</Version>
+    <Version>0.1.12</Version>
     <AssemblyVersion>0.1.12.0</AssemblyVersion>
     <FileVersion>0.1.12.0</FileVersion>
     <PackageIconUrl>https://raw.githubusercontent.com/UglyToad/PdfPig/master/documentation/pdfpig.png</PackageIconUrl>

--- a/tools/get-main-version.ps1
+++ b/tools/get-main-version.ps1
@@ -1,5 +1,6 @@
 $xml = New-Object XML
-$xml.Load(".\tools\UglyToad.PdfPig.Package\UglyToad.PdfPig.Package.csproj")
+$projectPath = Join-Path $PSScriptRoot "UglyToad.PdfPig.Package\UglyToad.PdfPig.Package.csproj"
+$xml.Load($projectPath)
 $current = $xml.Project.PropertyGroup[0].Version
 $hyphenIndex = $current.IndexOf('-')
 $len = If ($hyphenIndex -lt 0) { $current.Length } Else { $hyphenIndex }

--- a/tools/get-next-main-version.ps1
+++ b/tools/get-next-main-version.ps1
@@ -1,0 +1,20 @@
+$xml = New-Object XML
+$projectPath = Join-Path $PSScriptRoot "UglyToad.PdfPig.Package\UglyToad.PdfPig.Package.csproj"
+$xml.Load($projectPath)
+$current = $xml.Project.PropertyGroup[0].Version
+$hyphenIndex = $current.IndexOf('-')
+$len = If ($hyphenIndex -lt 0) { $current.Length } Else { $hyphenIndex }
+$version = $current.Substring(0, $len)
+
+# Split into parts
+$parts = $version.Split('.')
+
+# Increment last part (patch)
+$patch = [int]$parts[-1]
+$patch++
+
+# Build new version string
+$parts[-1] = $patch.ToString()
+$newVersion = $parts -join '.'
+
+Write-Output $newVersion

--- a/tools/set-version.ps1
+++ b/tools/set-version.ps1
@@ -1,6 +1,8 @@
 param (
   [Parameter(Position = 0, mandatory = $true)]
-  [string]$version
+  [string]$version,
+
+  [switch]$UpdateAssemblyAndFileVersion
 )
 
 $root = (Split-Path -parent $PSCommandPath)
@@ -17,6 +19,26 @@ $packageProjectPath = "$root/UglyToad.PdfPig.Package/UglyToad.PdfPig.Package.csp
 $xml = New-Object XML
 $xml.Load($packageProjectPath)
 $xml.Project.PropertyGroup[0].Version = $version
+
+if ($UpdateAssemblyAndFileVersion) {
+    # Update AssemblyVersion and FileVersion if the nodes exist, otherwise create them
+    if (-not $xml.Project.PropertyGroup[0].AssemblyVersion) {
+        $node = $xml.CreateElement("AssemblyVersion")
+        $node.InnerText = "$version.0"  # add the 4th segment
+        $xml.Project.PropertyGroup[0].AppendChild($node) | Out-Null
+    } else {
+        $xml.Project.PropertyGroup[0].AssemblyVersion = "$version.0"
+    }
+
+    if (-not $xml.Project.PropertyGroup[0].FileVersion) {
+        $node = $xml.CreateElement("FileVersion")
+        $node.InnerText = "$version.0"
+        $xml.Project.PropertyGroup[0].AppendChild($node) | Out-Null
+    } else {
+        $xml.Project.PropertyGroup[0].FileVersion = "$version.0"
+    }
+}
+
 $xml.Save($packageProjectPath)
 
 Write-Host $projs.Length


### PR DESCRIPTION
This PR changes the actions as follows:

- Remove the -alpha-001 postfix from all project version numbers
- Pushes to master will draft a new release in GitHub
- Publishing the release from GitHub will build, test and push the full version and then commit an increment for the version in the project files as well and assembly and file version