### PR TITLE
Enhance NameTokenizer to support GBK/GB18030 encoding detection

### DIFF
--- a/src/UglyToad.PdfPig.Core/ReadHelper.cs
+++ b/src/UglyToad.PdfPig.Core/ReadHelper.cs
@@ -307,14 +307,13 @@
 #else
             try
             {
-                var d = Encoding.UTF8.GetDecoder();
-
-                var charLength = d.GetCharCount(input, 0, input.Length);
-                var chars = new char[charLength];
-                d.Convert(input, 0, input.Length, chars, 0, charLength, true, out _, out _, out _);
+                // A throwing decoder is required: the default UTF-8 decoder silently replaces invalid
+                // bytes with U+FFFD instead of failing, which would make every input look "valid".
+                var throwingUtf8 = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false, throwOnInvalidBytes: true);
+                _ = throwingUtf8.GetCharCount(input, 0, input.Length);
                 return true;
             }
-            catch (Exception)
+            catch (DecoderFallbackException)
             {
                 return false;
             }

--- a/src/UglyToad.PdfPig.Tests/Integration/GithubIssuesTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Integration/GithubIssuesTests.cs
@@ -12,19 +12,39 @@
     public class GithubIssuesTests
     {
         [Fact]
-        public void Issues1309()
+        public void Issues1266()
         {
-            var path = IntegrationHelpers.GetDocumentPath("LKR824191.pdf");
+            var path = IntegrationHelpers.GetDocumentPath("issues-1266.pdf");
 
             using (var document = PdfDocument.Open(path, new ParsingOptions() { UseLenientParsing = true, UseActualText = true }))
             {
-                var page = document.GetPage(1);
-                var words = NearestNeighbourWordExtractor.Instance.GetWords(page.Letters);
-                var blocks = DocstrumBoundingBoxes.Instance.GetBlocks(words);
-                Assert.Equal(23, blocks.Count);
+                // The /BaseFont names of the embedded CJK fonts are written as raw GBK (codepage 936)
+                // bytes, which were previously decoded as windows-1252 and produced mojibake
+                // (e.g. "ABCDEE+ºÚÌå"). They should now be decoded correctly as Chinese. See issue #1266.
+                var fontNames = document.GetPages()
+                    .SelectMany(p => p.Letters)
+                    .Select(l => l.FontName)
+                    .Distinct()
+                    .OrderBy(n => n, System.StringComparer.Ordinal)
+                    .ToArray();
 
-                var text = blocks[13].Text;
-                Assert.Equal("-5,15 -5,15 -1,24 -6,39", text);
+                Assert.Equal(new[]
+                {
+                    "ABCDEE+Angsana New",
+                    "ABCDEE+Arial Narrow",
+                    "ABCDEE+Calibri",
+                    "ABCDEE+仿宋",            // FangSong
+                    "ABCDEE+宋体",            // SimSun
+                    "ABCDEE+微软雅黑",        // Microsoft YaHei
+                    "ABCDEE+微软雅黑,Bold",
+                    "ABCDEE+黑体",            // SimHei
+                    "ABCEEE+MingLiU",
+                    "Arial",
+                    "Arial,Bold",
+                    "Times New Roman",
+                    "Times New Roman,Bold",
+                    "Times New Roman,Italic",
+                }, fontNames);
             }
         }
 

--- a/src/UglyToad.PdfPig.Tests/Tokenization/NameTokenizerTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Tokenization/NameTokenizerTests.cs
@@ -1,5 +1,7 @@
 ﻿namespace UglyToad.PdfPig.Tests.Tokenization
 {
+    using System.Text;
+    using PdfPig.Core;
     using PdfPig.Tokenization;
     using PdfPig.Tokens;
 
@@ -145,6 +147,261 @@
             Assert.True(result);
 
             Assert.Equal("Hex#", AssertNameToken(token).Data);
+        }
+
+        [Fact]
+        public void ReadsGbkEncodedCjkName()
+        {
+            // "/ABCDEE+黑体" where 黑体 is written as raw GBK (codepage 936) bytes
+            // BA DA = 黑, CC E5 = 体. Not valid UTF-8, so it must be detected as GBK.
+            var raw = new byte[] { (byte)'/', (byte)'A', (byte)'B', (byte)'C', (byte)'D', (byte)'E', (byte)'E', (byte)'+', 0xBA, 0xDA, 0xCC, 0xE5 };
+            var input = new MemoryInputBytes(raw);
+            input.MoveNext();
+
+            var result = tokenizer.TryTokenize(input.CurrentByte, input, out var token);
+
+            Assert.True(result);
+            Assert.Equal("ABCDEE+黑体", AssertNameToken(token).Data);
+        }
+        
+        [Fact]
+        public void ReadsGbkEncodedCjkNameFromRawBytes()
+        {
+            // A plain name "/黑体" written as raw GBK (codepage 936) bytes: BA DA = 黑, CC E5 = 体.
+            // This is not valid UTF-8, so it must be detected and decoded as GBK. The decoding is not
+            // specific to font names - any name token benefits.
+            var raw = new byte[] { (byte)'/', 0xBA, 0xDA, 0xCC, 0xE5 };
+
+            Assert.Equal("黑体", TokenizeRaw(raw));
+        }
+
+        [Fact]
+        public void ReadsGbkEncodedCjkNameWithTrailingAscii()
+        {
+            // "/ABCDEE+微软雅黑,Bold" with the CJK part as raw GBK bytes.
+            var raw = new byte[]
+            {
+                (byte)'/', (byte)'A', (byte)'B', (byte)'C', (byte)'D', (byte)'E', (byte)'E', (byte)'+',
+                0xCE, 0xA2, 0xC8, 0xED, 0xD1, 0xC5, 0xBA, 0xDA,
+                (byte)',', (byte)'B', (byte)'o', (byte)'l', (byte)'d'
+            };
+            var input = new MemoryInputBytes(raw);
+            input.MoveNext();
+
+            var result = tokenizer.TryTokenize(input.CurrentByte, input, out var token);
+
+            Assert.True(result);
+            Assert.Equal("ABCDEE+微软雅黑,Bold", AssertNameToken(token).Data);
+        }
+
+        [Fact]
+        public void ReadsGbkEncodedCjkNameInterspersedWithAscii()
+        {
+            // ASCII characters before and after the GBK CJK bytes in an arbitrary (non-font) name:
+            // "/X黑体Y".
+            var raw = BuildRawName("X", "黑体", "Y");
+
+            Assert.Equal("X黑体Y", TokenizeRaw(raw));
+        }
+
+        [Fact]
+        public void IsolatedHighByteFallsBackToWindows1252()
+        {
+            // "/Café" where é is a single raw 0xE9 (Latin-1/Windows-1252) byte, not a valid GBK
+            // double-byte sequence. Must NOT be mis-decoded as GBK.
+            var raw = new byte[] { (byte)'/', (byte)'C', (byte)'a', (byte)'f', 0xE9 };
+            var input = new MemoryInputBytes(raw);
+            input.MoveNext();
+
+            var result = tokenizer.TryTokenize(input.CurrentByte, input, out var token);
+
+            Assert.True(result);
+            Assert.Equal("Café", AssertNameToken(token).Data);
+        }
+
+        [Theory]
+        [InlineData("黑体")]            // SimHei
+        [InlineData("宋体")]            // SimSun
+        [InlineData("仿宋")]            // FangSong
+        [InlineData("微软雅黑")]        // Microsoft YaHei
+        public void ReadsGbkEncodedCjkNames(string cjk)
+        {
+            // Build "/<cjk>" with the CJK characters encoded as raw GBK (codepage 936) bytes, the way
+            // the affected producers write them. These bytes are never valid UTF-8 for real CJK text.
+            var raw = BuildRawName(null, cjk, null);
+
+            Assert.Equal(cjk, TokenizeRaw(raw));
+        }
+
+        [Theory]
+        [InlineData("黑体")]            // SimHei
+        [InlineData("宋体")]            // SimSun
+        [InlineData("仿宋")]            // FangSong
+        [InlineData("微软雅黑")]        // Microsoft YaHei
+        public void ReadsFontGbkEncodedCjkNames(string cjk)
+        {
+            // Build "/ABCDEE+<cjk>" with the CJK part encoded as raw GBK (codepage 936) bytes, the way
+            // the affected producers write them. These bytes are never valid UTF-8 for real CJK text.
+            var raw = BuildRawName("ABCDEE+", cjk, null);
+
+            Assert.Equal("ABCDEE+" + cjk, TokenizeRaw(raw));
+        }
+
+        [Fact]
+        public void ReadsGbkEncodedCjkNameWithSubsetPrefixAndStyleSuffix()
+        {
+            // GBK CJK characters between an ASCII subset prefix and an ASCII ",Bold" style suffix.
+            var raw = BuildRawName("ABCDEE+", "微软雅黑", ",Bold");
+
+            Assert.Equal("ABCDEE+微软雅黑,Bold", TokenizeRaw(raw));
+        }
+
+        [Fact]
+        public void ReadsGbkEncodedCjkNameWithEscapedBytes()
+        {
+            // The GBK bytes for 黑体 (BA DA CC E5) written using #XX hex escapes, which is the
+            // spec-compliant way to embed non-ASCII bytes in a name. The result must still be GBK.
+            var input = StringBytesTestConverter.Convert("/#BA#DA#CC#E5");
+
+            var result = tokenizer.TryTokenize(input.First, input.Bytes, out var token);
+
+            Assert.True(result);
+            Assert.Equal("黑体", AssertNameToken(token).Data);
+        }
+
+        [Fact]
+        public void ReadsFontGbkEncodedCjkNameWithEscapedBytes()
+        {
+            // Same GBK bytes for 黑体 (BA DA CC E5) but written using #XX hex escapes, which is the
+            // spec-compliant way to embed non-ASCII bytes in a name. The result must still be GBK.
+            var input = StringBytesTestConverter.Convert("/ABCDEE+#BA#DA#CC#E5");
+
+            var result = tokenizer.TryTokenize(input.First, input.Bytes, out var token);
+
+            Assert.True(result);
+            Assert.Equal("ABCDEE+黑体", AssertNameToken(token).Data);
+        }
+
+        [Fact]
+        public void PrefersUtf8OverGbkForValidUtf8Cjk()
+        {
+            // 黑体 written as valid UTF-8 (E9 BB 91 E4 BD 93). UTF-8 is checked first (PDF 2.0, 7.3.5),
+            // so a genuinely UTF-8 encoded CJK name must not be re-interpreted as GBK.
+            var raw = new byte[] { (byte)'/', 0xE9, 0xBB, 0x91, 0xE4, 0xBD, 0x93 };
+
+            Assert.Equal("黑体", TokenizeRaw(raw));
+        }
+
+        [Fact]
+        public void GbkLeadByteAtLowerBoundaryIsDetected()
+        {
+            // 0x81 is the lowest GBK lead byte, 0x40 the lowest trail byte.
+            var raw = new byte[] { (byte)'/', 0x81, 0x40 };
+
+            Assert.Equal(DecodeGbk(new byte[] { 0x81, 0x40 }), TokenizeRaw(raw));
+        }
+
+        [Fact]
+        public void GbkLeadByteAtUpperBoundaryIsDetected()
+        {
+            // 0xFE is the highest GBK lead byte, 0xFE the highest trail byte.
+            var raw = new byte[] { (byte)'/', 0xFE, 0xFE };
+
+            Assert.Equal(DecodeGbk(new byte[] { 0xFE, 0xFE }), TokenizeRaw(raw));
+        }
+
+        [Theory]
+        [InlineData(0x80)] // 0x80 is not a valid GBK lead byte
+        [InlineData(0xFF)] // 0xFF is not a valid GBK lead byte
+        public void InvalidGbkLeadByteFallsBackToWindows1252(int lead)
+        {
+            var raw = new byte[] { (byte)'/', (byte)lead, (byte)'A' };
+
+            Assert.Equal(Decode1252(new byte[] { (byte)lead, (byte)'A' }), TokenizeRaw(raw));
+        }
+
+        [Fact]
+        public void GbkTrailByte0x7FIsRejectedAndFallsBackToWindows1252()
+        {
+            // 0x7F is excluded from the GBK trail range, so 0x81 0x7F is not a valid sequence.
+            var raw = new byte[] { (byte)'/', 0x81, 0x7F };
+
+            Assert.Equal(Decode1252(new byte[] { 0x81, 0x7F }), TokenizeRaw(raw));
+        }
+
+        [Fact]
+        public void DanglingGbkLeadByteAtEndFallsBackToWindows1252()
+        {
+            // A lead byte with no following trail byte (truncated) is not a valid GBK sequence.
+            var raw = new byte[] { (byte)'/', (byte)'A', 0x81 };
+
+            Assert.Equal(Decode1252(new byte[] { (byte)'A', 0x81 }), TokenizeRaw(raw));
+        }
+
+        [Fact]
+        public void HighByteFollowedBySubTrailRangeAsciiFallsBackToWindows1252()
+        {
+            // "/caf<E9>2" — é (E9) is followed by the digit '2' (0x32), which is below the GBK trail
+            // range (0x40-0xFE). The pair is therefore invalid GBK and the name stays Windows-1252.
+            var name = new byte[] { (byte)'c', (byte)'a', (byte)'f', 0xE9, (byte)'2' };
+            var raw = new byte[] { (byte)'/' }.Concat(name).ToArray();
+
+            Assert.Equal(Decode1252(name), TokenizeRaw(raw));
+        }
+
+        [Fact]
+        public void Gb18030FourByteSequenceFallsBackToWindows1252()
+        {
+            // GB18030 four-byte sequences use a 0x30-0x39 second byte, which is below the GBK trail
+            // range, so they are not treated as GBK (codepage 936 cannot decode them anyway).
+            var raw = new byte[] { (byte)'/', 0x81, 0x30, 0x81, 0x30 };
+
+            Assert.Equal(Decode1252(new byte[] { 0x81, 0x30, 0x81, 0x30 }), TokenizeRaw(raw));
+        }
+
+        [Fact]
+        public void SingleWindows1252HighByteIsPreserved()
+        {
+            // 0x80 is the Euro sign in Windows-1252; a lone occurrence must keep that meaning.
+            var raw = new byte[] { (byte)'/', 0x80 };
+
+            Assert.Equal("€", TokenizeRaw(raw));
+        }
+
+        // Codepage encodings require the provider that NameTokenizer's static constructor registers, so
+        // these are resolved at call time (after a NameTokenizer instance exists) rather than in static
+        // field initializers which could run first.
+        private static string DecodeGbk(byte[] bytes) => Encoding.GetEncoding(936).GetString(bytes);
+
+        private static string Decode1252(byte[] bytes) => Encoding.GetEncoding("windows-1252").GetString(bytes);
+
+        private static byte[] BuildRawName(string asciiPrefix, string cjk, string asciiSuffix)
+        {
+            var bytes = new System.Collections.Generic.List<byte> { (byte)'/' };
+            if (!string.IsNullOrEmpty(asciiPrefix))
+            {
+                bytes.AddRange(Encoding.ASCII.GetBytes(asciiPrefix));
+            }
+
+            bytes.AddRange(Encoding.GetEncoding(936).GetBytes(cjk));
+            if (!string.IsNullOrEmpty(asciiSuffix))
+            {
+                bytes.AddRange(Encoding.ASCII.GetBytes(asciiSuffix));
+            }
+
+            return bytes.ToArray();
+        }
+
+        private string TokenizeRaw(byte[] raw)
+        {
+            var input = new MemoryInputBytes(raw);
+            input.MoveNext();
+
+            var result = tokenizer.TryTokenize(input.CurrentByte, input, out var token);
+
+            Assert.True(result);
+
+            return AssertNameToken(token).Data;
         }
 
         private static NameToken AssertNameToken(IToken token)

--- a/src/UglyToad.PdfPig.Tests/Tokenization/Scanner/CoreTokenScannerTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Tokenization/Scanner/CoreTokenScannerTests.cs
@@ -302,6 +302,34 @@ endobj";
             }
         }
 
+        [Fact]
+        public void ScansGbkEncodedNamesAsDictionaryKeysAndValues()
+        {
+            // The GBK/GB18030 name decoding (issue #1266) lives in the NameTokenizer, so it applies to
+            // every name regardless of context - not just font /BaseFont names. This scans a dictionary
+            // whose key and values are CJK names written as raw GBK (codepage 936) bytes:
+            //   << /黑体 /宋体 /Color /仿宋 >>
+            var bytes = new List<byte>();
+            void Ascii(string s) => bytes.AddRange(System.Text.Encoding.ASCII.GetBytes(s));
+
+            Ascii("<< /");
+            bytes.AddRange(new byte[] { 0xBA, 0xDA, 0xCC, 0xE5 });   // 黑体 (key)
+            Ascii(" /");
+            bytes.AddRange(new byte[] { 0xCB, 0xCE, 0xCC, 0xE5 });   // 宋体 (value)
+            Ascii(" /Color /");
+            bytes.AddRange(new byte[] { 0xB7, 0xC2, 0xCB, 0xCE });   // 仿宋 (value)
+            Ascii(" >>");
+
+            var scanner = scannerFactory(new MemoryInputBytes(bytes.ToArray()));
+
+            Assert.True(scanner.MoveNext());
+            var dictionary = Assert.IsType<DictionaryToken>(scanner.CurrentToken);
+
+            Assert.True(dictionary.Data.ContainsKey("黑体"));
+            AssertCorrectToken<NameToken, string>(dictionary.Data["黑体"], "宋体");
+            AssertCorrectToken<NameToken, string>(dictionary.Data["Color"], "仿宋");
+        }
+
         private static void AssertCorrectToken<T, TData>(IToken token, TData expected) where T : IDataToken<TData>
         {
             var cast = Assert.IsType<T>(token);

--- a/src/UglyToad.PdfPig.Tokenization/NameTokenizer.cs
+++ b/src/UglyToad.PdfPig.Tokenization/NameTokenizer.cs
@@ -110,13 +110,68 @@
             bool isValidUtf8 = ReadHelper.IsValidUtf8(byteArray);
 #endif
 
-            var str = isValidUtf8
-                ? Encoding.UTF8.GetString(byteArray)
-                : Encoding.GetEncoding("windows-1252").GetString(byteArray);
-            
+            string str;
+            if (isValidUtf8)
+            {
+                // A name object treated as text should be interpreted as UTF-8 (PDF 2.0, 7.3.5).
+                str = Encoding.UTF8.GetString(byteArray);
+            }
+            else if (LooksLikeGbk(byteArray))
+            {
+                // Some producers (commonly Microsoft Office / WPS on Chinese systems) write the raw
+                // GBK/GB18030 bytes of CJK font names into name objects instead of UTF-8 or #-escapes.
+                // Only re-decode when every high byte forms a valid GBK double-byte sequence, otherwise
+                // an isolated Latin-1 byte (e.g. 'é' in a Western name) would be mangled. See issue #1266.
+                str = Encoding.GetEncoding(936).GetString(byteArray);
+            }
+            else
+            {
+                str = Encoding.GetEncoding("windows-1252").GetString(byteArray);
+            }
+
             token = NameToken.Create(str);
 
             return true;
+        }
+
+        /// <summary>
+        /// Determines whether the bytes (which are not valid UTF-8) look like GBK/GB18030 encoded text,
+        /// i.e. every byte is either ASCII or part of a valid GBK double-byte sequence and at least one
+        /// such double-byte sequence is present.
+        /// </summary>
+        private static bool LooksLikeGbk(ReadOnlySpan<byte> bytes)
+        {
+            bool sawDoubleByte = false;
+
+            for (int i = 0; i < bytes.Length;)
+            {
+                byte b = bytes[i];
+
+                if (b < 0x80)
+                {
+                    // ASCII (e.g. the subset prefix "ABCDEE+" or a ",Bold" suffix).
+                    i++;
+                    continue;
+                }
+
+                // High byte: it must be the lead byte of a GBK double-byte sequence (0x81-0xFE).
+                if (b < 0x81 || b == 0xFF || i + 1 >= bytes.Length)
+                {
+                    return false;
+                }
+
+                // The trailing byte must be in 0x40-0xFE excluding 0x7F.
+                byte trail = bytes[i + 1];
+                if (trail < 0x40 || trail > 0xFE || trail == 0x7F)
+                {
+                    return false;
+                }
+
+                sawDoubleByte = true;
+                i += 2;
+            }
+
+            return sawDoubleByte;
         }
     }
 }


### PR DESCRIPTION
Would fix #1266 