### PR TITLE
both Tj and TJ operators should increment text sequence #1241

### DIFF
--- a/src/UglyToad.PdfPig/Graphics/BaseStreamProcessor.cs
+++ b/src/UglyToad.PdfPig/Graphics/BaseStreamProcessor.cs
@@ -215,6 +215,8 @@
         /// <inheritdoc/>
         public void ShowText(IInputBytes bytes)
         {
+            TextSequence++;
+
             var currentState = GetCurrentState();
 
             var font = currentState.FontState.FromExtendedGraphicsState

--- a/src/UglyToad.PdfPig/Graphics/Operations/TextShowing/ShowText.cs
+++ b/src/UglyToad.PdfPig/Graphics/Operations/TextShowing/ShowText.cs
@@ -64,7 +64,7 @@
             operationContext.ShowText(input);
         }
 
-        string? EscapeText(string? text)
+        private static string? EscapeText(string? text)
         {
             if (text is null) return null;
             // Fix Issue 350 from PDF Spec 1.7 (page 408) on handling 'special characters' of '(', ')' and '\'.


### PR DESCRIPTION
the text sequence was added to group letters added by the same content stream operation together for layout analysis. TJ allows for individual letter positioning in the same operation which modifies the text matrix while writing whereas Tj just writes the text at the current location. both should be semantically equivalent for this sequence number. this was originally added in #61