### PR TITLE
Avoid reading ahead and then seeking back

### DIFF
--- a/src/UglyToad.PdfPig.Core/ReadHelper.cs
+++ b/src/UglyToad.PdfPig.Core/ReadHelper.cs
@@ -24,12 +24,17 @@
         /// </summary>
         public const byte AsciiCarriageReturn = 13;
 
+        /// <summary>
+        /// The tab '\t' character.
+        /// </summary>
+        public const byte AsciiTab = 9;
+
         private static readonly HashSet<int> EndOfNameCharacters =
         [
             ' ',
             AsciiCarriageReturn,
             AsciiLineFeed,
-            9,
+            AsciiTab,
             '>',
             '<',
             '[',

--- a/src/UglyToad.PdfPig.Core/StreamInputBytes.cs
+++ b/src/UglyToad.PdfPig.Core/StreamInputBytes.cs
@@ -96,6 +96,17 @@
         /// <inheritdoc />
         public void Seek(long position)
         {
+            var current = CurrentOffset;
+            if (position == current)
+            {
+                return;
+            }
+            else if (peekByte.HasValue && position == current + 1)
+            {
+                MoveNext();
+                return;
+            }
+
             isAtEnd = false;
             peekByte = null;
 

--- a/src/UglyToad.PdfPig.Fonts/Type1/Parser/Type1ArrayTokenizer.cs
+++ b/src/UglyToad.PdfPig.Fonts/Type1/Parser/Type1ArrayTokenizer.cs
@@ -14,7 +14,7 @@
         /// <inheritdoc />
         public bool ReadsNextByte { get; } = false;
 
-        private static readonly string[] Space = [" "];
+        private static readonly char[] Space = [' '];
 
         /// <inheritdoc />
         public bool TryTokenize(byte currentByte, IInputBytes inputBytes, out IToken token)

--- a/src/UglyToad.PdfPig.Fonts/Type1/Parser/Type1FontParser.cs
+++ b/src/UglyToad.PdfPig.Fonts/Type1/Parser/Type1FontParser.cs
@@ -88,6 +88,11 @@
                         {
                             int offset = 0;
 
+                            while (inputBytes.Peek() is { } b && ReadHelper.IsWhitespace(b))
+                            {
+                                inputBytes.MoveNext();
+                            }
+
                             while (inputBytes.MoveNext())
                             {
                                 if (inputBytes.CurrentByte == (byte)ClearToMark[offset])

--- a/src/UglyToad.PdfPig.Tests/Tokenization/NumericTokenizerTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Tokenization/NumericTokenizerTests.cs
@@ -91,7 +91,10 @@
             Assert.True(result);
             Assert.Equal(135.6654, AssertNumericToken(token).Data);
 
-            Assert.Equal('/', (char)input.Bytes.CurrentByte);
+            if (tokenizer.ReadsNextByte)
+                Assert.Equal('/', (char)input.Bytes.CurrentByte);
+            else
+                Assert.Equal('4', (char)input.Bytes.CurrentByte);
         }
 
         [Fact]

--- a/src/UglyToad.PdfPig.Tokenization/ArrayTokenizer.cs
+++ b/src/UglyToad.PdfPig.Tokenization/ArrayTokenizer.cs
@@ -9,7 +9,7 @@
     {
         private readonly bool usePdfDocEncoding;
 
-        public bool ReadsNextByte { get; } = false;
+        public bool ReadsNextByte => false;
 
         public ArrayTokenizer(bool usePdfDocEncoding)
         {

--- a/src/UglyToad.PdfPig.Tokenization/CommentTokenizer.cs
+++ b/src/UglyToad.PdfPig.Tokenization/CommentTokenizer.cs
@@ -6,7 +6,7 @@
 
     internal sealed class CommentTokenizer : ITokenizer
     {
-        public bool ReadsNextByte { get; } = true;
+        public bool ReadsNextByte => false;
 
         public bool TryTokenize(byte currentByte, IInputBytes inputBytes, out IToken token)
         {
@@ -17,10 +17,11 @@
                 return false;
             }
 
-            using var builder = new ValueStringBuilder();
+            using var builder = new ValueStringBuilder(stackalloc char[32]);
 
-            while (inputBytes.MoveNext() && !ReadHelper.IsEndOfLine(inputBytes.CurrentByte))
+            while (inputBytes.Peek() is { } c && !ReadHelper.IsEndOfLine(c))
             {
+                inputBytes.MoveNext();
                 builder.Append((char) inputBytes.CurrentByte);
             }
 

--- a/src/UglyToad.PdfPig.Tokenization/DictionaryTokenizer.cs
+++ b/src/UglyToad.PdfPig.Tokenization/DictionaryTokenizer.cs
@@ -11,7 +11,7 @@
         private readonly IReadOnlyList<NameToken> requiredKeys;
         private readonly bool useLenientParsing;
 
-        public bool ReadsNextByte { get; } = false;
+        public bool ReadsNextByte => false;
 
         /// <summary>
         /// Create a new <see cref="DictionaryTokenizer"/>.

--- a/src/UglyToad.PdfPig.Tokenization/EndOfLineTokenizer.cs
+++ b/src/UglyToad.PdfPig.Tokenization/EndOfLineTokenizer.cs
@@ -9,7 +9,7 @@
     public sealed class EndOfLineTokenizer : ITokenizer
     {
         /// <inheritdoc />
-        public bool ReadsNextByte { get; } = false;
+        public bool ReadsNextByte => false;
 
         /// <inheritdoc />
         public bool TryTokenize(byte currentByte, IInputBytes inputBytes, out IToken token)

--- a/src/UglyToad.PdfPig.Tokenization/HexTokenizer.cs
+++ b/src/UglyToad.PdfPig.Tokenization/HexTokenizer.cs
@@ -5,7 +5,7 @@
 
     internal sealed class HexTokenizer : ITokenizer
     {
-        public bool ReadsNextByte { get; } = false;
+        public bool ReadsNextByte => false;
 
         public bool TryTokenize(byte currentByte, IInputBytes inputBytes, out IToken token)
         {

--- a/src/UglyToad.PdfPig.Tokenization/NumericTokenizer.cs
+++ b/src/UglyToad.PdfPig.Tokenization/NumericTokenizer.cs
@@ -7,15 +7,7 @@ using Tokens;
 
 internal sealed class NumericTokenizer : ITokenizer
 {
-    private const byte Zero = 48;
-    private const byte Nine = 57;
-    private const byte Negative = (byte)'-';
-    private const byte Positive = (byte)'+';
-    private const byte Period = (byte)'.';
-    private const byte ExponentLower = (byte)'e';
-    private const byte ExponentUpper = (byte)'E';
-
-    public bool ReadsNextByte => true;
+    public bool ReadsNextByte => false;
 
     public bool TryTokenize(byte currentByte, IInputBytes inputBytes, out IToken? token)
     {
@@ -37,30 +29,50 @@ internal sealed class NumericTokenizer : ITokenizer
         var isExponentNegative = false;
         var exponentPart = 0;
 
-        do
+        byte? firstByte = currentByte;
+        bool noRead = true;
+        bool acceptSign = true;
+        while (!inputBytes.IsAtEnd() || firstByte is { })
         {
-            var b = inputBytes.CurrentByte;
-            if (b >= Zero && b <= Nine)
+            if (firstByte is { } b)
             {
+                firstByte = null;
+            }
+            else if (noRead)
+            {
+                noRead = false;
+                b = inputBytes.Peek() ?? 0;
+            }
+            else
+            {
+                inputBytes.MoveNext();
+                b = inputBytes.Peek() ?? 0;
+            }
+
+            if (b >= '0' && b <= '9')
+            {
+                var value = b - '0';
                 if (hasExponent)
                 {
-                    exponentPart = (exponentPart * 10) + (b - Zero);
+                    exponentPart = (exponentPart * 10) + value;
                 }
                 else if (hasFraction)
                 {
-                    fractionalPart = (fractionalPart * 10) + (b - Zero);
+                    fractionalPart = (fractionalPart * 10) + value;
                     fractionalCount++;
                 }
                 else
                 {
-                    integerPart = (integerPart * 10) + (b - Zero);
+                    integerPart = (integerPart * 10) + value;
                 }
+                acceptSign = false;
             }
-            else if (b == Positive)
+            else if (b == '+' && acceptSign)
             {
                 // Has no impact
+                acceptSign = false;
             }
-            else if (b == Negative)
+            else if (b == '-' && acceptSign)
             {
                 if (hasExponent)
                 {
@@ -70,30 +82,17 @@ internal sealed class NumericTokenizer : ITokenizer
                 {
                     isNegative = true;
                 }
+                // acceptSign = false; // Somehow we have a test that expects to support "--21.72" to return -21.72
             }
-            else if (b == Period)
+            else if (b == '.' && !hasExponent && !hasFraction)
             {
-                if (hasExponent || hasFraction)
-                {
-                    return false;
-                }
-
                 hasFraction = true;
+                acceptSign = false;
             }
-            else if (b == ExponentLower || b == ExponentUpper)
+            else if ((b == 'e' || b == 'E') && readBytes > 0 && !hasExponent)
             {
-                // Don't allow leading exponent.
-                if (readBytes == 0)
-                {
-                    return false;
-                }
-
-                if (hasExponent)
-                {
-                    return false;
-                }
-
                 hasExponent = true;
+                acceptSign = true;
             }
             else
             {
@@ -107,7 +106,7 @@ internal sealed class NumericTokenizer : ITokenizer
             }
 
             readBytes++;
-        } while (inputBytes.MoveNext());
+        }
 
         if (hasExponent && !isExponentNegative)
         {

--- a/src/UglyToad.PdfPig.Tokenization/PlainTokenizer.cs
+++ b/src/UglyToad.PdfPig.Tokenization/PlainTokenizer.cs
@@ -6,7 +6,7 @@
 
     internal sealed class PlainTokenizer : ITokenizer
     {
-        public bool ReadsNextByte { get; } = true;
+        public bool ReadsNextByte => false;
 
         public bool TryTokenize(byte currentByte, IInputBytes inputBytes, out IToken token)
         {
@@ -21,18 +21,11 @@
 
             builder.Append((char)currentByte);
             
-            while (inputBytes.MoveNext())
+            while (inputBytes.Peek() is { } b
+                && !ReadHelper.IsWhitespace(b)
+                && (char)b is not '<' and not '[' and not '/' and not ']' and not '>' and not '(' and not ')')
             {
-                if (ReadHelper.IsWhitespace(inputBytes.CurrentByte))
-                {
-                    break;
-                }
-
-                if (inputBytes.CurrentByte is (byte)'<' or (byte)'[' or (byte)'/' or (byte)']' or (byte)'>' or (byte)'(' or (byte)')')
-                {
-                    break;
-                }
-
+                inputBytes.MoveNext();
                 builder.Append((char) inputBytes.CurrentByte);
             }
 

--- a/src/UglyToad.PdfPig.Tokenization/Scanner/CoreTokenScanner.cs
+++ b/src/UglyToad.PdfPig.Tokenization/Scanner/CoreTokenScanner.cs
@@ -246,7 +246,7 @@
 
                 /* 
                  * Some tokenizers need to read the symbol of the next token to know if they have ended
-                 * so we don't want to move on to the next byte, we would lose a byte, e.g.: /NameOne/NameTwo or /Name(string)                
+                 * so we don't want to move on to the next byte, we would lose a byte, e.g.: /NameOne/NameTwo or /Name(string)
                  */
                 hasBytePreRead = tokenizer.ReadsNextByte;
 
@@ -317,12 +317,13 @@
         {
             // The ID operator should be followed by a single white-space character, and the next character is interpreted
             // as the first byte of image data. 
-            if (!ReadHelper.IsWhitespace(inputBytes.CurrentByte))
+            if (inputBytes.Peek() is { } c
+                && !ReadHelper.IsWhitespace(c))
             {
                 throw new PdfDocumentFormatException($"No whitespace character following the image data (ID) operator. Position: {inputBytes.CurrentOffset}.");
             }
 
-            var startsAt = inputBytes.CurrentOffset - 2;
+            var startsAt = inputBytes.CurrentOffset - 1;
 
             return ReadUntilEndImage(startsAt);
         }

--- a/src/UglyToad.PdfPig/Parser/FileStructure/FileHeaderParser.cs
+++ b/src/UglyToad.PdfPig/Parser/FileStructure/FileHeaderParser.cs
@@ -80,9 +80,8 @@
             }
 
             var atEnd = scanner.CurrentPosition == scanner.Length;
-            var rewind = atEnd ? 1 : 2;
 
-            var commentOffset = scanner.CurrentPosition - comment.Data.Length - rewind;
+            var commentOffset = scanner.CurrentPosition - comment.Data.Length - 1;
 
             scanner.Seek(0);
 

--- a/src/UglyToad.PdfPig/Parser/FileStructure/FirstPassParser.StartXref.cs
+++ b/src/UglyToad.PdfPig/Parser/FileStructure/FirstPassParser.StartXref.cs
@@ -10,13 +10,56 @@ internal static partial class FirstPassParser
 {
     private static ReadOnlySpan<byte> StartXRefBytes => "startxref"u8;
 
+    public const long EndOfFileBufferSize = 1024;
+
     public static StartXRefLocation GetFirstCrossReferenceOffset(
         IInputBytes bytes,
         ISeekableTokenScanner scanner,
         ILog log)
     {
+        // We used to read backward through the file, but this is quite expensive for streams that directly wrap OS files.
+        // Instead we fetch the last 1024 bytes of the file and do a memory search, as cheap first attempt. This is significantly faster
+        // in practice, if there is no in-process caching of the file involved
+        // 
+        // If that fails (in practice it should never) we fall back to the old method of reading backwards.
         var fileLength = bytes.Length;
+        {
+            var fetchFrom = Math.Max(bytes.Length - EndOfFileBufferSize, 0L);
 
+            bytes.Seek(fetchFrom);
+
+            Span<byte> byteBuffer = new byte[bytes.Length - fetchFrom];   // TODO: Maybe use PoolArray?
+
+            int n = bytes.Read(byteBuffer);
+
+            if (n == byteBuffer.Length)
+            {
+                int lx = byteBuffer.LastIndexOf("startxref"u8);
+
+                if (lx < 0)
+                {
+                    // See old code. We also try a mangled version
+                    lx = byteBuffer.LastIndexOf("startref"u8);
+                }
+
+                if (lx >= 0)
+                {
+                    scanner.Seek(fetchFrom + lx);
+
+                    if (scanner.TryReadToken(out OperatorToken startXrefOp) && (startXrefOp.Data == "startxref" || startXrefOp.Data == "startref"))
+                    {
+                        var pos = GetNumericTokenFollowingCurrent(scanner);
+
+                        log.Debug($"Found startxref at {pos}");
+
+                        return new StartXRefLocation(fetchFrom + lx, pos);
+                    }
+                }
+
+            }
+        }
+
+        // Now fall through in the old code
         var buffer = new CircularByteBuffer(StartXRefBytes.Length);
 
         // Start from the end of the file

--- a/src/UglyToad.PdfPig/Parser/Parts/BruteForceSearcher.cs
+++ b/src/UglyToad.PdfPig/Parser/Parts/BruteForceSearcher.cs
@@ -57,7 +57,7 @@
                     {
                         var next = bytes.Peek();
 
-                        if (next.HasValue && next == 'n')
+                        if (next == 'n')
                         {
                             if (ReadHelper.IsString(bytes, "endobj"))
                             {

--- a/src/UglyToad.PdfPig/Tokenization/Scanner/PdfTokenScanner.cs
+++ b/src/UglyToad.PdfPig/Tokenization/Scanner/PdfTokenScanner.cs
@@ -465,7 +465,7 @@
                 read++;
             }
 
-            long streamDataEnd = inputBytes.CurrentOffset + 1;
+            long streamDataEnd = inputBytes.CurrentOffset;
 
             if (possibleEndLocation == null)
                 return false;


### PR DESCRIPTION
This builds upon PR #1188 (=first commit of this PR).

Cleans up all builtin tokenizers to no longer read one byte too much but instead use the Peek() on the input bytes.

This allows simplifying logic in quite a few places where other parsers had to compensate for reading a byte early on. Or where parsers/tokenizers had to seek back to make things work.

Also make ReadsNextByte a constant virtual method instead of a hidden readonly variable in each parser.