### PR TITLE
Add xref-streams tied to any parts, not just the first

### DIFF
--- a/src/UglyToad.PdfPig/CrossReference/CrossReferenceTableBuilder.cs
+++ b/src/UglyToad.PdfPig/CrossReference/CrossReferenceTableBuilder.cs
@@ -56,16 +56,16 @@
                 // add this and follow chain defined by 'Prev' keys
                 xrefPartToBytePositionOrder.Add(firstCrossReferenceOffset);
 
-                // Get any streams that are tied to this table.
-                var activePart = currentPart;
-                var dependents = parts.Where(x => x.TiedToXrefAtOffset == activePart.Offset);
-                foreach (var dependent in dependents)
-                {
-                    xrefPartToBytePositionOrder.Add(dependent.Offset);
-                }
-
                 while (currentPart.Dictionary != null)
                 {
+                    // Get any streams that are tied to this table.
+                    var activePart = currentPart;
+                    var dependents = parts.Where(x => x.TiedToXrefAtOffset == activePart.Offset);
+                    foreach (var dependent in dependents)
+                    {
+                        xrefPartToBytePositionOrder.Add(dependent.Offset);
+                    }
+
                     long prevBytePos = currentPart.GetPreviousOffset();
                     if (prevBytePos == -1)
                     {


### PR DESCRIPTION
### What happened today was me fixing a bug in PdfPig:

On 8000 pdf-files PdfPig failed to read the correct StructTree-object for about 1% of them. The StructTree object was simply missing in the CrossReferenceTable.
It turned out that the constructed CrossReferenceTable could miss Stream-parts if there were multiple Table-parts because a stream will only be added if it's associated with the very first Table-part. The remedy would seem to be to check for and add streams that are associated with any of the Table-parts, not just the first one.
On a sample of 72 files where this failed, this changed fixed the StructTree for all of them.
I've included four files where this was fixed:

[doc-00044a646349ce519d9b7287159795cc.pdf](https://github.com/user-attachments/files/22567156/doc-00044a646349ce519d9b7287159795cc.pdf)
[doc-00072bb64c86990e7391ef5baca69099.pdf](https://github.com/user-attachments/files/22567157/doc-00072bb64c86990e7391ef5baca69099.pdf)
[doc-000558f2b1d03d09ea6bb359732a8f09.pdf](https://github.com/user-attachments/files/22567158/doc-000558f2b1d03d09ea6bb359732a8f09.pdf)
[doc-000518224506a58efb993b67ef57661b.pdf](https://github.com/user-attachments/files/22567159/doc-000518224506a58efb993b67ef57661b.pdf)

### Then I made a PR and discovered everything had changed

I fetched latest master (it had been a couple of months) and realized that the code wasn't called anymore because the parsing of xrefs had been completely refactored: https://github.com/UglyToad/PdfPig/commit/0afe021ad396b0919a451a2c6a750acaa336deaa

The refactored PdfPig-code still can't deal with that situation (for instance the 4 files I've attached) so I'm back to square one.

Even though my change in this PR is for some files than are no longer in play I'm submitting it anyway, since it may give you a hint about what's currently wrong and how to fix it.