### PR TITLE
Expose font dictionary indirect reference on FontDetails

### DIFF
--- a/src/UglyToad.PdfPig/Content/ResourceStore.cs
+++ b/src/UglyToad.PdfPig/Content/ResourceStore.cs
@@ -232,7 +232,12 @@
 
                     try
                     {
-                        loadedFonts[reference] = fontFactory.Get(fontObject);
+                        var loadedFont = fontFactory.Get(fontObject);
+                        // Stamp the font dictionary's indirect reference so consumers can
+                        // distinguish same-named fonts (e.g. two subsets of one typeface
+                        // embedded without unique subset prefixes). See FontDetails.FontDictionaryReference.
+                        loadedFont.Details?.SetFontDictionaryReference(reference);
+                        loadedFonts[reference] = loadedFont;
                     }
                     catch
                     {
@@ -285,6 +290,8 @@
             }
 
             var font = fontFactory.Get(fontDictionaryToken);
+
+            font.Details?.SetFontDictionaryReference(fontReferenceToken.Data);
 
             return font;
         }

--- a/src/UglyToad.PdfPig/PdfFonts/FontDetails.cs
+++ b/src/UglyToad.PdfPig/PdfFonts/FontDetails.cs
@@ -1,5 +1,7 @@
 ﻿namespace UglyToad.PdfPig.PdfFonts
 {
+    using Core;
+
     /// <summary>
     /// Summary details of the font used to draw a glyph.
     /// </summary>
@@ -35,6 +37,16 @@
         /// </summary>
         public bool IsItalic { get; }
 
+        /// <summary>
+        /// The indirect reference of the font dictionary this font was loaded from,
+        /// when it was loaded from an indirect object. Uniquely identifies the font
+        /// within its source document even when multiple font objects share the same
+        /// name (e.g. two different subsets of one typeface embedded without unique
+        /// subset prefixes). <c>null</c> for fonts defined directly inside a resource
+        /// dictionary (no indirect object) or for synthetic/fallback fonts.
+        /// </summary>
+        public IndirectReference? FontDictionaryReference { get; private set; }
+
         private readonly Lazy<FontDetails> _bold;
 
         /// <summary>
@@ -47,7 +59,14 @@
             Weight = weight;
             IsItalic = isItalic;
 
-            _bold = isBold ? new Lazy<FontDetails>(() => this) : new Lazy<FontDetails>(() => new FontDetails(Name, true, Weight, IsItalic));
+            // Evaluated lazily so a FontDictionaryReference assigned after construction
+            // still propagates to the bold variant.
+            _bold = isBold
+                ? new Lazy<FontDetails>(() => this)
+                : new Lazy<FontDetails>(() => new FontDetails(Name, true, Weight, IsItalic)
+                {
+                    FontDictionaryReference = FontDictionaryReference
+                });
         }
 
         /// <summary>
@@ -66,7 +85,29 @@
 
         internal FontDetails WithName(string? name) => name is not null
             ? new FontDetails(name, IsBold, Weight, IsItalic)
+            {
+                FontDictionaryReference = FontDictionaryReference
+            }
             : this;
+
+        /// <summary>
+        /// Record the indirect reference of the font dictionary this font was loaded from.
+        /// Called by the resource system immediately after font construction; assigning the
+        /// same value again is a no-op.
+        /// </summary>
+        internal void SetFontDictionaryReference(IndirectReference reference)
+        {
+            FontDictionaryReference = reference;
+
+            // Propagate to an already-materialized bold variant. The bold Lazy caches its
+            // value, so a variant created before this stamp would otherwise keep a stale
+            // null reference forever. (A not-yet-materialized variant picks the reference
+            // up at evaluation time via the initializer closure.)
+            if (_bold.IsValueCreated && !ReferenceEquals(_bold.Value, this))
+            {
+                _bold.Value.SetFontDictionaryReference(reference);
+            }
+        }
 
         /// <inheritdoc />
         public override string ToString()


### PR DESCRIPTION
Documents can embed multiple font objects sharing one BaseFont name (e.g. two different subsets of a typeface embedded without unique subset prefixes). Consumers resolving fonts by Letter.FontName alone cannot tell them apart, causing glyph-level rendering corruption when the subsets have complementary glyph coverage.

- FontDetails.FontDictionaryReference: the indirect reference of the font dictionary the font was loaded from (null for direct/synthetic fonts); propagated through AsBold()/WithName()
- ResourceStore stamps the reference at both font-load sites (LoadFontDictionary and GetFontDirectly)

This gives Letter.FontDetails a stable in-document font identity without changing the IFont interface or any rendering behavior.

Note: I'm using BaseStreamProcessor now, but unlike the Skia renderer which relies on PdfPig's fallback per-glyph shape drawing, my SafePDF resolves fonts using the font-definitions so I can install fonts into my rasterized and hinted Font Glyph Atlas for faster screen drawing, and into D2D as a font for smaller print spool streams. If you have a better idea of how to do the above, let me know.
