### PR TITLE
Expose XmpMetadata.GetXmlMemory() and add warning to GetXDocument()

### DIFF
--- a/src/UglyToad.PdfPig/Content/XmpMetadata.cs
+++ b/src/UglyToad.PdfPig/Content/XmpMetadata.cs
@@ -29,16 +29,31 @@
         }
 
         /// <summary>
+        /// Get the decoded bytes for the metadata stream as <see cref="ReadOnlyMemory{T}"/>. This can be interpreted as a sequence of plain-text bytes.
+        /// </summary>
+        /// <returns>The bytes for the metadata object with any filters removed.</returns>
+        public ReadOnlyMemory<byte> GetXmlMemory()
+        {
+            return MetadataStreamToken.Decode(filterProvider, pdfTokenScanner);
+        }
+
+        /// <summary>
         /// Get the decoded bytes for the metadata stream. This can be interpreted as a sequence of plain-text bytes.
         /// </summary>
         /// <returns>The bytes for the metadata object with any filters removed.</returns>
         public ReadOnlySpan<byte> GetXmlBytes()
         {
-            return MetadataStreamToken.Decode(filterProvider, pdfTokenScanner).Span;
+            return GetXmlMemory().Span;
         }
 
         /// <summary>
         /// Gets the metadata stream as an <see cref="XDocument"/>.
+        /// <para>
+        /// It is recommended to NOT use this method as it parses the XML document without security settings.
+        /// This method also converts the bytes into string before processing.
+        /// </para>
+        /// Instead, create your own XmlReader with the desired without settings (you can create a <see cref="System.IO.MemoryStream"/> based on <see cref="GetXmlMemory"/>),
+        /// and then load the XDocument.
         /// </summary>
         /// <returns>The <see cref="XDocument"/> for the XMP XML.</returns>
         public XDocument GetXDocument()


### PR DESCRIPTION
Fix #1372