### PR TITLE
Add and use PdfDocumentStackDepthException in StackDepthGuard to avoid conflict with PdfDocumentFormatException handling

### DIFF
--- a/src/UglyToad.PdfPig.Core/PdfDocumentStackDepthException.cs
+++ b/src/UglyToad.PdfPig.Core/PdfDocumentStackDepthException.cs
@@ -1,0 +1,15 @@
+﻿namespace UglyToad.PdfPig.Core
+{
+    using System;
+
+    /// <summary>
+    /// Represents an exception that is thrown when the stack depth of a PDF document exceeds the allowed limit.
+    /// </summary>
+    public sealed class PdfDocumentStackDepthException : Exception
+    {
+        /// <inheritdoc />
+        internal PdfDocumentStackDepthException(int maxStackDepth)
+            : base($"Exceeded maximum nesting depth of {maxStackDepth}.")
+        { }
+    }
+}

--- a/src/UglyToad.PdfPig.Core/StackDepthGuard.cs
+++ b/src/UglyToad.PdfPig.Core/StackDepthGuard.cs
@@ -41,7 +41,7 @@
             if (++depth > maxStackDepth)
             {
                 depth--; // Decrement so Exit remains balanced if someone catches this
-                throw new PdfDocumentFormatException($"Exceeded maximum nesting depth of {maxStackDepth}.");
+                throw new PdfDocumentStackDepthException(maxStackDepth);
             }
         }
 

--- a/src/UglyToad.PdfPig.Tests/Integration/GithubIssuesTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Integration/GithubIssuesTests.cs
@@ -35,7 +35,7 @@
 
             var options = new ParsingOptions { MaxStackDepth = 256 };
             using var ms = new MemoryStream(payload);
-            var ex = Assert.Throws<PdfDocumentFormatException>(() => PdfDocument.Open(ms, options));
+            var ex = Assert.Throws<PdfDocumentStackDepthException>(() => PdfDocument.Open(ms, options));
             Assert.Equal($"Exceeded maximum nesting depth of {options.MaxStackDepth}.", ex.Message);
             return;
 
@@ -120,10 +120,9 @@
 
             var options = new ParsingOptions()
             {
-                UseLenientParsing = true,
-                MaxStackDepth = 100
+                UseLenientParsing = true
             };
-            var ex = Assert.Throws<PdfDocumentFormatException>(() => PdfDocument.Open(path, options));
+            var ex = Assert.Throws<PdfDocumentStackDepthException>(() => PdfDocument.Open(path, options));
             Assert.Equal($"Exceeded maximum nesting depth of {options.MaxStackDepth}.", ex.Message);
         }
 


### PR DESCRIPTION
Example of previous conflict was in `DictionaryTokenizer.TryTokenize()`'s `PdfDocumentFormatException` handling