### PR TITLE
Unseal ParsingOptions

### DIFF
--- a/src/UglyToad.PdfPig/ParsingOptions.cs
+++ b/src/UglyToad.PdfPig/ParsingOptions.cs
@@ -7,7 +7,7 @@
     /// <summary>
     /// Configures options used by the parser when reading PDF documents.
     /// </summary>
-    public sealed class ParsingOptions
+    public class ParsingOptions
     {
         /// <summary>
         /// A default <see cref="ParsingOptions"/> with <see cref="UseLenientParsing"/> set to false.


### PR DESCRIPTION
The rational is to let users create their version of  `ParsingOptions` so that it can be used in `BaseStreamProcessor<TPageContent>` implementations