### PR TITLE
BUGFIX: Decode Indexed colour-table bytes to the base space's component ranges

### DIFF
--- a/src/UglyToad.PdfPig/Graphics/Colors/ColorSpaceDetails.cs
+++ b/src/UglyToad.PdfPig/Graphics/Colors/ColorSpaceDetails.cs
@@ -403,15 +403,7 @@
         internal override double[] Process(params double[] values)
         {
             var csBytes = UnwrapIndexedColorSpaceBytes([ClampColorIndex(values[0])]);
-
-            var scaledCsBytes = new double[csBytes.Length];
-
-            for (int i = 0; i < csBytes.Length; i++)
-            {
-                scaledCsBytes[i] = csBytes[i] / 255.0;
-            }
-
-            return BaseColorSpace.Process(scaledCsBytes);
+            return BaseColorSpace.Process(ScaleIndexedComponents(csBytes));
         }
 
         /// <inheritdoc/>
@@ -425,16 +417,43 @@
             return cache.GetOrAdd(values[0], v =>
             {
                 var csBytes = UnwrapIndexedColorSpaceBytes([ClampColorIndex(v)]);
+                return BaseColorSpace.GetColor(ScaleIndexedComponents(csBytes));
+            });
+        }
 
-                var scaledCsBytes = new double[csBytes.Length];
+        /// <summary>
+        /// Decode colour-table bytes to the base colour space's component ranges.
+        /// ISO 32000-2 (PDF 2.0) 8.6.6.3: the colour table data is interpreted as
+        /// component values in the base space, i.e. each byte decodes to
+        /// min + (byte / 255) × (max − min) of that component's range. Device and
+        /// most CIE spaces use [0, 1]; Lab uses L* ∈ [0, 100] and a*/b* from the
+        /// /Range entry — feeding Lab a [0, 1] L* renders near-black.
+        /// </summary>
+        private double[] ScaleIndexedComponents(Span<byte> csBytes)
+        {
+            var scaled = new double[csBytes.Length];
 
+            if (BaseColorSpace is LabColorSpaceDetails labBase)
+            {
                 for (int i = 0; i < csBytes.Length; i++)
                 {
-                    scaledCsBytes[i] = csBytes[i] / 255.0;
+                    double unit = csBytes[i] / 255.0;
+                    scaled[i] = (i % 3) switch
+                    {
+                        0 => unit * 100.0,                                                          // L*: [0, 100]
+                        1 => labBase.Matrix[0] + unit * (labBase.Matrix[1] - labBase.Matrix[0]),    // a*: /Range
+                        _ => labBase.Matrix[2] + unit * (labBase.Matrix[3] - labBase.Matrix[2]),    // b*: /Range
+                    };
                 }
+                return scaled;
+            }
 
-                return BaseColorSpace.GetColor(scaledCsBytes);
-            });
+            for (int i = 0; i < csBytes.Length; i++)
+            {
+                scaled[i] = csBytes[i] / 255.0;
+            }
+
+            return scaled;
         }
 
         internal Span<byte> UnwrapIndexedColorSpaceBytes(Span<byte> input)


### PR DESCRIPTION
## Problem: Indexed color decode bug..

There is an indexed color decode bug breaking the "Lab" (lower left corner) square in this indexed color test.

> NOTE: some *other* colors in this test vary slightly because Adobe is applying an ICC print color adjustment, and we are not. AFAIK these are not bugs.. just the lower left square.

(top acrobat, bottom PdfPig colorspace)
<img width="187" height="427" alt="image" src="https://github.com/user-attachments/assets/0ede3b14-2c8e-44dd-94db-716684f94d2b" />

Sample file: 
[pdfium_2_color_indexed.pdf](https://github.com/user-attachments/files/30144825/pdfium_2_color_indexed.pdf)

## Explanation of the fix...

ISO 32000-2 8.6.6.3: colour table data is interpreted as component values in the base colour space. IndexedColorSpaceDetails unconditionally scaled table bytes to [0, 1], which is only correct for spaces whose components span [0, 1]. Lab expects L* in [0, 100] and a*/b* in the /Range entry (default [-100, 100]) - an Indexed-over-Lab lookup therefore produced L* <= 1.0, rendering near-black for any table entry (e.g. white table entries render black).

Scale each component to the base space's range: Lab per-component (L* x100, a*/b* lerped over /Range); all other supported base spaces keep the [0, 1] scaling.