### PR TITLE
update release logic to check out master before commit

### DIFF
--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -44,5 +44,10 @@ jobs:
           .\tools\set-version.ps1 $newVer -UpdateAssemblyAndFileVersion
           git config user.name "github-actions"
           git config user.email "github-actions@github.com"
+          
+          git fetch origin master
+          git checkout master
+          git pull
+          
           git commit -am "Increment version to $newVer"
           git push


### PR DESCRIPTION
I believe this might fix the problem with the current release action, but since it's GHA who knows 🤷 