### PR TITLE
Fix: brute-force xref scan loses stream position, missing recoverable trailers

### DIFF
--- a/src/UglyToad.PdfPig/Parser/FileStructure/XrefBruteForcer.cs
+++ b/src/UglyToad.PdfPig/Parser/FileStructure/XrefBruteForcer.cs
@@ -1,4 +1,4 @@
-﻿namespace UglyToad.PdfPig.Parser.FileStructure;
+namespace UglyToad.PdfPig.Parser.FileStructure;
 
 using Core;
 using Logging;
@@ -135,6 +135,12 @@ internal static class XrefBruteForcer
 
                 var potentialTableOffset = bytes.CurrentOffset - 4;
 
+                // TryReadTableAtOffset seeks the shared stream and does not restore
+                // position (including on failure). Snapshot so the scan resumes from
+                // here — otherwise a failed parse can skip past later keywords such
+                // as a recoverable 'trailer' dictionary.
+                var resumePosition = bytes.CurrentOffset;
+
                 if (xrefOffsetSeen.Contains(potentialTableOffset))
                 {
                     log.Debug($"Skipping circular xref reference at {potentialTableOffset}");
@@ -158,6 +164,8 @@ internal static class XrefBruteForcer
                     log.Warn(
                         $"Found a table at {potentialTableOffset} but couldn't parse it.");
                 }
+
+                bytes.Seek(resumePosition);
             }
             else if (buffer.EndsWith("/XRef"))
             {
@@ -176,6 +184,9 @@ internal static class XrefBruteForcer
                 }
                 xrefOffsetSeen.Add(offset);
 
+                // Same position-preservation as the table branch above.
+                var resumePosition = bytes.CurrentOffset;
+
                 var stream = XrefStreamParser.TryReadStreamAtOffset(
                     new FileHeaderOffset(0),
                     offset,
@@ -187,10 +198,16 @@ internal static class XrefBruteForcer
                 {
                     results.Add(stream);
                 }
+
+                bytes.Seek(resumePosition);
             }
             else if (buffer.EndsWith("trailer "))
             {
                 ClearQueues();
+
+                // Ensure the scanner reads from the byte scan's current position —
+                // a preceding failed table/stream parse may have moved it elsewhere.
+                scanner.Seek(bytes.CurrentOffset);
 
                 // Grab the last trailer dictionary as backup in case we find no valid xrefs.
                 if (scanner.TryReadToken(out DictionaryToken trailerDict))


### PR DESCRIPTION
## Problem: brute-force xref scan loses stream position, missing recoverable trailers

`PdfDocument.Open` throws `"Could not find an xref trailer or stream dictionary in the input file"`
for some malformed-but-recoverable PDFs - even under lenient parsing - that Acrobat/Foxit open fine.

Repro: PDFium's Type3 test file ships a deliberately broken xref section:

  [pdfium_type3_basic.pdf](https://github.com/user-attachments/files/29740413/pdfium_type3_basic.pdf)

```pdf
xref
0 
trailer
<< /Size 0 /Root 1 0 R >>
startxref
0
%%EOF
```

The body objects and the trailer dictionary itself are perfectly valid — only the xref machinery
around them is broken.

<img width="1274" height="619" alt="image" src="https://github.com/user-attachments/assets/c52776d0-1e9b-408c-9c9a-8c7e1d27f81c" />


### Root cause

`XrefBruteForcer.FindAllXrefsInFileOrder` scans the input byte-by-byte and has a handler that
captures a backup `trailer` dictionary — but it never fired for this file. When the scan hits
`" xref"` it calls `XrefTableParser.TryReadTableAtOffset`, which **seeks the shared `IInputBytes`
and does not restore position on failure**. The failed parse of the malformed table left the stream
positioned *past* the `trailer` keyword, so the scan loop never saw it → `LastTrailer` stayed null
→ `PdfDocumentFactory` threw. The same hazard exists in the `"/XRef"` stream branch.

### Fix

- Snapshot `bytes.CurrentOffset` before the nested table/stream parse attempts and seek back
  afterwards, so the byte scan always resumes where it left off.
- Seek the token scanner to the scan position before reading the backup trailer dictionary, since
  a preceding failed parse may have moved it elsewhere.

No behavior change for well-formed files (the brute-forcer only runs when direct xref parsing has
already failed), and no change to non-lenient error behavior.

### Verified

- The PDFium type3 file now opens; page content parses and renders correctly.
- Existing test suite passes.
