### PR TITLE
make TokenScanner public through Structure to iterate indirect objects

### DIFF
--- a/src/UglyToad.PdfPig/Structure.cs
+++ b/src/UglyToad.PdfPig/Structure.cs
@@ -35,8 +35,9 @@
 
         /// <summary>
         /// Provides access to tokenization capabilities for objects by object number.
+        /// This is the document-level token scanner used to dereference indirect object references.
         /// </summary>
-        internal IPdfTokenScanner TokenScanner { get; }
+        public IPdfTokenScanner TokenScanner { get; }
 
         internal Structure(
             Catalog catalog,


### PR DESCRIPTION
TLDR - I am using PdfPig in a custom PDF Renderer, and in order to render embedded XForm object, I need access to TokenScanner/PdfScanner publically. 

This Supercedes - https://github.com/UglyToad/PdfPig/pull/1305


This is a screenshot of an early alpha build of SafePDF, intended to provide a free 99% memory safe PDF reader for the masses that is not vulnerable to the kind of buffer overrun CVEs as Acrobat. It's built with my custom UI toolkit Fluid, vector rendering using my [SilkyNvg fork](https://github.com/jeske/SilkyNvg) to which I added a Veldrid GPU backend (it's wicked fast).

<img width="1233" height="529" alt="image" src="https://github.com/user-attachments/assets/b3a40038-9352-42d5-9e69-ace262a8472d" />


# Summary

It's a one-line visibility change. No new allocations, no behavioral changes, no breaking changes.

**File:** `src/UglyToad.PdfPig/Structure.cs`

```csharp
// Was: internal IPdfTokenScanner TokenScanner { get; }
public IPdfTokenScanner TokenScanner { get; }
```

## Why

When rendering Form XObjects, the renderer must:

1. Walk `Page Dictionary → /Resources → /XObject → /<name>` (entries are often indirect references)
2. Resolve the `StreamToken` for the Form XObject
3. Read the `/Matrix` array from the stream dictionary (also potentially indirect)
4. Decode and parse the content stream into operations

Each step requires `IPdfTokenScanner` to dereference `IndirectReferenceToken` values. PdfPig uses this scanner internally everywhere, but never exposed it for consumers who need to traverse dictionary trees themselves.

## Usage (consumer side)

```csharp
// Access scanner at document level (correct — it's shared across all pages)
var scanner = pdfDocument.Structure.TokenScanner;

// Resolve indirect references in page resource dictionaries
PdfExtensions.TryGet<DictionaryToken>(page.Dictionary, NameToken.Resources, scanner, out var resources);
PdfExtensions.TryGet<DictionaryToken>(resources, NameToken.Xobject, scanner, out var xobjectDict);
PdfExtensions.TryGet<StreamToken>(xobjectDict, xobjectName, scanner, out var xobjectStream);
```

## Alternatives Considered

- **PdfPig's built-in content stream processing:** Processes Form XObjects internally, but doesn't expose parsed `IGraphicsStateOperation` lists in a way an external renderer can consume.
