### PR TITLE
Expose annotation appearance streams and appearance state as public

### DIFF
--- a/src/UglyToad.PdfPig/Annotations/Annotation.cs
+++ b/src/UglyToad.PdfPig/Annotations/Annotation.cs
@@ -84,6 +84,26 @@
         public bool HasDownAppearance => downAppearanceStream != null;
 
         /// <summary>
+        /// The normal appearance stream for this annotation, if any. Each appearance is a Form XObject.
+        /// </summary>
+        public AppearanceStream? NormalAppearance => normalAppearanceStream;
+
+        /// <summary>
+        /// The roll-over appearance stream (shown on hover), if any.
+        /// </summary>
+        public AppearanceStream? RollOverAppearance => rollOverAppearanceStream;
+
+        /// <summary>
+        /// The down appearance stream (shown on click), if any.
+        /// </summary>
+        public AppearanceStream? DownAppearance => downAppearanceStream;
+
+        /// <summary>
+        /// The current appearance state name, if any.
+        /// </summary>
+        public string? AppearanceState => appearanceState;
+
+        /// <summary>
         /// The <see cref="Annotation"/> this annotation was in reply to. Can be <see langword="null" />
         /// </summary>
         public Annotation? InReplyTo { get; }

--- a/src/UglyToad.PdfPig/Annotations/AppearanceStream.cs
+++ b/src/UglyToad.PdfPig/Annotations/AppearanceStream.cs
@@ -22,6 +22,11 @@
         public bool IsStateless => statelessAppearanceStream != null;
 
         /// <summary>
+        /// The stateless appearance stream, if this appearance stream is stateless.
+        /// </summary>
+        public StreamToken? StatelessAppearanceStream => statelessAppearanceStream;
+
+        /// <summary>
         /// Get list of states. If this is a stateless appearance stream, an empty collection is returned.
         /// </summary>
         public ICollection<string> GetStates => appearanceStreamsByState != null ? appearanceStreamsByState.Keys : new string[0];


### PR DESCRIPTION
This is necessary for my PDF Renderer to access the Appearance Stream parsing inside PdfPig..

I can do it without this, but it means duplicating the parsing that is already there. 

Here is a screenshot of PDF Highlight Annotations Rendering. 

>  Note: the text looks washed out because we are temporaily emulating multiply blend mode with alpha, but that's an issue inside our renderer not related to PdfPig.

<img width="706" height="382" alt="image" src="https://github.com/user-attachments/assets/b1cdff0b-e62f-4e1e-b3b0-a7c7cd0ed35f" />

