### PR TITLE
PageBuilder: Fix importing page contents stored as indirect array

### DIFF
--- a/src/UglyToad.PdfPig.Tests/Writer/PdfDocumentBuilderTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Writer/PdfDocumentBuilderTests.cs
@@ -1329,6 +1329,24 @@
         }
 
         [Fact]
+        public void CanAddAndModifyPageWithArrayReference()
+        {
+            using var builder = new PdfDocumentBuilder();
+            using (var document = PdfDocument.Open(IntegrationHelpers.GetDocumentPath("GHOSTSCRIPT-697507-0.pdf")))
+            {
+                var pageBuilder = builder.AddPage(document, 1);
+                pageBuilder.NewContentStreamAfter();
+                pageBuilder.SetStrokeColor(0, 0, 0);
+            }
+            var bytes = builder.Build();
+
+            using (var document = PdfDocument.Open(bytes))
+            {
+                Assert.NotNull(document.GetPage(1).Content);
+            }
+        }
+
+        [Fact]
         public void CanAddInternalLinkToPage()
         {
             var builder = new PdfDocumentBuilder();

--- a/src/UglyToad.PdfPig/Writer/PdfDocumentBuilder.cs
+++ b/src/UglyToad.PdfPig/Writer/PdfDocumentBuilder.cs
@@ -361,7 +361,7 @@ namespace UglyToad.PdfPig.Writer
 
                 var contentReferences = new List<IndirectReferenceToken>();
 
-                if (contentsToken is ArrayToken array)
+                if (DirectObjectFinder.TryGet<ArrayToken>(contentsToken, document.Structure.TokenScanner, out var array))
                 {
                     foreach (var item in array.Data)
                     {


### PR DESCRIPTION
When importing a page, if the page content was represented as an array reference, the reference itself was copied.

Resolve Contents through DirectObjectFinder and copy each referenced content stream token into the destination document instead.

Add a regression test based on an existing sample document.

This is similar to what BasePageFactory, which already dereferences array references
[src/UglyToad.PdfPig/Content/BasePageFactory.cs](https://github.com/UglyToad/PdfPig/blob/34229134ac4033d81903502dcc53042bb41605ac/src/UglyToad.PdfPig/Content/BasePageFactory.cs#L117)