### PR TITLE
Do not return glyph bbox and path in Type1Font if character name is '.notdef'

### DIFF
--- a/src/UglyToad.PdfPig.Fonts/Type1/Type1FontProgram.cs
+++ b/src/UglyToad.PdfPig.Fonts/Type1/Type1FontProgram.cs
@@ -62,6 +62,11 @@
         /// </summary>
         public PdfRectangle? GetCharacterBoundingBox(string characterName)
         {
+            if (string.Equals(characterName, GlyphList.NotDefined, StringComparison.OrdinalIgnoreCase))
+            {
+                return null;
+            }
+
             var glyph = GetCharacterPath(characterName);
             return PdfSubpath.GetBoundingRectangle(glyph);
         }
@@ -94,8 +99,13 @@
         /// <summary>
         /// Get the pdfpath for the character with the given name.
         /// </summary>
-        public IReadOnlyList<PdfSubpath> GetCharacterPath(string characterName)
+        public IReadOnlyList<PdfSubpath>? GetCharacterPath(string characterName)
         {
+            if (string.Equals(characterName, GlyphList.NotDefined, StringComparison.OrdinalIgnoreCase))
+            {
+                return null;
+            }
+
             if (!CharStrings.TryGenerate(characterName, out var glyph))
             {
                 return null;


### PR DESCRIPTION
[jtehm-melillo-2679746_less.pdf](https://github.com/user-attachments/files/24308583/jtehm-melillo-2679746_less.pdf)

Fixes an issue when rendering some glyphs in this document

<img width="1183" height="264" alt="image" src="https://github.com/user-attachments/assets/1795908c-21c6-4d8f-9809-9b720c31835d" />
