### PR TITLE
Properly override Equals and GetHashCode methods for IToken and add tests

### DIFF
--- a/src/UglyToad.PdfPig.Tests/Tokens/ArrayTokenTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Tokens/ArrayTokenTests.cs
@@ -48,5 +48,60 @@
 
             Assert.Equal("[ (hedgehog), 7, obj ]", token.ToString());
         }
+
+        [Fact]
+        public void EqualsAndGetHashCode()
+        {
+            var token1 = new ArrayToken(new IToken[] { new NumericToken(1), new NumericToken(2) });
+            var token2 = new ArrayToken(new IToken[] { new NumericToken(1), new NumericToken(2) });
+            var token3 = new ArrayToken(new IToken[] { new NumericToken(1), new NumericToken(3) });
+
+            Assert.Equal(token1, token2);
+            Assert.Equal(token1.GetHashCode(), token2.GetHashCode());
+            Assert.NotEqual(token1, token3);
+            Assert.False(token1.Equals(null));
+            Assert.False(token1.Equals(new object()));
+        }
+
+        [Fact]
+        public void EqualsIsOrderSensitive()
+        {
+            var token = new ArrayToken(new IToken[] { new NumericToken(1), new NumericToken(2) });
+            var reordered = new ArrayToken(new IToken[] { new NumericToken(2), new NumericToken(1) });
+
+            Assert.NotEqual(token, reordered);
+            Assert.NotEqual(reordered, token);
+        }
+
+        [Fact]
+        public void EqualsIsLengthSensitive()
+        {
+            var token = new ArrayToken(new IToken[] { new NumericToken(1), new NumericToken(2) });
+            var prefix = new ArrayToken(new IToken[] { new NumericToken(1) });
+            var longer = new ArrayToken(new IToken[] { new NumericToken(1), new NumericToken(2), new NumericToken(3) });
+
+            Assert.NotEqual(token, prefix);
+            Assert.NotEqual(prefix, token);
+            Assert.NotEqual(token, longer);
+            Assert.NotEqual(longer, token);
+        }
+
+        [Fact]
+        public void EqualsEmptyAndNestedArrays()
+        {
+            var empty1 = new ArrayToken(new IToken[0]);
+            var empty2 = new ArrayToken(new IToken[0]);
+
+            Assert.Equal(empty1, empty2);
+            Assert.Equal(empty1.GetHashCode(), empty2.GetHashCode());
+
+            var nested1 = new ArrayToken(new IToken[] { new ArrayToken(new IToken[] { new NumericToken(1) }), new StringToken("a") });
+            var nested2 = new ArrayToken(new IToken[] { new ArrayToken(new IToken[] { new NumericToken(1) }), new StringToken("a") });
+            var nested3 = new ArrayToken(new IToken[] { new ArrayToken(new IToken[] { new NumericToken(2) }), new StringToken("a") });
+
+            Assert.Equal(nested1, nested2);
+            Assert.Equal(nested1.GetHashCode(), nested2.GetHashCode());
+            Assert.NotEqual(nested1, nested3);
+        }
     }
 }

--- a/src/UglyToad.PdfPig.Tests/Tokens/DictionaryTokenTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Tokens/DictionaryTokenTests.cs
@@ -98,5 +98,90 @@ namespace UglyToad.PdfPig.Tests.Tokens
             Assert.True(newDictionary.ContainsKey(NameToken.ActualText));
             Assert.Equal("The text", newDictionary.Get<StringToken>(NameToken.ActualText, new TestPdfTokenScanner()).Data);
         }
+
+        [Fact]
+        public void EqualsAndGetHashCode()
+        {
+            var dict1 = new DictionaryToken(new Dictionary<NameToken, IToken>
+            {
+                { NameToken.Create("Key1"), new NumericToken(1) },
+                { NameToken.Create("Key2"), new NumericToken(2) }
+            });
+            var dict2 = new DictionaryToken(new Dictionary<NameToken, IToken>
+            {
+                { NameToken.Create("Key1"), new NumericToken(1) },
+                { NameToken.Create("Key2"), new NumericToken(2) }
+            });
+            var dict3 = new DictionaryToken(new Dictionary<NameToken, IToken>
+            {
+                { NameToken.Create("Key1"), new NumericToken(1) },
+                { NameToken.Create("Key2"), new NumericToken(3) }
+            });
+
+            Assert.Equal(dict1, dict2);
+            Assert.Equal(dict1.GetHashCode(), dict2.GetHashCode());
+            Assert.NotEqual(dict1, dict3);
+            Assert.False(dict1.Equals(null));
+            Assert.False(dict1.Equals(new object()));
+        }
+
+        [Fact]
+        public void EqualsAndGetHashCodeIgnoreInsertionOrder()
+        {
+            var dict1 = new DictionaryToken(new Dictionary<NameToken, IToken>
+            {
+                { NameToken.Create("Key1"), new NumericToken(1) },
+                { NameToken.Create("Key2"), new NumericToken(2) }
+            });
+            var dict2 = new DictionaryToken(new Dictionary<NameToken, IToken>
+            {
+                { NameToken.Create("Key2"), new NumericToken(2) },
+                { NameToken.Create("Key1"), new NumericToken(1) }
+            });
+
+            Assert.Equal(dict1, dict2);
+            Assert.Equal(dict2, dict1);
+            Assert.Equal(dict1.GetHashCode(), dict2.GetHashCode());
+        }
+
+        [Fact]
+        public void EqualsComparesNestedTokensByValue()
+        {
+            var dict1 = new DictionaryToken(new Dictionary<NameToken, IToken>
+            {
+                { NameToken.Create("Kids"), new ArrayToken(new IToken[] { new NumericToken(1), new StringToken("a") }) }
+            });
+            var dict2 = new DictionaryToken(new Dictionary<NameToken, IToken>
+            {
+                { NameToken.Create("Kids"), new ArrayToken(new IToken[] { new NumericToken(1), new StringToken("a") }) }
+            });
+            var dict3 = new DictionaryToken(new Dictionary<NameToken, IToken>
+            {
+                { NameToken.Create("Kids"), new ArrayToken(new IToken[] { new NumericToken(2), new StringToken("a") }) }
+            });
+
+            Assert.Equal(dict1, dict2);
+            Assert.Equal(dict1.GetHashCode(), dict2.GetHashCode());
+            Assert.NotEqual(dict1, dict3);
+        }
+
+        [Fact]
+        public void EqualsIsCountAndKeySensitive()
+        {
+            var empty = new DictionaryToken(new Dictionary<NameToken, IToken>());
+            var single = new DictionaryToken(new Dictionary<NameToken, IToken>
+            {
+                { NameToken.Create("Key1"), new NumericToken(1) }
+            });
+            var sameValueOtherKey = new DictionaryToken(new Dictionary<NameToken, IToken>
+            {
+                { NameToken.Create("Key2"), new NumericToken(1) }
+            });
+
+            Assert.Equal(empty, new DictionaryToken(new Dictionary<NameToken, IToken>()));
+            Assert.NotEqual(empty, single);
+            Assert.NotEqual(single, empty);
+            Assert.NotEqual(single, sameValueOtherKey);
+        }
     }
 }

--- a/src/UglyToad.PdfPig.Tests/Tokens/HexTokenTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Tokens/HexTokenTests.cs
@@ -33,5 +33,40 @@
 
             Assert.Equal(expected, value);
         }
+
+        [Fact]
+        public void EqualsAndGetHashCode()
+        {
+            var token1 = new HexToken("AE".ToCharArray());
+            var token2 = new HexToken("AE".ToCharArray());
+            var token3 = new HexToken("61".ToCharArray());
+
+            Assert.Equal(token1, token2);
+            Assert.Equal(token1.GetHashCode(), token2.GetHashCode());
+            Assert.NotEqual(token1, token3);
+            Assert.False(token1.Equals(null));
+            Assert.False(token1.Equals(new object()));
+        }
+
+        [Fact]
+        public void EqualsIgnoresHexDigitCase()
+        {
+            var upper = new HexToken("AE".ToCharArray());
+            var lower = new HexToken("ae".ToCharArray());
+
+            Assert.Equal(upper, lower);
+            Assert.Equal(upper.GetHashCode(), lower.GetHashCode());
+        }
+
+        [Fact]
+        public void NotEqualToStringTokenWithSameText()
+        {
+            var hex = new HexToken("61".ToCharArray());
+            var str = new StringToken("a");
+
+            Assert.Equal("a", hex.Data);
+            Assert.False(hex.Equals(str));
+            Assert.False(str.Equals(hex));
+        }
     }
 }

--- a/src/UglyToad.PdfPig.Tests/Tokens/TokenEqualityTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Tokens/TokenEqualityTests.cs
@@ -1,0 +1,248 @@
+﻿namespace UglyToad.PdfPig.Tests.Tokens
+{
+    using PdfPig.Tokens;
+    using PdfPig.Core;
+    using System.Collections.Generic;
+
+    public class TokenEqualityTests
+    {
+        [Fact]
+        public void BooleanTokenEquals()
+        {
+            Assert.Equal(BooleanToken.True, BooleanToken.True);
+            Assert.Equal(BooleanToken.True.GetHashCode(), BooleanToken.True.GetHashCode());
+            Assert.NotEqual(BooleanToken.True, BooleanToken.False);
+            Assert.False(BooleanToken.True.Equals(null));
+        }
+
+        [Fact]
+        public void CommentTokenEquals()
+        {
+            var t1 = new CommentToken("test");
+            var t2 = new CommentToken("test");
+            var t3 = new CommentToken("other");
+
+            Assert.Equal(t1, t2);
+            Assert.Equal(t1.GetHashCode(), t2.GetHashCode());
+            Assert.NotEqual(t1, t3);
+            Assert.False(t1.Equals(null));
+        }
+
+        [Fact]
+        public void EndOfLineTokenEquals()
+        {
+            var t1 = EndOfLineToken.Token;
+            var t2 = EndOfLineToken.Token;
+            
+            Assert.Equal(t1, t2);
+            Assert.Equal(t1.GetHashCode(), t2.GetHashCode());
+        }
+
+        [Fact]
+        public void IndirectReferenceTokenEquals()
+        {
+            var t1 = new IndirectReferenceToken(new IndirectReference(1, 0));
+            var t2 = new IndirectReferenceToken(new IndirectReference(1, 0));
+            var t3 = new IndirectReferenceToken(new IndirectReference(2, 0));
+
+            Assert.Equal(t1, t2);
+            Assert.Equal(t1.GetHashCode(), t2.GetHashCode());
+            Assert.NotEqual(t1, t3);
+        }
+
+        [Fact]
+        public void InlineImageDataTokenEquals()
+        {
+            var data1 = new byte[] { 1, 2, 3 };
+            var data2 = new byte[] { 1, 2, 3 };
+            var data3 = new byte[] { 1, 2, 4 };
+
+            var t1 = new InlineImageDataToken(data1);
+            var t2 = new InlineImageDataToken(data1); // Same reference
+            var t3 = new InlineImageDataToken(data2); // Same content, different reference
+            var t4 = new InlineImageDataToken(data3);
+
+            Assert.Equal(t1, t2);
+            Assert.Equal(t1.GetHashCode(), t2.GetHashCode());
+            
+            Assert.Equal(t1, t3);
+            Assert.NotEqual(t1, t4);
+        }
+
+        [Fact]
+        public void NameTokenEquals()
+        {
+            var t1 = NameToken.Create("Test");
+            var t2 = NameToken.Create("Test");
+            var t3 = NameToken.Create("Other");
+
+            Assert.Equal(t1, t2);
+            Assert.Equal(t1.GetHashCode(), t2.GetHashCode());
+            Assert.NotEqual(t1, t3);
+        }
+
+        [Fact]
+        public void NullTokenEquals()
+        {
+            var t1 = NullToken.Instance;
+            var t2 = NullToken.Instance;
+
+            Assert.Equal(t1, t2);
+            Assert.Equal(t1.GetHashCode(), t2.GetHashCode());
+        }
+
+        [Fact]
+        public void NumericTokenEquals()
+        {
+            var t1 = new NumericToken(1);
+            var t2 = new NumericToken(1);
+            var t3 = new NumericToken(2);
+
+            Assert.Equal(t1, t2);
+            Assert.Equal(t1.GetHashCode(), t2.GetHashCode());
+            Assert.NotEqual(t1, t3);
+        }
+
+        [Fact]
+        public void ObjectTokenEquals()
+        {
+            var t1 = new ObjectToken(XrefLocation.File(0), new IndirectReference(1, 0), new NumericToken(1));
+            var t2 = new ObjectToken(XrefLocation.File(0), new IndirectReference(1, 0), new NumericToken(1));
+            var t3 = new ObjectToken(XrefLocation.File(0), new IndirectReference(2, 0), new NumericToken(1));
+
+            Assert.Equal(t1, t2);
+            Assert.Equal(t1.GetHashCode(), t2.GetHashCode());
+            Assert.NotEqual(t1, t3);
+        }
+
+        [Fact]
+        public void OperatorTokenEquals()
+        {
+            var t1 = OperatorToken.Create("w".AsSpan());
+            var t2 = OperatorToken.Create("w".AsSpan());
+            var t3 = OperatorToken.Create("W".AsSpan());
+
+            Assert.Equal(t1, t2);
+            Assert.Equal(t1.GetHashCode(), t2.GetHashCode());
+            Assert.NotEqual(t1, t3);
+        }
+
+        [Fact]
+        public void StreamTokenEquals()
+        {
+            var dict1 = new DictionaryToken(new Dictionary<NameToken, IToken> { { NameToken.Length, new NumericToken(1) } });
+            var dict2 = new DictionaryToken(new Dictionary<NameToken, IToken> { { NameToken.Length, new NumericToken(1) } });
+            var data1 = new byte[] { 65 };
+            var data2 = new byte[] { 65 };
+
+            var t1 = new StreamToken(dict1, data1);
+            var t2 = new StreamToken(dict2, data2);
+
+            Assert.Equal(t1, t2);
+            Assert.Equal(t1.GetHashCode(), t2.GetHashCode());
+        }
+
+        [Fact]
+        public void StringTokenEquals()
+        {
+            var t1 = new StringToken("test");
+            var t2 = new StringToken("test");
+            var t3 = new StringToken("other");
+
+            Assert.Equal(t1, t2);
+            Assert.Equal(t1.GetHashCode(), t2.GetHashCode());
+            Assert.NotEqual(t1, t3);
+        }
+
+        [Fact]
+        public void StringTokenNotEqualWhenEncodingDiffers()
+        {
+            var iso = new StringToken("test", StringToken.Encoding.Iso88591);
+            var utf16 = new StringToken("test", StringToken.Encoding.Utf16BE);
+
+            Assert.NotEqual(iso, utf16);
+            Assert.NotEqual(utf16, iso);
+        }
+
+        [Fact]
+        public void NumericTokenIntAndDoubleWithSameValueAreEqual()
+        {
+            var integer = new NumericToken(1);
+            var floating = new NumericToken(1.0);
+
+            Assert.Equal(integer, floating);
+            Assert.Equal(integer.GetHashCode(), floating.GetHashCode());
+        }
+
+        [Fact]
+        public void StreamTokenNotEqualWhenDictionaryOrDataDiffers()
+        {
+            var dict = new DictionaryToken(new Dictionary<NameToken, IToken> { { NameToken.Length, new NumericToken(1) } });
+            var otherDict = new DictionaryToken(new Dictionary<NameToken, IToken> { { NameToken.Length, new NumericToken(2) } });
+
+            var token = new StreamToken(dict, new byte[] { 65 });
+            var differentDictionary = new StreamToken(otherDict, new byte[] { 65 });
+            var differentData = new StreamToken(dict, new byte[] { 66 });
+
+            Assert.NotEqual(token, differentDictionary);
+            Assert.NotEqual(token, differentData);
+            Assert.False(token.Equals(null));
+        }
+
+        [Fact]
+        public void IndirectReferenceTokenNotEqualWhenGenerationDiffers()
+        {
+            var t1 = new IndirectReferenceToken(new IndirectReference(1, 0));
+            var t2 = new IndirectReferenceToken(new IndirectReference(1, 1));
+
+            Assert.NotEqual(t1, t2);
+        }
+
+        [Fact]
+        public void ObjectTokenNotEqualWhenDataDiffers()
+        {
+            var t1 = new ObjectToken(XrefLocation.File(0), new IndirectReference(1, 0), new NumericToken(1));
+            var t2 = new ObjectToken(XrefLocation.File(0), new IndirectReference(1, 0), new NumericToken(2));
+
+            Assert.NotEqual(t1, t2);
+        }
+
+        [Fact]
+        public void TokensOfDifferentTypesAreNeverEqual()
+        {
+            var tokens = new IToken[]
+            {
+                new NumericToken(1),
+                new StringToken("1"),
+                new HexToken("31".ToCharArray()),
+                NameToken.Create("1"),
+                new CommentToken("1"),
+                BooleanToken.True,
+                NullToken.Instance,
+                EndOfLineToken.Token,
+                OperatorToken.Create("1".AsSpan()),
+                new ArrayToken(new IToken[] { new NumericToken(1) }),
+                new DictionaryToken(new Dictionary<NameToken, IToken>()),
+                new IndirectReferenceToken(new IndirectReference(1, 0)),
+                new InlineImageDataToken(new byte[] { 49 })
+            };
+
+            for (var i = 0; i < tokens.Length; i++)
+            {
+                Assert.False(tokens[i].Equals(null), $"{tokens[i].GetType().Name} should not equal null.");
+
+                for (var j = 0; j < tokens.Length; j++)
+                {
+                    if (i == j)
+                    {
+                        continue;
+                    }
+
+                    Assert.False(
+                        tokens[i].Equals(tokens[j]),
+                        $"{tokens[i].GetType().Name} should not equal {tokens[j].GetType().Name}.");
+                }
+            }
+        }
+    }
+}

--- a/src/UglyToad.PdfPig.Tokens/ArrayToken.cs
+++ b/src/UglyToad.PdfPig.Tokens/ArrayToken.cs
@@ -85,6 +85,24 @@
         }
         
         /// <inheritdoc />
+        public override int GetHashCode()
+        {
+            HashCode hash = new HashCode();
+            foreach (var t in Data)
+            {
+                hash.Add(t);
+            }
+
+            return hash.ToHashCode();
+        }
+
+        /// <inheritdoc />
+        public override bool Equals(object? obj)
+        {
+            return obj is IToken token && Equals(token);
+        }
+
+        /// <inheritdoc />
         public bool Equals(IToken obj)
         {
             if (ReferenceEquals(this, obj))
@@ -92,7 +110,7 @@
                 return true;
             }
 
-            if (!(obj is ArrayToken other))
+            if (obj is not ArrayToken other)
             {
                 return false;
             }

--- a/src/UglyToad.PdfPig.Tokens/BooleanToken.cs
+++ b/src/UglyToad.PdfPig.Tokens/BooleanToken.cs
@@ -42,6 +42,12 @@
         }
 
         /// <inheritdoc />
+        public override bool Equals(object? obj)
+        {
+            return obj is IToken token && Equals(token);
+        }
+
+        /// <inheritdoc />
         public bool Equals(IToken obj)
         {
             if (ReferenceEquals(this, obj))
@@ -49,7 +55,7 @@
                 return true;
             }
 
-            if (!(obj is BooleanToken other))
+            if (obj is not BooleanToken other)
             {
                 return false;
             }

--- a/src/UglyToad.PdfPig.Tokens/CommentToken.cs
+++ b/src/UglyToad.PdfPig.Tokens/CommentToken.cs
@@ -4,7 +4,7 @@
     /// A comment from a PDF document. Any occurrence of the percent sign character (%) outside a string or stream
     /// introduces a comment. The comment consists of all characters between the percent sign and the end of the line.
     /// </summary>
-    public class CommentToken : IDataToken<string>
+    public sealed class CommentToken : IDataToken<string>
     {
         /// <summary>
         /// The text of the comment (excluding the initial percent '%' sign).
@@ -25,6 +25,18 @@
         {
             return Data;
         }
+        
+        /// <inheritdoc />
+        public override int GetHashCode()
+        {
+            return Data.GetHashCode();
+        }
+
+        /// <inheritdoc />
+        public override bool Equals(object? obj)
+        {
+            return obj is IToken token && Equals(token);
+        }
 
         /// <inheritdoc />
         public bool Equals(IToken obj)
@@ -34,7 +46,7 @@
                 return true;
             }
 
-            if (!(obj is CommentToken other))
+            if (obj is not CommentToken other)
             {
                 return false;
             }

--- a/src/UglyToad.PdfPig.Tokens/DictionaryToken.cs
+++ b/src/UglyToad.PdfPig.Tokens/DictionaryToken.cs
@@ -8,7 +8,7 @@
     /// A dictionary object is an associative table containing pairs of objects, known as the dictionary's entries. 
     /// The key must be a <see cref="NameToken"/> and the value may be an kind of <see cref="IToken"/>.
     /// </summary>
-    public class DictionaryToken : IDataToken<IReadOnlyDictionary<string, IToken>>, IEquatable<DictionaryToken>
+    public sealed class DictionaryToken : IDataToken<IReadOnlyDictionary<string, IToken>>, IEquatable<DictionaryToken>
     {
         /// <summary>
         /// The key value pairs in this dictionary.
@@ -168,15 +168,38 @@
         }
 
         /// <inheritdoc />
+        public override int GetHashCode()
+        {
+            // Equals is insensitive to entry order so the hash must be too
+            int hash = 0;
+
+            foreach (var kvp in Data)
+            {
+                unchecked
+                {
+                    hash += HashCode.Combine(kvp.Key, kvp.Value);
+                }
+            }
+
+            return hash;
+        }
+
+        /// <inheritdoc />
+        public override bool Equals(object? obj)
+        {
+            return obj is DictionaryToken token && Equals(token);
+        }
+
+        /// <inheritdoc />
         public bool Equals(IToken obj)
         {
-            return Equals(obj as DictionaryToken);
+            return obj is DictionaryToken token && Equals(token);
         }
 
         /// <inheritdoc />
         public bool Equals(DictionaryToken other)
         {
-            if (other == null)
+            if (other is null)
             { 
                 return false;
             }
@@ -207,6 +230,5 @@
         {
             return string.Join(", ", Data.Select(x => $"<{x.Key}, {x.Value}>"));
         }
-       
     }
 }

--- a/src/UglyToad.PdfPig.Tokens/EndOfLineToken.cs
+++ b/src/UglyToad.PdfPig.Tokens/EndOfLineToken.cs
@@ -3,7 +3,7 @@
     /// <summary>
     /// Represents an End Of Line marker found in Adobe Type 1 font files and the cross-reference table.
     /// </summary>
-    public class EndOfLineToken : IToken
+    public sealed class EndOfLineToken : IToken
     {
         /// <summary>
         /// The instance of the end of line token.
@@ -12,6 +12,18 @@
 
         private EndOfLineToken()
         {
+        }
+
+        /// <inheritdoc />
+        public override int GetHashCode()
+        {
+            return typeof(EndOfLineToken).GetHashCode();
+        }
+
+        /// <inheritdoc />
+        public override bool Equals(object? obj)
+        {
+            return obj is IToken token && Equals(token);
         }
 
         /// <inheritdoc />

--- a/src/UglyToad.PdfPig.Tokens/HexToken.cs
+++ b/src/UglyToad.PdfPig.Tokens/HexToken.cs
@@ -146,6 +146,18 @@ namespace UglyToad.PdfPig.Tokens
 
             return value;
         }
+        
+        /// <inheritdoc />
+        public override int GetHashCode()
+        {
+            return Data.GetHashCode();
+        }
+
+        /// <inheritdoc />
+        public override bool Equals(object? obj)
+        {
+            return obj is IToken token && Equals(token);
+        }
 
         /// <inheritdoc />
         public bool Equals(IToken obj)
@@ -155,7 +167,7 @@ namespace UglyToad.PdfPig.Tokens
                 return true;
             }
 
-            if (!(obj is HexToken other))
+            if (obj is not HexToken other)
             {
                 return false;
             }

--- a/src/UglyToad.PdfPig.Tokens/IToken.cs
+++ b/src/UglyToad.PdfPig.Tokens/IToken.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-namespace UglyToad.PdfPig.Tokens
+﻿namespace UglyToad.PdfPig.Tokens
 {
     /// <summary>
     /// A marker interface for tokens from the PDF file contents.

--- a/src/UglyToad.PdfPig.Tokens/IndirectReferenceToken.cs
+++ b/src/UglyToad.PdfPig.Tokens/IndirectReferenceToken.cs
@@ -5,7 +5,7 @@
     /// <summary>
     /// A reference to an indirect object (see <see cref="ObjectToken"/>).
     /// </summary>
-    public class IndirectReferenceToken : IDataToken<IndirectReference>
+    public sealed class IndirectReferenceToken : IDataToken<IndirectReference>
     {
         /// <summary>
         /// The identifier for an object in the PDF file.
@@ -21,6 +21,17 @@
             Data = data;
         }
 
+        public override int GetHashCode()
+        {
+            return Data.GetHashCode();
+        }
+
+        /// <inheritdoc />
+        public override bool Equals(object? obj)
+        {
+            return obj is IToken token && Equals(token);
+        }
+
         /// <inheritdoc />
         public bool Equals(IToken obj)
         {
@@ -29,7 +40,7 @@
                 return true;
             }
 
-            if (!(obj is IndirectReferenceToken other))
+            if (obj is not IndirectReferenceToken other)
             {
                 return false;
             }

--- a/src/UglyToad.PdfPig.Tokens/InlineImageDataToken.cs
+++ b/src/UglyToad.PdfPig.Tokens/InlineImageDataToken.cs
@@ -20,6 +20,28 @@
         }
 
         /// <inheritdoc />
+        public override int GetHashCode()
+        {
+            var hash = new HashCode();
+#if NET6_0_OR_GREATER
+            hash.AddBytes(Data.Span);
+#else
+            var span = Data.Span;
+            for (var i = 0; i < span.Length; i++)
+            {
+                hash.Add(span[i]);
+            }
+#endif
+            return hash.ToHashCode();
+        }
+
+        /// <inheritdoc />
+        public override bool Equals(object? obj)
+        {
+            return obj is IToken token && Equals(token);
+        }
+
+        /// <inheritdoc />
         public bool Equals(IToken obj)
         {
             if (ReferenceEquals(this, obj))
@@ -27,7 +49,7 @@
                 return true;
             }
 
-            if (!(obj is InlineImageDataToken other))
+            if (obj is not InlineImageDataToken other)
             {
                 return false;
             }

--- a/src/UglyToad.PdfPig.Tokens/NameToken.cs
+++ b/src/UglyToad.PdfPig.Tokens/NameToken.cs
@@ -8,7 +8,7 @@
     /// Each name is considered identical if it has the same sequence of characters. Names are used in
     /// PDF documents to identify dictionary keys and other elements of a PDF document.
     /// </summary>
-    public partial class NameToken : IDataToken<string>
+    public sealed partial class NameToken : IDataToken<string>
     {
         /// <inheritdoc />
         /// <summary>
@@ -45,9 +45,15 @@
         }
 
         /// <inheritdoc />
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
-            return Equals(obj as NameToken);
+            return obj is NameToken token && Equals(token);
+        }
+
+        /// <inheritdoc />
+        public bool Equals(IToken obj)
+        {
+            return obj is NameToken token && Equals(token);
         }
 
         /// <summary>
@@ -56,12 +62,6 @@
         public bool Equals(NameToken other)
         {
             return string.Equals(Data, other?.Data);
-        }
-
-        /// <inheritdoc />
-        public bool Equals(IToken obj)
-        {
-            return Equals(obj as NameToken);
         }
 
         /// <inheritdoc />

--- a/src/UglyToad.PdfPig.Tokens/NullToken.cs
+++ b/src/UglyToad.PdfPig.Tokens/NullToken.cs
@@ -6,7 +6,7 @@
     /// An indirect object reference to a nonexistent object is treated the same as the null object. 
     /// Specifying the null object as the value of a dictionary entry is equivalent to omitting the entry entirely.
     /// </summary>
-    public class NullToken : IDataToken<object>
+    public sealed class NullToken : IDataToken<object>
     {
         /// <summary>
         /// The single instance of the <see cref="NullToken"/>.
@@ -16,12 +16,12 @@
         /// <summary>
         /// <see langword="null"/>.
         /// </summary>
-        public object Data { get; } = null;
+        public object Data { get; } = null!;
 
         private NullToken() { }
 
         /// <inheritdoc />
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             return obj is NullToken;
         }
@@ -29,9 +29,9 @@
         /// <summary>
         /// Whether two null tokens are equal.
         /// </summary>
-        protected bool Equals(NullToken other)
+        public bool Equals(NullToken? other)
         {
-            return Equals(Data, other.Data);
+            return other is not null;
         }
 
         /// <inheritdoc />

--- a/src/UglyToad.PdfPig.Tokens/NumericToken.cs
+++ b/src/UglyToad.PdfPig.Tokens/NumericToken.cs
@@ -186,6 +186,12 @@
         }
 
         /// <inheritdoc />
+        public override bool Equals(object? obj)
+        {
+            return obj is IToken token && Equals(token);
+        }
+
+        /// <inheritdoc />
         public bool Equals(IToken obj)
         {
             if (ReferenceEquals(this, obj))

--- a/src/UglyToad.PdfPig.Tokens/ObjectToken.cs
+++ b/src/UglyToad.PdfPig.Tokens/ObjectToken.cs
@@ -38,6 +38,18 @@
         }
 
         /// <inheritdoc />
+        public override int GetHashCode()
+        {
+            return HashCode.Combine(Number, Data);
+        }
+
+        /// <inheritdoc />
+        public override bool Equals(object? obj)
+        {
+            return obj is IToken token && Equals(token);
+        }
+
+        /// <inheritdoc />
         public bool Equals(IToken obj)
         {
             if (ReferenceEquals(this, obj))
@@ -45,7 +57,7 @@
                 return true;
             }
 
-            if (!(obj is ObjectToken other))
+            if (obj is not ObjectToken other)
             {
                 return false;
             }

--- a/src/UglyToad.PdfPig.Tokens/OperatorToken.cs
+++ b/src/UglyToad.PdfPig.Tokens/OperatorToken.cs
@@ -174,6 +174,12 @@
         }
 
         /// <inheritdoc />
+        public override bool Equals(object? obj)
+        {
+            return obj is IToken token && Equals(token);
+        }
+
+        /// <inheritdoc />
         public bool Equals(IToken obj)
         {
             if (ReferenceEquals(this, obj))
@@ -181,7 +187,7 @@
                 return true;
             }
 
-            if (!(obj is OperatorToken other))
+            if (obj is not OperatorToken other)
             {
                 return false;
             }

--- a/src/UglyToad.PdfPig.Tokens/StreamToken.cs
+++ b/src/UglyToad.PdfPig.Tokens/StreamToken.cs
@@ -41,6 +41,29 @@
         }
 
         /// <inheritdoc />
+        public override int GetHashCode()
+        {
+            var hash = new HashCode();
+            hash.Add(StreamDictionary);
+#if NET6_0_OR_GREATER
+            hash.AddBytes(Data.Span);
+#else
+            var span = Data.Span;
+            for (var i = 0; i < span.Length; i++)
+            {
+                hash.Add(span[i]);
+            }
+#endif
+            return hash.ToHashCode();
+        }
+
+        /// <inheritdoc />
+        public override bool Equals(object? obj)
+        {
+            return obj is IToken token && Equals(token);
+        }
+
+        /// <inheritdoc />
         public bool Equals(IToken obj)
         {
             if (ReferenceEquals(this, obj))
@@ -48,7 +71,7 @@
                 return true;
             }
 
-            if (!(obj is StreamToken other))
+            if (obj is not StreamToken other)
             {
                 return false;
             }

--- a/src/UglyToad.PdfPig.Tokens/StringToken.cs
+++ b/src/UglyToad.PdfPig.Tokens/StringToken.cs
@@ -50,7 +50,7 @@ namespace UglyToad.PdfPig.Tokens
         /// </summary>
         public byte[] GetBytes()
         {
-            if (rawBytes != null)
+            if (rawBytes is not null)
             {
                 return rawBytes;
             }
@@ -83,6 +83,18 @@ namespace UglyToad.PdfPig.Tokens
                 default:
                     return OtherEncodings.StringAsLatin1Bytes(Data);
             }
+        }
+
+        /// <inheritdoc />
+        public override int GetHashCode()
+        {
+            return HashCode.Combine(EncodedWith, Data);
+        }
+
+        /// <inheritdoc />
+        public override bool Equals(object? obj)
+        {
+            return obj is IToken token && Equals(token);
         }
 
         /// <inheritdoc />

--- a/src/UglyToad.PdfPig.Tokens/UglyToad.PdfPig.Tokens.csproj
+++ b/src/UglyToad.PdfPig.Tokens/UglyToad.PdfPig.Tokens.csproj
@@ -1,23 +1,24 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;net462;net471;net6.0;net8.0;net9.0</TargetFrameworks>
-    <LangVersion>12</LangVersion>
-    <Version>0.1.16</Version>
-    <IsTestProject>False</IsTestProject>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <SignAssembly>true</SignAssembly>
-    <AssemblyOriginatorKeyFile>..\pdfpig.snk</AssemblyOriginatorKeyFile>
-  </PropertyGroup>
-  <ItemGroup Condition="'$(TargetFramework)'=='net462'">
-    <PackageReference Include="System.ValueTuple" Version="4.5.0" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)'=='netstandard2.0' or '$(TargetFramework)'=='net462' or '$(TargetFramework)'=='net471'">
-    <PackageReference Include="System.Memory" Version="4.6.0" />
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="..\pdfpig.snk" Link="pdfpig.snk" />
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\UglyToad.PdfPig.Core\UglyToad.PdfPig.Core.csproj" />
-  </ItemGroup>
+	<PropertyGroup>
+		<TargetFrameworks>netstandard2.0;netstandard2.1;net462;net471;net6.0;net8.0;net9.0</TargetFrameworks>
+		<LangVersion>12</LangVersion>
+		<Version>0.1.16</Version>
+		<IsTestProject>False</IsTestProject>
+		<GenerateDocumentationFile>true</GenerateDocumentationFile>
+		<SignAssembly>true</SignAssembly>
+		<AssemblyOriginatorKeyFile>..\pdfpig.snk</AssemblyOriginatorKeyFile>
+		<Nullable>enable</Nullable>
+	</PropertyGroup>
+	<ItemGroup Condition="'$(TargetFramework)'=='net462'">
+		<PackageReference Include="System.ValueTuple" Version="4.5.0" />
+	</ItemGroup>
+	<ItemGroup Condition="'$(TargetFramework)'=='netstandard2.0' or '$(TargetFramework)'=='net462' or '$(TargetFramework)'=='net471'">
+		<PackageReference Include="System.Memory" Version="4.6.0" />
+	</ItemGroup>
+	<ItemGroup>
+		<None Include="..\pdfpig.snk" Link="pdfpig.snk" />
+	</ItemGroup>
+	<ItemGroup>
+		<ProjectReference Include="..\UglyToad.PdfPig.Core\UglyToad.PdfPig.Core.csproj" />
+	</ItemGroup>
 </Project>

--- a/tools/UglyToad.PdfPig.Benchmarks/UglyToad.PdfPig.Benchmarks.csproj
+++ b/tools/UglyToad.PdfPig.Benchmarks/UglyToad.PdfPig.Benchmarks.csproj
@@ -23,7 +23,7 @@
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(PdfPigVersion)' == 'Latest'">
-		<PackageReference Include="PdfPig" Version="0.1.15-alpha-20260520-fee5c" />
+		<PackageReference Include="PdfPig" Version="0.1.15" />
 	</ItemGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
Properly override the `Equals(object? obj)` and `GetHashCode()` methods and add tests to check expected behaviour.

NB: (pre-existing, not changed) HexToken equality is based on its decoded Data string, which strips zero bytes, so <6100> and <61> compare equal despite different raw bytes.