### PR TITLE
Fix regression introduced in 3592fc8 where slicing the stream to the length breaks decoding

### DIFF
--- a/src/UglyToad.PdfPig/PdfExtensions.cs
+++ b/src/UglyToad.PdfPig/PdfExtensions.cs
@@ -64,17 +64,6 @@
 
             var transform = stream.Data;
 
-            var length = stream.StreamDictionary.GetIntOrDefault(NameToken.Length, -1);
-
-            // If a length is available and it's smaller than the actual data length, use that. This trims whitespace (e.g. newlines) that might have been introduced during transport.
-            // And with that it handles some issues before individual filters have to deal with it.
-            //
-            // Do this before the first filter (to handle cases like multiple filters, etc).
-            if (length > 0 && length < transform.Length)
-            {
-                transform = transform.Slice(0, length);
-            }
-
             for (var i = 0; i < filters.Count; i++)
             {
                 var filter = filters[i];
@@ -102,17 +91,6 @@
             double totalMaxEstSize = stream.Data.Length * 100;
 
             var transform = stream.Data;
-
-            var length = stream.StreamDictionary.GetIntOrDefault(NameToken.Length, -1);
-
-            // If a length is available and it's smaller than the actual data length, use that. This trims whitespace (e.g. newlines) that might have been introduced during transport.
-            // And with that it handles some issues before individual filters have to deal with it.
-            //
-            // Do this before the first filter (to handle cases like multiple filters, etc).
-            if (length > 0 && length < transform.Length)
-            {
-                transform = transform.Slice(0, length);
-            }
 
             for (var i = 0; i < filters.Count; i++)
             {


### PR DESCRIPTION
Unfortunately the regression was not caught with the tests in the project.

I caught that when running tests in the https://github.com/BobLd/PdfPig.Rendering.Skia project.

3 tests are now failing over there:

- UglyToad.PdfPig.Rendering.Skia.Tests.TestRendering.PdfPigSkiaTest(expectedImage: "AcroFormsBasicFields_1.png", pdfFile: "AcroFormsBasicFields.pdf", pageNumber: 1, scale: 2) Failed
- UglyToad.PdfPig.Rendering.Skia.Tests.TestRendering.PdfPigSkiaTest(expectedImage: "FontMatrix-concat_1.png", pdfFile: "FontMatrix-concat.pdf", pageNumber: 1, scale: 2) Failed
- UglyToad.PdfPig.Rendering.Skia.Tests.TestRendering.PdfPigSkiaTest(expectedImage: "caly-issues-58-2_1.png", pdfFile: "caly-issues-58-2.pdf", pageNumber: 1, scale: 2) Failed

<img width="715" height="171" alt="image" src="https://github.com/user-attachments/assets/bc48af86-0d8c-4058-a871-9326154cdfa9" />

I'm lacking time to add the tests to this projects, but wanted to at least fix that for now.

cc @rhuijben 
