### PR TITLE
First create the StreamInputBytes in PdfDocument.Open() to check the stream CanRead and CanSeek

### DIFF
--- a/src/UglyToad.PdfPig/Parser/PdfDocumentFactory.cs
+++ b/src/UglyToad.PdfPig/Parser/PdfDocumentFactory.cs
@@ -44,9 +44,9 @@
 
         internal static PdfDocument Open(Stream stream, ParsingOptions? options)
         {
-            var initialPosition = stream.Position;
-
             var streamInput = new StreamInputBytes(stream, false);
+
+            var initialPosition = stream.Position;
 
             try
             {


### PR DESCRIPTION
address part of #1146

`stream.Position` needs `CanSeek` (see https://learn.microsoft.com/en-us/dotnet/api/system.io.stream.position?view=net-9.0)

We just create the `StreamInputBytes` before accessing the Position