### PR TITLE
Support default colour spaces

### DIFF
--- a/src/UglyToad.PdfPig.Tests/ContentTests/ResourceStoreDefaultColorSpaceTests.cs
+++ b/src/UglyToad.PdfPig.Tests/ContentTests/ResourceStoreDefaultColorSpaceTests.cs
@@ -1,0 +1,259 @@
+﻿namespace UglyToad.PdfPig.Tests.ContentTests
+{
+    using System.Collections.Generic;
+    using PdfPig.Content;
+    using PdfPig.Graphics.Colors;
+    using PdfPig.PdfFonts;
+    using PdfPig.Tokens;
+    using UglyToad.PdfPig.Tests.Tokens;
+    using Xunit;
+
+    public class ResourceStoreDefaultColorSpaceTests
+    {
+        private sealed class NoOpFontFactory : IFontFactory
+        {
+            public IFont Get(DictionaryToken dictionary) => null!;
+        }
+
+        private static ResourceStore BuildStore()
+        {
+            return new ResourceStore(
+                new TestPdfTokenScanner(),
+                new NoOpFontFactory(),
+                new TestFilterProvider(),
+                new ParsingOptions
+                {
+                    UseLenientParsing = true,
+                    SkipMissingFonts = true,
+                });
+        }
+
+        [Fact]
+        public void DeviceRgbRequest_WithDefaultRgbInResources_UsesDefaultRgb()
+        {
+            // Resources/ColorSpace/DefaultRGB -> [ /CalRGB << /WhitePoint [0.9505 1 1.089] >> ]
+            var calRgbDict = new DictionaryToken(new Dictionary<NameToken, IToken>
+            {
+                {
+                    NameToken.WhitePoint,
+                    new ArrayToken(new IToken[]
+                    {
+                        new NumericToken(0.9505),
+                        new NumericToken(1.0),
+                        new NumericToken(1.089),
+                    })
+                },
+            });
+            var defaultRgbArray = new ArrayToken(new IToken[] { NameToken.Calrgb, calRgbDict });
+
+            var resources = new DictionaryToken(new Dictionary<NameToken, IToken>
+            {
+                {
+                    NameToken.ColorSpace,
+                    new DictionaryToken(new Dictionary<NameToken, IToken>
+                    {
+                        { NameToken.DefaultRgb, defaultRgbArray },
+                    })
+                },
+            });
+
+            var store = BuildStore();
+            store.LoadResourceDictionary(resources);
+
+            var details = store.GetColorSpaceDetails(
+                NameToken.Devicergb,
+                new DictionaryToken(new Dictionary<NameToken, IToken>()));
+
+            Assert.Equal(ColorSpace.CalRGB, details.Type);
+        }
+
+        [Fact]
+        public void GetDeviceColorSpaceDetails_WithDefaultRgbInResources_UsesDefaultRgb()
+        {
+            // The g/rg/k operators select a device colour space directly; per 8.6.5.6 the matching
+            // Default* substitution must still apply (it takes precedence over any output intent).
+            var calRgbDict = new DictionaryToken(new Dictionary<NameToken, IToken>
+            {
+                {
+                    NameToken.WhitePoint,
+                    new ArrayToken(new IToken[]
+                    {
+                        new NumericToken(0.9505),
+                        new NumericToken(1.0),
+                        new NumericToken(1.089),
+                    })
+                },
+            });
+            var defaultRgbArray = new ArrayToken(new IToken[] { NameToken.Calrgb, calRgbDict });
+
+            var resources = new DictionaryToken(new Dictionary<NameToken, IToken>
+            {
+                {
+                    NameToken.ColorSpace,
+                    new DictionaryToken(new Dictionary<NameToken, IToken>
+                    {
+                        { NameToken.DefaultRgb, defaultRgbArray },
+                    })
+                },
+            });
+
+            var store = BuildStore();
+            store.LoadResourceDictionary(resources);
+
+            var details = store.GetDeviceColorSpaceDetails(ColorSpace.DeviceRGB);
+
+            Assert.Equal(ColorSpace.CalRGB, details.Type);
+        }
+
+        [Fact]
+        public void GetDeviceColorSpaceDetails_WithoutDefault_ReturnsDeviceColorSpace()
+        {
+            var store = BuildStore();
+            store.LoadResourceDictionary(new DictionaryToken(new Dictionary<NameToken, IToken>()));
+
+            Assert.Same(DeviceGrayColorSpaceDetails.Instance, store.GetDeviceColorSpaceDetails(ColorSpace.DeviceGray));
+            Assert.Same(DeviceRgbColorSpaceDetails.Instance, store.GetDeviceColorSpaceDetails(ColorSpace.DeviceRGB));
+            Assert.Same(DeviceCmykColorSpaceDetails.Instance, store.GetDeviceColorSpaceDetails(ColorSpace.DeviceCMYK));
+        }
+
+        [Fact]
+        public void IndexedBase_WithDefaultRgbInResources_UsesDefaultRgb()
+        {
+            // 8.6.5.6: the base colour space of an Indexed space, when it is a device colour space, must
+            // be replaced by the corresponding Default* colour space.
+            var calRgbDict = new DictionaryToken(new Dictionary<NameToken, IToken>
+            {
+                {
+                    NameToken.WhitePoint,
+                    new ArrayToken(new IToken[]
+                    {
+                        new NumericToken(0.9505),
+                        new NumericToken(1.0),
+                        new NumericToken(1.089),
+                    })
+                },
+            });
+            var defaultRgbArray = new ArrayToken(new IToken[] { NameToken.Calrgb, calRgbDict });
+
+            var resources = new DictionaryToken(new Dictionary<NameToken, IToken>
+            {
+                {
+                    NameToken.ColorSpace,
+                    new DictionaryToken(new Dictionary<NameToken, IToken>
+                    {
+                        { NameToken.DefaultRgb, defaultRgbArray },
+                    })
+                },
+            });
+
+            var store = BuildStore();
+            store.LoadResourceDictionary(resources);
+
+            // [ /Indexed /DeviceRGB 1 <000000FFFFFF> ] : 2 entries of 3 RGB components.
+            var indexedArray = new ArrayToken(new IToken[]
+            {
+                NameToken.Indexed,
+                NameToken.Devicergb,
+                new NumericToken(1),
+                new StringToken("ÿÿÿ"),
+            });
+            var imageDictionary = new DictionaryToken(new Dictionary<NameToken, IToken>
+            {
+                { NameToken.ColorSpace, indexedArray },
+            });
+
+            var details = store.GetColorSpaceDetails(NameToken.Indexed, imageDictionary);
+
+            var indexed = Assert.IsType<IndexedColorSpaceDetails>(details);
+            Assert.Equal(ColorSpace.CalRGB, indexed.BaseColorSpace.Type);
+        }
+
+        [Fact]
+        public void GetDeviceColorSpaceDetails_WithIndexedDefaultRgb_ReturnsDeviceColorSpace()
+        {
+            // 8.6.5.6: any colour space other than a Lab, Indexed, or Pattern colour space may be used as a
+            // default colour space. An Indexed DefaultRGB is therefore invalid and must be ignored, leaving
+            // the device colour space in place.
+            // DefaultRGB -> [ /Indexed /DeviceGray 1 <00FF> ]
+            var defaultRgbArray = new ArrayToken(new IToken[]
+            {
+                NameToken.Indexed,
+                NameToken.Devicegray,
+                new NumericToken(1),
+                new StringToken("ÿ"),
+            });
+
+            var resources = new DictionaryToken(new Dictionary<NameToken, IToken>
+            {
+                {
+                    NameToken.ColorSpace,
+                    new DictionaryToken(new Dictionary<NameToken, IToken>
+                    {
+                        { NameToken.DefaultRgb, defaultRgbArray },
+                    })
+                },
+            });
+
+            var store = BuildStore();
+            store.LoadResourceDictionary(resources);
+
+            Assert.Same(DeviceRgbColorSpaceDetails.Instance, store.GetDeviceColorSpaceDetails(ColorSpace.DeviceRGB));
+        }
+
+        [Fact]
+        public void GetDeviceColorSpaceDetails_WithSelfReferentialIndexedDefaultRgb_ReturnsDeviceColorSpace()
+        {
+            // Regression: a self-referential default - /DefaultRGB defined as an Indexed space whose base
+            // is /DeviceRGB - must not recurse forever. Resolving DeviceRGB resolves the Indexed default,
+            // whose base resolves DeviceRGB again; the re-entrancy guard breaks the loop and the Indexed
+            // default is rejected, leaving the device colour space.
+            // DefaultRGB -> [ /Indexed /DeviceRGB 1 <000000FFFFFF> ]
+            var defaultRgbArray = new ArrayToken(new IToken[]
+            {
+                NameToken.Indexed,
+                NameToken.Devicergb,
+                new NumericToken(1),
+                new StringToken("ÿÿÿ"),
+            });
+
+            var resources = new DictionaryToken(new Dictionary<NameToken, IToken>
+            {
+                {
+                    NameToken.ColorSpace,
+                    new DictionaryToken(new Dictionary<NameToken, IToken>
+                    {
+                        { NameToken.DefaultRgb, defaultRgbArray },
+                    })
+                },
+            });
+
+            var store = BuildStore();
+            store.LoadResourceDictionary(resources);
+
+            Assert.Same(DeviceRgbColorSpaceDetails.Instance, store.GetDeviceColorSpaceDetails(ColorSpace.DeviceRGB));
+        }
+
+        [Fact]
+        public void GetDeviceColorSpaceDetails_WithPatternDefaultRgb_ReturnsDeviceColorSpace()
+        {
+            // 8.6.5.6: a Pattern colour space may not be used as a default colour space, so a Pattern
+            // DefaultRGB must be ignored, leaving the device colour space in place.
+            // DefaultRGB -> /Pattern
+            var resources = new DictionaryToken(new Dictionary<NameToken, IToken>
+            {
+                {
+                    NameToken.ColorSpace,
+                    new DictionaryToken(new Dictionary<NameToken, IToken>
+                    {
+                        { NameToken.DefaultRgb, NameToken.Pattern },
+                    })
+                },
+            });
+
+            var store = BuildStore();
+            store.LoadResourceDictionary(resources);
+
+            Assert.Same(DeviceRgbColorSpaceDetails.Instance, store.GetDeviceColorSpaceDetails(ColorSpace.DeviceRGB));
+        }
+    }
+}

--- a/src/UglyToad.PdfPig/Content/IResourceStore.cs
+++ b/src/UglyToad.PdfPig/Content/IResourceStore.cs
@@ -53,6 +53,15 @@
         ColorSpaceDetails GetColorSpaceDetails(NameToken? name, DictionaryToken? dictionary);
 
         /// <summary>
+        /// Get the colour space details for a device colour space selected directly (for example by the
+        /// <c>g</c> / <c>rg</c> / <c>k</c> operators), applying the <c>DefaultGray</c> / <c>DefaultRGB</c> /
+        /// <c>DefaultCMYK</c> substitution from the current resource dictionary when present (PDF 2.0,
+        /// 8.6.5.6 "Default colour spaces"). Returns the device colour space itself when no matching
+        /// default colour space is defined.
+        /// </summary>
+        ColorSpaceDetails GetDeviceColorSpaceDetails(ColorSpace deviceColorSpace);
+
+        /// <summary>
         /// Get the marked content properties dictionary corresponding to the name.
         /// </summary>
         DictionaryToken? GetMarkedContentPropertiesDictionary(NameToken name);

--- a/src/UglyToad.PdfPig/Content/ResourceStore.cs
+++ b/src/UglyToad.PdfPig/Content/ResourceStore.cs
@@ -12,7 +12,7 @@
     using Filters;
     using Util;
 
-    internal class ResourceStore : IResourceStore
+    internal sealed class ResourceStore : IResourceStore
     {
         private readonly IPdfTokenScanner scanner;
         private readonly IFontFactory fontFactory;
@@ -307,10 +307,14 @@
                 return ColorSpaceDetailsParser.GetColorSpaceDetails(null, dictionary, scanner, this, filterProvider);
             }
 
-            if (name.TryMapToColorSpace(out ColorSpace colorspaceActual))
+            if (name.TryMapToColorSpace(out ColorSpace colorSpaceActual))
             {
-                // TODO - We need to find a way to store profile that have an actual dictionary, e.g. ICC profiles - without parsing them again
-                return ColorSpaceDetailsParser.GetColorSpaceDetails(colorspaceActual, dictionary, scanner, this, filterProvider);
+                if (TryGetDefaultSubstitute(colorSpaceActual, out NameToken? substituteName))
+                {
+                    return GetColorSpaceDetails(substituteName, dictionary);
+                }
+                
+                return ColorSpaceDetailsParser.GetColorSpaceDetails(colorSpaceActual, dictionary, scanner, this, filterProvider);
             }
 
             // Named color spaces
@@ -326,7 +330,8 @@
                 {
                     return ColorSpaceDetailsParser.GetColorSpaceDetails(mapped, dictionary, scanner, this, filterProvider);
                 }
-                else if (namedColorSpace.Data is ArrayToken array)
+                
+                if (namedColorSpace.Data is ArrayToken array)
                 {
                     var csd = ColorSpaceDetailsParser.GetColorSpaceDetails(mapped, dictionary.With(NameToken.ColorSpace, array), scanner, this, filterProvider);
                     loadedNamedColorSpaceDetails[name] = csd;
@@ -335,6 +340,56 @@
             }
 
             throw new InvalidOperationException($"Could not find color space for token '{name}'.");
+        }
+
+        public ColorSpaceDetails GetDeviceColorSpaceDetails(ColorSpace deviceColorSpace)
+        {
+            // 8.6.5.6: a directly selected device colour space is remapped to its DefaultGray/RGB/CMYK
+            // substitute when one is present in the current resources. Otherwise return the device
+            // space singleton.
+            // Any colour space other than a Lab, Indexed, or Pattern colour space may be used as a default
+            // colour space and it should be compatible with the original device colour space.
+            // We reject those families up-front from the substitute's own definition, before resolving its
+            // details. Besides being cheaper, this prevents infinite recursion for a self-referential default
+            // such as /DefaultRGB defined as [ /Indexed /DeviceRGB ... ], whose base would otherwise resolve
+            // this same device colour space again.
+            if (TryGetDefaultSubstitute(deviceColorSpace, out NameToken? substituteName) &&
+                TryGetNamedColorSpace(substituteName, out ResourceColorSpace substitute) &&
+                substitute.Name.TryMapToColorSpace(out ColorSpace substituteColorSpace) &&
+                substituteColorSpace is not ColorSpace.Lab and not ColorSpace.Indexed and not ColorSpace.Pattern)
+            {
+                return GetColorSpaceDetails(substituteName, null);
+            }
+
+            return deviceColorSpace switch
+            {
+                ColorSpace.DeviceGray => DeviceGrayColorSpaceDetails.Instance,
+                ColorSpace.DeviceRGB => DeviceRgbColorSpaceDetails.Instance,
+                ColorSpace.DeviceCMYK => DeviceCmykColorSpaceDetails.Instance,
+                _ => throw new ArgumentOutOfRangeException(nameof(deviceColorSpace),
+                    deviceColorSpace,
+                    "Expected a device colour space (DeviceGray, DeviceRGB or DeviceCMYK).")
+            };
+        }
+
+        private bool TryGetDefaultSubstitute(ColorSpace requested, [NotNullWhen(true)] out NameToken? substituteName)
+        {
+            NameToken? candidate = requested switch
+            {
+                ColorSpace.DeviceGray => NameToken.DefaultGray,
+                ColorSpace.DeviceRGB => NameToken.DefaultRgb,
+                ColorSpace.DeviceCMYK => NameToken.DefaultCmyk,
+                _ => null
+            };
+
+            if (candidate is not null && namedColorSpaces.TryGetValue(candidate, out _))
+            {
+                substituteName = candidate;
+                return true;
+            }
+
+            substituteName = null;
+            return false;
         }
 
         public bool TryGetXObject(NameToken name, [NotNullWhen(true)] out StreamToken? stream)

--- a/src/UglyToad.PdfPig/Graphics/ColorSpaceContext.cs
+++ b/src/UglyToad.PdfPig/Graphics/ColorSpaceContext.cs
@@ -40,7 +40,7 @@
                 return;
             }
 
-            if (patternName != null && CurrentStrokingColorSpace.Type == ColorSpace.Pattern)
+            if (patternName is not null && CurrentStrokingColorSpace.Type == ColorSpace.Pattern)
             {
                 currentStateFunc().CurrentStrokingColor = ((PatternColorSpaceDetails)CurrentStrokingColorSpace).GetColor(patternName);
                 // TODO - use operands values for Uncoloured Tiling Patterns
@@ -53,20 +53,17 @@
 
         public void SetStrokingColorGray(double gray)
         {
-            CurrentStrokingColorSpace = DeviceGrayColorSpaceDetails.Instance;
-            currentStateFunc().CurrentStrokingColor = CurrentStrokingColorSpace.GetColor(gray);
+            SetDeviceColor(ColorSpace.DeviceGray, [gray], stroking: true);
         }
 
         public void SetStrokingColorRgb(double r, double g, double b)
         {
-            CurrentStrokingColorSpace = DeviceRgbColorSpaceDetails.Instance;
-            currentStateFunc().CurrentStrokingColor = CurrentStrokingColorSpace.GetColor(r, g, b);
+            SetDeviceColor(ColorSpace.DeviceRGB, [r, g, b], stroking: true);
         }
 
         public void SetStrokingColorCmyk(double c, double m, double y, double k)
         {
-            CurrentStrokingColorSpace = DeviceCmykColorSpaceDetails.Instance;
-            currentStateFunc().CurrentStrokingColor = CurrentStrokingColorSpace.GetColor(c, m, y, k);
+            SetDeviceColor(ColorSpace.DeviceCMYK, [c, m, y, k], stroking: true);
         }
 
         public void SetNonStrokingColorspace(NameToken colorspace, DictionaryToken? dictionary = null)
@@ -87,7 +84,7 @@
                 return;
             }
 
-            if (patternName != null && CurrentNonStrokingColorSpace.Type == ColorSpace.Pattern)
+            if (patternName is not null && CurrentNonStrokingColorSpace.Type == ColorSpace.Pattern)
             {
                 currentStateFunc().CurrentNonStrokingColor = ((PatternColorSpaceDetails)CurrentNonStrokingColorSpace).GetColor(patternName);
                 // TODO - use operands values for Uncoloured Tiling Patterns
@@ -100,20 +97,42 @@
 
         public void SetNonStrokingColorGray(double gray)
         {
-            CurrentNonStrokingColorSpace = DeviceGrayColorSpaceDetails.Instance;
-            currentStateFunc().CurrentNonStrokingColor = CurrentNonStrokingColorSpace.GetColor(gray);
+            SetDeviceColor(ColorSpace.DeviceGray, [gray], stroking: false);
         }
 
         public void SetNonStrokingColorRgb(double r, double g, double b)
         {
-            CurrentNonStrokingColorSpace = DeviceRgbColorSpaceDetails.Instance;
-            currentStateFunc().CurrentNonStrokingColor = CurrentNonStrokingColorSpace.GetColor(r, g, b);
+            SetDeviceColor(ColorSpace.DeviceRGB, [r, g, b], stroking: false);
         }
 
         public void SetNonStrokingColorCmyk(double c, double m, double y, double k)
         {
-            CurrentNonStrokingColorSpace = DeviceCmykColorSpaceDetails.Instance;
-            currentStateFunc().CurrentNonStrokingColor = CurrentNonStrokingColorSpace.GetColor(c, m, y, k);
+            SetDeviceColor(ColorSpace.DeviceCMYK, [c, m, y, k], stroking: false);
+        }
+
+        /// <summary>
+        /// Set a colour selected directly through a device colour operator (<c>g</c>/<c>rg</c>/<c>k</c>
+        /// and their stroking variants). Per 8.6.5.6, "Default colour spaces", the device colour space is
+        /// first remapped to the corresponding <c>DefaultGray</c>/<c>DefaultRGB</c>/<c>DefaultCMYK</c> space
+        /// when one is defined in the current resource dictionary; otherwise the device space is used as-is.
+        /// </summary>
+        private void SetDeviceColor(ColorSpace deviceColorSpace, ReadOnlySpan<double> values, bool stroking)
+        {
+            var colorSpace = resourceStore.GetDeviceColorSpaceDetails(deviceColorSpace);
+            var state = currentStateFunc();
+
+            IColor color = colorSpace.GetColor(values.ToArray());
+
+            if (stroking)
+            {
+                CurrentStrokingColorSpace = colorSpace;
+                state.CurrentStrokingColor = color;
+            }
+            else
+            {
+                CurrentNonStrokingColorSpace = colorSpace;
+                state.CurrentNonStrokingColor = color;
+            }
         }
 
         public IColorSpaceContext DeepClone()

--- a/src/UglyToad.PdfPig/Util/ColorSpaceDetailsParser.cs
+++ b/src/UglyToad.PdfPig/Util/ColorSpaceDetailsParser.cs
@@ -482,6 +482,15 @@
             if (DirectObjectFinder.TryGet(csToken, scanner, out NameToken? alternateNameToken)
                 && ColorSpaceMapper.TryMap(alternateNameToken, resourceStore, out var baseColorSpaceName))
             {
+                // 8.6.5.6: when a special colour space is based on an underlying device colour space, the
+                // DefaultGray/DefaultRGB/DefaultCMYK substitution shall be used in place of that device
+                // space. This applies to the base of an Indexed space, the alternate of a Separation/DeviceN
+                // space and the underlying space of a Pattern - all of which are resolved here.
+                if (baseColorSpaceName is ColorSpace.DeviceGray or ColorSpace.DeviceRGB or ColorSpace.DeviceCMYK)
+                {
+                    return resourceStore.GetDeviceColorSpaceDetails(baseColorSpaceName);
+                }
+
                 return GetColorSpaceDetails(
                     baseColorSpaceName,
                     dictionary,


### PR DESCRIPTION
> Colours that are specified in a device colour space (DeviceGray, DeviceRGB, or DeviceCMYK) are device-dependent. By setting default colour spaces (PDF 1. 1), a PDF writer can request that such colours shall be systematically transformed (remapped) into device-independent CIE-based colour spaces.

<img width="925" height="448" alt="image" src="https://github.com/user-attachments/assets/6b0fc45d-6e05-4061-94b5-1f4d33b9a3b9" />

<img width="889" height="894" alt="image" src="https://github.com/user-attachments/assets/37c70eba-fc9b-4cc9-b3f6-759ee4571348" />
