### PR TITLE
Fix TextSequence over-increment on TJ (#1241 follow-up)

### DIFF
--- a/src/UglyToad.PdfPig/Graphics/BaseStreamProcessor.cs
+++ b/src/UglyToad.PdfPig/Graphics/BaseStreamProcessor.cs
@@ -230,7 +230,11 @@
         public void ShowText(IInputBytes bytes)
         {
             TextSequence++;
+            ShowTextInternal(bytes);
+        }
 
+        private void ShowTextInternal(IInputBytes bytes)
+        {
             var currentState = GetCurrentState();
 
             var font = currentState.FontState.FromExtendedGraphicsState
@@ -411,7 +415,7 @@
                         bytes = ((StringToken)token).GetBytes();
                     }
 
-                    ShowText(new MemoryInputBytes(bytes));
+                    ShowTextInternal(new MemoryInputBytes(bytes));
                 }
             }
         }


### PR DESCRIPTION
#1241 added TextSequence++ to ShowText(), but ShowPositionedText() (the TJ operator) already increments the counter and then calls ShowText() in a loop — so a TJ with N strings now increments by N+1 instead of 1, breaking letter grouping.

Fix: extract the rendering body into a private ShowTextInternal() that doesn't touch TextSequence. ShowText() increments once and delegates; ShowPositionedText() calls ShowTextInternal() in the loop. Both Tj and TJ now produce exactly one increment per operator.