### PR TITLE
Avoid doing a true file seek for simple peeking in the token parser

### DIFF
--- a/src/UglyToad.PdfPig/Parser/PdfDocumentFactory.cs
+++ b/src/UglyToad.PdfPig/Parser/PdfDocumentFactory.cs
@@ -25,9 +25,9 @@
 
     internal static class PdfDocumentFactory
     {
-        public static PdfDocument Open(byte[] fileBytes, ParsingOptions? options = null)
+        public static PdfDocument Open(ReadOnlyMemory<byte> memory, ParsingOptions? options = null)
         {
-            var inputBytes = new MemoryInputBytes(fileBytes);
+            var inputBytes = new MemoryInputBytes(memory);
 
             return Open(inputBytes, options);
         }

--- a/src/UglyToad.PdfPig/PdfDocument.cs
+++ b/src/UglyToad.PdfPig/PdfDocument.cs
@@ -103,6 +103,14 @@
         public static PdfDocument Open(byte[] fileBytes, ParsingOptions? options = null) => PdfDocumentFactory.Open(fileBytes, options);
 
         /// <summary>
+        /// Creates a <see cref="PdfDocument"/> for reading from the provided file bytes.
+        /// </summary>
+        /// <param name="memory">The bytes of the PDF file.</param>
+        /// <param name="options">Optional parameters controlling parsing.</param>
+        /// <returns>A <see cref="PdfDocument"/> providing access to the file contents.</returns>
+        public static PdfDocument Open(ReadOnlyMemory<byte> memory, ParsingOptions? options = null) => PdfDocumentFactory.Open(memory, options);
+
+        /// <summary>
         /// Opens a file and creates a <see cref="PdfDocument"/> for reading from the provided file path.
         /// </summary>
         /// <param name="filePath">The full path to the file location of the PDF file.</param>

--- a/src/UglyToad.PdfPig/Tokenization/Scanner/PdfTokenScanner.cs
+++ b/src/UglyToad.PdfPig/Tokenization/Scanner/PdfTokenScanner.cs
@@ -342,14 +342,9 @@
 
                 if ((char)inputBytes.CurrentByte == '\r')
                 {
-                    if (!inputBytes.MoveNext())
+                    if (inputBytes.Peek() == '\n')
                     {
-                        return false;
-                    }
-
-                    if ((char)inputBytes.CurrentByte != '\n')
-                    {
-                        inputBytes.Seek(inputBytes.CurrentOffset - 1);
+                        inputBytes.MoveNext();
                     }
                     break;
                 }


### PR DESCRIPTION
A seek on a plain filestream is handled by the OS so has some overhead. We can easily avoid that.

Handle the normal peek, and also use this code in the EOL detection that did its own peeking by using seek.
(Shaves a few percent of the time running the test suite for me).

Also allow opening a pdf from a ReadOnlyMemory<byte> object without using .ToArray().
