### PR TITLE
Update DebugType to portable to fix issue when publishing NuGet

### DIFF
--- a/tools/UglyToad.PdfPig.Package/UglyToad.PdfPig.Package.csproj
+++ b/tools/UglyToad.PdfPig.Package/UglyToad.PdfPig.Package.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net462;net471;net6.0;net8.0</TargetFrameworks>
     <PackageId>PdfPig</PackageId>
-    <DebugType>full</DebugType>
+    <DebugType>portable</DebugType>
     <Authors>UglyToad</Authors>
     <Title>PdfPig</Title>
     <Description>Reads text content from PDF documents and supports document creation. Apache 2.0 licensed.</Description>


### PR DESCRIPTION
Attempt at fixing the following when publishing NuGet package:
> Symbols package publishing failed. The associated symbols package could not be published due to the following reason(s):
    The uploaded symbols package contains one or more pdbs that are not portable.