### PR TITLE
Change GetColor() signature to use ReadOnlySpan<double> and avoid allocation

### DIFF
--- a/src/UglyToad.PdfPig.Core/UglyToad.PdfPig.Core.csproj
+++ b/src/UglyToad.PdfPig.Core/UglyToad.PdfPig.Core.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;netstandard2.1;net462;net471;net6.0;net8.0;net9.0</TargetFrameworks>
-    <LangVersion>12</LangVersion>
+    <LangVersion>13</LangVersion>
     <Version>0.1.16</Version>
     <IsTestProject>False</IsTestProject>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/UglyToad.PdfPig.DocumentLayoutAnalysis/UglyToad.PdfPig.DocumentLayoutAnalysis.csproj
+++ b/src/UglyToad.PdfPig.DocumentLayoutAnalysis/UglyToad.PdfPig.DocumentLayoutAnalysis.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;netstandard2.1;net462;net471;net6.0;net8.0;net9.0</TargetFrameworks>
-    <LangVersion>12</LangVersion>
+    <LangVersion>13</LangVersion>
     <Version>0.1.16</Version>
     <IsTestProject>False</IsTestProject>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/UglyToad.PdfPig.Fonts/UglyToad.PdfPig.Fonts.csproj
+++ b/src/UglyToad.PdfPig.Fonts/UglyToad.PdfPig.Fonts.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;netstandard2.1;net462;net471;net6.0;net8.0;net9.0</TargetFrameworks>
-    <LangVersion>12</LangVersion>
+    <LangVersion>13</LangVersion>
     <Version>0.1.16</Version>
     <IsTestProject>False</IsTestProject>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/UglyToad.PdfPig.Tests/Graphics/Colors/IndexedLabColorSpaceDetailsTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Graphics/Colors/IndexedLabColorSpaceDetailsTests.cs
@@ -29,7 +29,7 @@ namespace UglyToad.PdfPig.Tests.Graphics.Colors
         {
             var indexed = CreateIndexedOverLab();
 
-            var (r, g, b) = indexed.GetColor(1).ToRGBValues();
+            var (r, g, b) = indexed.GetColor([1]).ToRGBValues();
 
             // Without range decoding L* becomes 1.0 (of 100) and this renders near-black.
             Assert.True(r > 0.9 && g > 0.9 && b > 0.9, $"Expected near-white but got ({r}, {g}, {b}).");
@@ -40,7 +40,7 @@ namespace UglyToad.PdfPig.Tests.Graphics.Colors
         {
             var indexed = CreateIndexedOverLab();
 
-            var (r, g, b) = indexed.GetColor(0).ToRGBValues();
+            var (r, g, b) = indexed.GetColor([0]).ToRGBValues();
 
             Assert.True(r < 0.1 && g < 0.1 && b < 0.1, $"Expected near-black but got ({r}, {g}, {b}).");
         }
@@ -72,7 +72,7 @@ namespace UglyToad.PdfPig.Tests.Graphics.Colors
         {
             var indexed = CreateIndexedOverLab();
 
-            var (cr, cg, cb) = indexed.GetColor(1).ToRGBValues();
+            var (cr, cg, cb) = indexed.GetColor([1]).ToRGBValues();
             indexed.GetRgb([1.0], out double rr, out double rg, out double rb);
             double[] p = indexed.Process(1);
 
@@ -93,7 +93,7 @@ namespace UglyToad.PdfPig.Tests.Graphics.Colors
             var lab = new LabColorSpaceDetails(D50WhitePoint, null, [0.0, 0.0, 0.0, 0.0]);
             var indexed = new IndexedColorSpaceDetails(lab, 0, [0x80, 0x00, 0xFF]);
 
-            var (r, g, b) = indexed.GetColor(0).ToRGBValues();
+            var (r, g, b) = indexed.GetColor([0]).ToRGBValues();
 
             Assert.Equal(r, g, 12);
             Assert.Equal(g, b, 12);

--- a/src/UglyToad.PdfPig.Tests/Graphics/Colors/TintColorSpaceComponentMismatchTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Graphics/Colors/TintColorSpaceComponentMismatchTests.cs
@@ -1,0 +1,152 @@
+namespace UglyToad.PdfPig.Tests.Graphics.Colors
+{
+    using PdfPig.Functions;
+    using PdfPig.Graphics.Colors;
+    using PdfPig.Tokens;
+
+    /// <summary>
+    /// A Separation or DeviceN tint function is not obliged to produce exactly as many values as its
+    /// alternate colour space consumes. <see cref="ColorSpaceDetails.GetColor"/> and
+    /// <see cref="ColorSpaceDetails.GetRgb"/> must reconcile the mismatch the same way, so that a colour
+    /// space renders identically whether it is reached through an <c>scn</c> operator or through the
+    /// unboxed RGB path.
+    /// </summary>
+    public class TintColorSpaceComponentMismatchTests
+    {
+        /// <summary>
+        /// A type 2 (exponential interpolation) tint function over domain [0 1] with exponent 1,
+        /// i.e. f(t) = c0 + t × (c1 − c0). The number of outputs is the length of <paramref name="c0"/>.
+        /// </summary>
+        private static PdfFunction Tint(double[] c0, double[] c1)
+        {
+            static ArrayToken Numbers(double[] values)
+            {
+                var tokens = new IToken[values.Length];
+                for (int i = 0; i < values.Length; i++)
+                {
+                    tokens[i] = new NumericToken(values[i]);
+                }
+
+                return new ArrayToken(tokens);
+            }
+
+            var domain = new ArrayToken([new NumericToken(0), new NumericToken(1)]);
+            var dictionary = new DictionaryToken(new Dictionary<NameToken, IToken>
+            {
+                { NameToken.FunctionType, new NumericToken(2) }
+            });
+
+            return new PdfFunctionType2(dictionary, domain, null, Numbers(c0), Numbers(c1), 1);
+        }
+
+        private static void AssertGetColorMatchesGetRgb(ColorSpaceDetails colorSpace, double[] values)
+        {
+            var (r, g, b) = colorSpace.GetColor(values).ToRGBValues();
+            colorSpace.GetRgb(values, out double rr, out double rg, out double rb);
+
+            Assert.Equal(rr, r, 12);
+            Assert.Equal(rg, g, 12);
+            Assert.Equal(rb, b, 12);
+        }
+
+        [Fact]
+        public void Separation_TintUnderFillsAlternate_GetColorPadsInsteadOfThrowing()
+        {
+            // Two outputs over a three component alternate. GetColor used to hand DeviceRGB a
+            // two-element span and throw, while GetRgb zero-padded and rendered red.
+            var separation = new SeparationColorSpaceDetails(
+                NameToken.Create("Spot"),
+                DeviceRgbColorSpaceDetails.Instance,
+                Tint([0, 0], [1, 0]));
+
+            var (r, g, b) = separation.GetColor([1.0]).ToRGBValues();
+
+            Assert.Equal(1.0, r, 12);
+            Assert.Equal(0.0, g, 12);
+            Assert.Equal(0.0, b, 12);
+
+            AssertGetColorMatchesGetRgb(separation, [1.0]);
+        }
+
+        [Fact]
+        public void DeviceN_TintUnderFillsAlternate_GetColorPadsInsteadOfThrowing()
+        {
+            var deviceN = new DeviceNColorSpaceDetails(
+                [NameToken.Create("A"), NameToken.Create("B")],
+                DeviceRgbColorSpaceDetails.Instance,
+                Tint([0, 0], [1, 0]));
+
+            var (r, g, b) = deviceN.GetColor([1.0, 1.0]).ToRGBValues();
+
+            Assert.Equal(1.0, r, 12);
+            Assert.Equal(0.0, g, 12);
+            Assert.Equal(0.0, b, 12);
+
+            AssertGetColorMatchesGetRgb(deviceN, [1.0, 1.0]);
+        }
+
+        [Fact]
+        public void DeviceN_TintOverFillsAlternate_GetColorTrimsInsteadOfThrowing()
+        {
+            // Four outputs over a three component alternate: the surplus is dropped.
+            var deviceN = new DeviceNColorSpaceDetails(
+                [NameToken.Create("A"), NameToken.Create("B")],
+                DeviceRgbColorSpaceDetails.Instance,
+                Tint([0, 0, 0, 0], [1, 0, 0, 1]));
+
+            var (r, g, b) = deviceN.GetColor([1.0, 1.0]).ToRGBValues();
+
+            Assert.Equal(1.0, r, 12);
+            Assert.Equal(0.0, g, 12);
+            Assert.Equal(0.0, b, 12);
+
+            AssertGetColorMatchesGetRgb(deviceN, [1.0, 1.0]);
+        }
+
+        [Fact]
+        public void Separation_GetColorIsCachedPerTintValue()
+        {
+            var separation = new SeparationColorSpaceDetails(
+                NameToken.Create("Spot"),
+                DeviceRgbColorSpaceDetails.Instance,
+                Tint([0, 0, 0], [1, 0, 0]));
+
+            Assert.Same(separation.GetColor([0.25]), separation.GetColor([0.25]));
+        }
+
+        [Fact]
+        public void DeviceN_GetColorIsCachedPerComponentTuple()
+        {
+            var deviceN = new DeviceNColorSpaceDetails(
+                [NameToken.Create("A"), NameToken.Create("B")],
+                DeviceRgbColorSpaceDetails.Instance,
+                Tint([0, 0, 0], [1, 0, 0]));
+
+            // Distinct arrays with equal contents must hit the same cache entry.
+            Assert.Same(deviceN.GetColor([0.25, 0.5]), deviceN.GetColor([0.25, 0.5]));
+            Assert.NotSame(deviceN.GetColor([0.25, 0.5]), deviceN.GetColor([0.75, 0.5]));
+        }
+
+        [Fact]
+        public void ICCBased_GetColor_DoesNotClipIntoTheCallersBuffer()
+        {
+            // The caller's span may be over an array the caller keeps -- notably the Operands array held by
+            // a parsed SetStrokeColorAdvanced operation -- so range clipping must not write through it.
+            var icc = new ICCBasedColorSpaceDetails(
+                3,
+                DeviceRgbColorSpaceDetails.Instance,
+                [0.0, 0.5, 0.0, 0.5, 0.0, 0.5],
+                null);
+
+            double[] values = [1.0, 1.0, 1.0];
+
+            var (r, g, b) = icc.GetColor(values).ToRGBValues();
+
+            Assert.Equal(0.5, r, 12);
+            Assert.Equal(0.5, g, 12);
+            Assert.Equal(0.5, b, 12);
+
+            Assert.Equal(new[] { 1.0, 1.0, 1.0 }, values);
+        }
+    }
+}

--- a/src/UglyToad.PdfPig.Tests/UglyToad.PdfPig.Tests.csproj
+++ b/src/UglyToad.PdfPig.Tests/UglyToad.PdfPig.Tests.csproj
@@ -4,7 +4,7 @@
         <IsTestProject>true</IsTestProject>
         <IsPackable>false</IsPackable>
         <DebugType>full</DebugType>
-        <LangVersion>12</LangVersion>
+        <LangVersion>13</LangVersion>
         <SignAssembly>true</SignAssembly>
         <AssemblyOriginatorKeyFile>..\pdfpig.snk</AssemblyOriginatorKeyFile>
         <RuntimeFrameworkVersion Condition="'$(TargetFramework)'=='netcoreapp2.1'">2.1.30</RuntimeFrameworkVersion>

--- a/src/UglyToad.PdfPig.Tokenization/UglyToad.PdfPig.Tokenization.csproj
+++ b/src/UglyToad.PdfPig.Tokenization/UglyToad.PdfPig.Tokenization.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;netstandard2.1;net462;net471;net6.0;net8.0;net9.0</TargetFrameworks>
-    <LangVersion>12</LangVersion>
+    <LangVersion>13</LangVersion>
     <Version>0.1.16</Version>
     <IsTestProject>False</IsTestProject>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/UglyToad.PdfPig.Tokens/UglyToad.PdfPig.Tokens.csproj
+++ b/src/UglyToad.PdfPig.Tokens/UglyToad.PdfPig.Tokens.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
 		<TargetFrameworks>netstandard2.0;netstandard2.1;net462;net471;net6.0;net8.0;net9.0</TargetFrameworks>
-		<LangVersion>12</LangVersion>
+		<LangVersion>13</LangVersion>
 		<Version>0.1.16</Version>
 		<IsTestProject>False</IsTestProject>
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/UglyToad.PdfPig/Graphics/ColorSpaceContext.cs
+++ b/src/UglyToad.PdfPig/Graphics/ColorSpaceContext.cs
@@ -1,8 +1,6 @@
 ﻿namespace UglyToad.PdfPig.Graphics
 {
     using System;
-    using System.Collections.Generic;
-    using System.Linq;
     using Colors;
     using Content;
     using Tokens;
@@ -33,7 +31,7 @@
             currentStateFunc().CurrentStrokingColor = CurrentStrokingColorSpace.GetInitializeColor();
         }
 
-        public void SetStrokingColor(IReadOnlyList<double> operands, NameToken? patternName)
+        public void SetStrokingColor(ReadOnlySpan<double> operands, NameToken? patternName)
         {
             if (CurrentStrokingColorSpace is UnsupportedColorSpaceDetails)
             {
@@ -47,7 +45,7 @@
             }
             else
             {
-                currentStateFunc().CurrentStrokingColor = CurrentStrokingColorSpace.GetColor(operands.ToArray());
+                currentStateFunc().CurrentStrokingColor = CurrentStrokingColorSpace.GetColor(operands);
             }
         }
 
@@ -77,7 +75,7 @@
             currentStateFunc().CurrentNonStrokingColor = CurrentNonStrokingColorSpace.GetInitializeColor();
         }
 
-        public void SetNonStrokingColor(IReadOnlyList<double> operands, NameToken? patternName)
+        public void SetNonStrokingColor(ReadOnlySpan<double> operands, NameToken? patternName)
         {
             if (CurrentNonStrokingColorSpace is UnsupportedColorSpaceDetails)
             {
@@ -91,7 +89,7 @@
             }
             else
             {
-                currentStateFunc().CurrentNonStrokingColor = CurrentNonStrokingColorSpace.GetColor(operands.ToArray());
+                currentStateFunc().CurrentNonStrokingColor = CurrentNonStrokingColorSpace.GetColor(operands);
             }
         }
 
@@ -121,7 +119,7 @@
             var colorSpace = resourceStore.GetDeviceColorSpaceDetails(deviceColorSpace);
             var state = currentStateFunc();
 
-            IColor color = colorSpace.GetColor(values.ToArray());
+            IColor color = colorSpace.GetColor(values);
 
             if (stroking)
             {

--- a/src/UglyToad.PdfPig/Graphics/Colors/ColorSpaceDetails.cs
+++ b/src/UglyToad.PdfPig/Graphics/Colors/ColorSpaceDetails.cs
@@ -47,7 +47,7 @@
         /// <summary>
         /// Get the color.
         /// </summary>
-        public abstract IColor GetColor(params double[] values);
+        public abstract IColor GetColor(ReadOnlySpan<double> values);
 
         /// <summary>
         /// Get the color as an unboxed RGB triple. Avoids allocating an <see cref="IColor"/> and bypasses the
@@ -100,28 +100,61 @@
             var rounded = Math.Round(componentValue * 255, MidpointRounding.AwayFromZero);
             return (byte)rounded;
         }
+    }
+
+    /// <summary>
+    /// <see cref="ColorSpaceDetails"/> that have a tint function: <see cref="SeparationColorSpaceDetails"/> and <see cref="DeviceNColorSpaceDetails"/>.
+    /// </summary>
+    internal static class TintColorSpaceDetailsHelper
+    {
+        /// <summary>
+        /// Evaluate <paramref name="tintInput"/> through a tint <paramref name="tint"/> function and write exactly
+        /// <paramref name="alternate"/>'s <see cref="NumberOfColorComponents"/> output values into
+        /// <paramref name="buffer"/>, which must be at least <see cref="TintBufferSize"/> long.
+        /// </summary>
+        /// <returns>The slice of <paramref name="buffer"/> holding the alternate space's component values.</returns>
+        private static ReadOnlySpan<double> EvalTint(PdfFunction tint, ColorSpaceDetails alternate,
+            ReadOnlySpan<double> tintInput, Span<double> buffer)
+        {
+            int alternateComponents = alternate.NumberOfColorComponents;
+            int written = tint.Eval(tintInput, buffer);
+
+            if (written < alternateComponents)
+            {
+                // A buggy tint function under-filled the buffer. Zero the trailing slots so the alternate
+                // space doesn't read uninitialised stack memory. A tint function that over-fills is trimmed
+                // by the slice below, so the alternate space always sees the component count it expects.
+                buffer.Slice(written, alternateComponents - written).Clear();
+            }
+
+            return buffer.Slice(0, alternateComponents);
+        }
 
         /// <summary>
         /// Evaluate <paramref name="tintInput"/> through a tint <paramref name="tint"/> function whose output values
         /// are then mapped to RGB by <paramref name="alternate"/>'s <see cref="GetRgb"/>. Allocation-free for the
-        /// typical case where the alternate colour space has at most 8 components.
+        /// typical case where the alternate colour space has at most <see cref="MaxStackallocComponents"/> components.
         /// </summary>
-        private protected static void GetRgbViaTint(PdfFunction tint, ColorSpaceDetails alternate,
+        public static void GetRgbViaTint(PdfFunction tint, ColorSpaceDetails alternate,
             ReadOnlySpan<double> tintInput, out double r, out double g, out double b)
         {
-            int alternateComponents = alternate.NumberOfColorComponents;
-            int tintMax = tint.MaxOutputComponentCount;
-            int max = tintMax > alternateComponents ? tintMax : alternateComponents;
-            Span<double> buffer = max <= 16 ? stackalloc double[max] : new double[max];
-            int written = tint.Eval(tintInput, buffer);
-            if (written < alternateComponents)
-            {
-                // A buggy tint function under-filled the buffer. Zero the trailing slots so the alternate
-                // space's GetRgb call doesn't read uninitialised stack memory.
-                buffer.Slice(written, alternateComponents - written).Clear();
-                written = alternateComponents;
-            }
-            alternate.GetRgb(buffer.Slice(0, written), out r, out g, out b);
+            int max = Math.Max(tint.MaxOutputComponentCount, alternate.NumberOfColorComponents);
+            Span<double> buffer = max <= 32 ? stackalloc double[max] : new double[max];
+            alternate.GetRgb(EvalTint(tint, alternate, tintInput, buffer), out r, out g, out b);
+        }
+
+        /// <summary>
+        /// Evaluate <paramref name="tintInput"/> through a tint <paramref name="tint"/> function whose output values
+        /// are then mapped to a colour by <paramref name="alternate"/>'s <see cref="GetColor"/>. The
+        /// <see cref="GetRgb"/> equivalent is <see cref="GetRgbViaTint"/>; the two must stay in step so that a
+        /// colour space renders the same whichever path it is reached through.
+        /// </summary>
+        public static IColor GetColorViaTint(PdfFunction tint, ColorSpaceDetails alternate,
+            ReadOnlySpan<double> tintInput)
+        {
+            int max = Math.Max(tint.MaxOutputComponentCount, alternate.NumberOfColorComponents);
+            Span<double> buffer = max <= 32 ? stackalloc double[max] : new double[max];
+            return alternate.GetColor(EvalTint(tint, alternate, tintInput, buffer));
         }
     }
 
@@ -152,11 +185,11 @@
         }
 
         /// <inheritdoc/>
-        public override IColor GetColor(params double[] values)
+        public override IColor GetColor(ReadOnlySpan<double> values)
         {
-            if (values is null || values.Length != NumberOfColorComponents)
+            if (values.Length != NumberOfColorComponents)
             {
-                throw new ArgumentException($"Invalid number of inputs, expecting {NumberOfColorComponents} but got {values?.Length ?? 0}", nameof(values));
+                throw new ArgumentException($"Invalid number of inputs, expecting {NumberOfColorComponents} but got {values.Length}", nameof(values));
             }
 
             double gray = values[0];
@@ -222,11 +255,11 @@
         }
 
         /// <inheritdoc/>
-        public override IColor GetColor(params double[] values)
+        public override IColor GetColor(ReadOnlySpan<double> values)
         {
-            if (values is null || values.Length != NumberOfColorComponents)
+            if (values.Length != NumberOfColorComponents)
             {
-                throw new ArgumentException($"Invalid number of inputs, expecting {NumberOfColorComponents} but got {values?.Length ?? 0}", nameof(values));
+                throw new ArgumentException($"Invalid number of inputs, expecting {NumberOfColorComponents} but got {values.Length}", nameof(values));
             }
 
             double r = values[0];
@@ -293,11 +326,11 @@
         }
 
         /// <inheritdoc/>
-        public override IColor GetColor(params double[] values)
+        public override IColor GetColor(ReadOnlySpan<double> values)
         {
-            if (values is null || values.Length != NumberOfColorComponents)
+            if (values.Length != NumberOfColorComponents)
             {
-                throw new ArgumentException($"Invalid number of inputs, expecting {NumberOfColorComponents} but got {values?.Length ?? 0}", nameof(values));
+                throw new ArgumentException($"Invalid number of inputs, expecting {NumberOfColorComponents} but got {values.Length}", nameof(values));
             }
 
             double c = values[0];
@@ -437,11 +470,11 @@
         }
 
         /// <inheritdoc/>
-        public override IColor GetColor(params double[] values)
+        public override IColor GetColor(ReadOnlySpan<double> values)
         {
-            if (values is null || values.Length != NumberOfColorComponents)
+            if (values.Length != NumberOfColorComponents)
             {
-                throw new ArgumentException($"Invalid number of inputs, expecting {NumberOfColorComponents} but got {values?.Length ?? 0}", nameof(values));
+                throw new ArgumentException($"Invalid number of inputs, expecting {NumberOfColorComponents} but got {values.Length}", nameof(values));
             }
 
             return cache.GetOrAdd(values[0], v =>
@@ -562,7 +595,7 @@
         {
             // Setting the current stroking or nonstroking colour space to an Indexed colour space shall
             // initialize the corresponding current colour to 0.
-            return GetColor(0);
+            return GetColor([0]);
         }
 
         /// <inheritdoc/>
@@ -598,6 +631,10 @@
     public sealed class DeviceNColorSpaceDetails : ColorSpaceDetails
     {
         private readonly ConcurrentDictionary<double[], IColor> cache = new(DoubleArrayEqualityComparer.Instance);
+
+#if NET9_0_OR_GREATER
+        private readonly ConcurrentDictionary<double[], IColor>.AlternateLookup<ReadOnlySpan<double>> lookup;
+#endif
 
         /// <summary>
         /// <inheritdoc/>
@@ -657,6 +694,10 @@
             Attributes = attributes;
             TintFunction = tintFunction;
             BaseType = AlternateColorSpace.Type;
+
+#if NET9_0_OR_GREATER
+            lookup = cache.GetAlternateLookup<ReadOnlySpan<double>>();
+#endif
         }
 
         /// <inheritdoc/>
@@ -667,26 +708,36 @@
         }
 
         /// <inheritdoc/>
-        public override IColor GetColor(params double[] values)
+        public override IColor GetColor(ReadOnlySpan<double> values)
         {
-            if (values is null || values.Length != NumberOfColorComponents)
+            if (values.Length != NumberOfColorComponents)
             {
-                throw new ArgumentException($"Invalid number of inputs, expecting {NumberOfColorComponents} but got {values?.Length ?? 0}", nameof(values));
+                throw new ArgumentException($"Invalid number of inputs, expecting {NumberOfColorComponents} but got {values.Length}", nameof(values));
             }
 
             // TODO - use attributes
 
-            if (cache.TryGetValue(values, out var color))
+#if NET9_0_OR_GREATER
+            if (lookup.TryGetValue(values, out var color))
             {
                 return color;
             }
 
-            var evaled = TintFunction.Eval(values);
-            color = AlternateColorSpace.GetColor(evaled);
+            color = TintColorSpaceDetailsHelper.GetColorViaTint(TintFunction, AlternateColorSpace, values);
 
-            // The caller owns the values array and may mutate it after this call, so key on a copy.
-            cache.TryAdd(values.ToArray(), color);
+            lookup.TryAdd(values, color);
+#else
+            double[] key = values.ToArray();
 
+            if (cache.TryGetValue(key, out var color))
+            {
+                return color;
+            }
+
+            color = TintColorSpaceDetailsHelper.GetColorViaTint(TintFunction, AlternateColorSpace, values);
+
+            cache.TryAdd(key, color);
+#endif
             return color;
         }
 
@@ -730,16 +781,21 @@
             // When this space is set to the current colour space (using the CS or cs operators), each component
             // shall be given an initial value of 1.0. The SCN and scn operators respectively shall set the current
             // stroking and nonstroking colour.
-            return GetColor(Enumerable.Repeat(1.0, NumberOfColorComponents).ToArray());
+            Span<double> buffer = NumberOfColorComponents <= 32 ? stackalloc double[NumberOfColorComponents] : new double[NumberOfColorComponents];
+            buffer.Fill(1.0);
+            return GetColor(buffer);
         }
 
         /// <inheritdoc/>
         public override void GetRgb(ReadOnlySpan<double> values, out double r, out double g, out double b)
         {
-            GetRgbViaTint(TintFunction, AlternateColorSpace, values, out r, out g, out b);
+            TintColorSpaceDetailsHelper.GetRgbViaTint(TintFunction, AlternateColorSpace, values, out r, out g, out b);
         }
 
         private sealed class DoubleArrayEqualityComparer : IEqualityComparer<double[]>
+#if NET9_0_OR_GREATER
+        , IAlternateEqualityComparer<ReadOnlySpan<double>, double[]>
+#endif
         {
             public static readonly DoubleArrayEqualityComparer Instance = new DoubleArrayEqualityComparer();
 
@@ -768,6 +824,29 @@
 
                 return hash.ToHashCode();
             }
+            
+#if NET9_0_OR_GREATER
+            public bool Equals(ReadOnlySpan<double> alternate, double[] other)
+            {
+                return alternate.SequenceEqual(other);
+            }
+
+            public int GetHashCode(ReadOnlySpan<double> alternate)
+            {
+                var hash = new HashCode();
+                foreach (var value in alternate)
+                {
+                    hash.Add(value);
+                }
+
+                return hash.ToHashCode();
+            }
+
+            public double[] Create(ReadOnlySpan<double> alternate)
+            {
+                return alternate.ToArray();
+            }
+#endif
         }
 
         /// <summary>
@@ -888,20 +967,16 @@
         }
 
         /// <inheritdoc/>
-        public override IColor GetColor(params double[] values)
+        public override IColor GetColor(ReadOnlySpan<double> values)
         {
-            if (values is null || values.Length != NumberOfColorComponents)
+            if (values.Length != NumberOfColorComponents)
             {
-                throw new ArgumentException($"Invalid number of inputs, expecting {NumberOfColorComponents} but got {values?.Length ?? 0}", nameof(values));
+                throw new ArgumentException($"Invalid number of inputs, expecting {NumberOfColorComponents} but got {values.Length}", nameof(values));
             }
 
             // TODO - we ignore the name for now
 
-            return cache.GetOrAdd(values[0], v =>
-            {
-                var evaled = TintFunction.Eval(v);
-                return AlternateColorSpace.GetColor(evaled);
-            });
+            return cache.GetOrAdd(values[0], v => TintColorSpaceDetailsHelper.GetColorViaTint(TintFunction, AlternateColorSpace, [v]));
         }
 
         /// <inheritdoc/>
@@ -933,13 +1008,13 @@
         public override IColor GetInitializeColor()
         {
             // The initial value for both the stroking and nonstroking colour in the graphics state shall be 1.0.
-            return GetColor(1.0);
+            return GetColor([1.0]);
         }
 
         /// <inheritdoc/>
         public override void GetRgb(ReadOnlySpan<double> values, out double r, out double g, out double b)
         {
-            GetRgbViaTint(TintFunction, AlternateColorSpace, values.Slice(0, 1), out r, out g, out b);
+            TintColorSpaceDetailsHelper.GetRgbViaTint(TintFunction, AlternateColorSpace, values.Slice(0, 1), out r, out g, out b);
         }
     }
 
@@ -1037,11 +1112,11 @@
         }
 
         /// <inheritdoc/>
-        public override IColor GetColor(params double[] values)
+        public override IColor GetColor(ReadOnlySpan<double> values)
         {
-            if (values is null || values.Length != NumberOfColorComponents)
+            if (values.Length != NumberOfColorComponents)
             {
-                throw new ArgumentException($"Invalid number of inputs, expecting {NumberOfColorComponents} but got {values?.Length ?? 0}", nameof(values));
+                throw new ArgumentException($"Invalid number of inputs, expecting {NumberOfColorComponents} but got {values.Length}", nameof(values));
             }
 
             GetRgb(values, out double r, out double g, out double b);
@@ -1055,7 +1130,7 @@
             // initialize all components of the corresponding current colour to 0.0 (unless the range of valid
             // values for a given component does not include 0.0, in which case the nearest valid value shall
             // be substituted.)
-            return GetColor(0);
+            return GetColor([0]);
         }
 
         /// <inheritdoc/>
@@ -1181,11 +1256,11 @@
         }
 
         /// <inheritdoc/>
-        public override IColor GetColor(params double[] values)
+        public override IColor GetColor(ReadOnlySpan<double> values)
         {
-            if (values is null || values.Length != NumberOfColorComponents)
+            if (values.Length != NumberOfColorComponents)
             {
-                throw new ArgumentException($"Invalid number of inputs, expecting {NumberOfColorComponents} but got {values?.Length ?? 0}", nameof(values));
+                throw new ArgumentException($"Invalid number of inputs, expecting {NumberOfColorComponents} but got {values.Length}", nameof(values));
             }
 
             GetRgb(values, out double r, out double g, out double b);
@@ -1340,11 +1415,11 @@
         }
 
         /// <inheritdoc/>
-        public override IColor GetColor(params double[] values)
+        public override IColor GetColor(ReadOnlySpan<double> values)
         {
-            if (values is null || values.Length != NumberOfColorComponents)
+            if (values.Length != NumberOfColorComponents)
             {
-                throw new ArgumentException($"Invalid number of inputs, expecting {NumberOfColorComponents} but got {values?.Length ?? 0}", nameof(values));
+                throw new ArgumentException($"Invalid number of inputs, expecting {NumberOfColorComponents} but got {values.Length}", nameof(values));
             }
 
             GetRgb(values, out double r, out double g, out double b);
@@ -1472,22 +1547,23 @@
         }
 
         /// <inheritdoc/>
-        public override IColor GetColor(params double[] values)
+        public override IColor GetColor(ReadOnlySpan<double> values)
         {
-            if (values is null || values.Length != NumberOfColorComponents)
+            if (values.Length != NumberOfColorComponents)
             {
-                throw new ArgumentException($"Invalid number of inputs, expecting {NumberOfColorComponents} but got {values?.Length ?? 0}", nameof(values));
+                throw new ArgumentException($"Invalid number of inputs, expecting {NumberOfColorComponents} but got {values.Length}", nameof(values));
             }
 
             // TODO - use ICC profile
 
+            Span<double> buffer = stackalloc double[values.Length]; // 1, 3 or 4
             for (int c = 0; c < values.Length; c++)
             {
                 int i = 2 * c;
-                values[c] = PdfFunction.ClipToRange(values[c], Range[i], Range[i + 1]);
+                buffer[c] = PdfFunction.ClipToRange(values[c], Range[i], Range[i + 1]);
             }
 
-            return AlternateColorSpace.GetColor(values);
+            return AlternateColorSpace.GetColor(buffer);
         }
 
         /// <inheritdoc/>
@@ -1498,35 +1574,23 @@
             // values for a given component does not include 0.0, in which case the nearest valid value shall
             // be substituted.)
             double v = PdfFunction.ClipToRange(0.0, Range[0], Range[1]);
-            double[] init = Enumerable.Repeat(v, NumberOfColorComponents).ToArray();
-            return GetColor(init);
+            Span<double> buffer = stackalloc double[NumberOfColorComponents]; // 1, 3 or 4
+            buffer.Fill(v);
+            return GetColor(buffer);
         }
 
         /// <inheritdoc/>
         public override void GetRgb(ReadOnlySpan<double> values, out double r, out double g, out double b)
         {
             // TODO - use ICC profile
-            int n = NumberOfColorComponents;
-            if (n <= 4)
+ 
+            Span<double> clipped = stackalloc double[NumberOfColorComponents]; // 1, 3 or 4
+            for (int c = 0; c < NumberOfColorComponents; c++)
             {
-                Span<double> clipped = stackalloc double[4];
-                for (int c = 0; c < n; c++)
-                {
-                    int i = 2 * c;
-                    clipped[c] = PdfFunction.ClipToRange(values[c], Range[i], Range[i + 1]);
-                }
-                AlternateColorSpace.GetRgb(clipped.Slice(0, n), out r, out g, out b);
+                int i = 2 * c;
+                clipped[c] = PdfFunction.ClipToRange(values[c], Range[i], Range[i + 1]);
             }
-            else
-            {
-                double[] clipped = new double[n];
-                for (int c = 0; c < n; c++)
-                {
-                    int i = 2 * c;
-                    clipped[c] = PdfFunction.ClipToRange(values[c], Range[i], Range[i + 1]);
-                }
-                AlternateColorSpace.GetRgb(clipped, out r, out g, out b);
-            }
+            AlternateColorSpace.GetRgb(clipped, out r, out g, out b);
         }
 
         /// <inheritdoc/>
@@ -1608,7 +1672,7 @@
         /// Use <see cref="GetColor(NameToken)"/> instead.
         /// </para>
         /// </summary>
-        public override IColor GetColor(params double[] values)
+        public override IColor GetColor(ReadOnlySpan<double> values)
         {
             throw new InvalidOperationException("PatternColorSpaceDetails");
         }
@@ -1677,7 +1741,7 @@
         }
 
         /// <inheritdoc/>
-        public override IColor GetColor(params double[] values)
+        public override IColor GetColor(ReadOnlySpan<double> values)
         {
             throw new InvalidOperationException("UnsupportedColorSpaceDetails");
         }

--- a/src/UglyToad.PdfPig/Graphics/IColorSpaceContext.cs
+++ b/src/UglyToad.PdfPig/Graphics/IColorSpaceContext.cs
@@ -1,6 +1,5 @@
 ﻿namespace UglyToad.PdfPig.Graphics
 {
-    using System.Collections.Generic;
     using Colors;
     using Tokens;
     using UglyToad.PdfPig.Core;
@@ -37,7 +36,7 @@
         /// <summary>
         /// Set the color to use for stroking operations using the current color space.
         /// </summary>
-        void SetStrokingColor(IReadOnlyList<double> operands, NameToken? patternName = null);
+        void SetStrokingColor(ReadOnlySpan<double> operands, NameToken? patternName = null);
 
         /// <summary>
         /// Set the stroking color space to DeviceGray and set the gray level to use for stroking operations.
@@ -65,7 +64,7 @@
         /// <summary>
         /// Set the color to use for nonstroking operations using the current color space.
         /// </summary>
-        void SetNonStrokingColor(IReadOnlyList<double> operands, NameToken? patternName = null);
+        void SetNonStrokingColor(ReadOnlySpan<double> operands, NameToken? patternName = null);
 
         /// <summary>
         /// Set the nonstroking color space to DeviceGray and set the gray level to use for nonstroking operations.

--- a/src/UglyToad.PdfPig/Graphics/Operations/SetNonStrokeColor.cs
+++ b/src/UglyToad.PdfPig/Graphics/Operations/SetNonStrokeColor.cs
@@ -1,18 +1,19 @@
 ﻿namespace UglyToad.PdfPig.Graphics.Operations
 {
-    using System.Collections.Generic;
     using System.IO;
     using System.Linq;
 
     /// <summary>
     /// Set the nonstroking color based on the current color space.
     /// </summary>
-    public class SetNonStrokeColor : IGraphicsStateOperation
+    public sealed class SetNonStrokeColor : IGraphicsStateOperation
     {
         /// <summary>
         /// The symbol for this operation in a stream.
         /// </summary>
         public const string Symbol = "sc";
+
+        private readonly double[] operands;
 
         /// <inheritdoc />
         public string Operator => Symbol;
@@ -20,7 +21,7 @@
         /// <summary>
         /// The values for the color, 1 for grayscale, 3 for RGB, 4 for CMYK.
         /// </summary>
-        public IReadOnlyList<double> Operands { get; }
+        public ReadOnlySpan<double> Operands => operands;
 
         /// <summary>
         /// Create a new <see cref="SetNonStrokeColor"/>.
@@ -28,7 +29,7 @@
         /// <param name="operands">The color operands.</param>
         public SetNonStrokeColor(double[] operands)
         {
-            Operands = operands;
+            this.operands = operands;
         }
 
         /// <inheritdoc />
@@ -53,7 +54,7 @@
         /// <inheritdoc />
         public override string ToString()
         {
-            var arguments = string.Join(" ", Operands.Select(x => x.ToString("N")));
+            var arguments = string.Join(" ", operands.Select(x => x.ToString("N")));
             return $"{arguments} {Symbol}";
         }
     }

--- a/src/UglyToad.PdfPig/Graphics/Operations/SetNonStrokeColorAdvanced.cs
+++ b/src/UglyToad.PdfPig/Graphics/Operations/SetNonStrokeColorAdvanced.cs
@@ -1,6 +1,5 @@
 ﻿namespace UglyToad.PdfPig.Graphics.Operations
 {
-    using System.Collections.Generic;
     using System.IO;
     using System.Linq;
     using Tokens;
@@ -9,7 +8,7 @@
     /// <summary>
     /// Set the stroking color based on the current color space with support for Pattern, Separation, DeviceN, and ICCBased color spaces.
     /// </summary>
-    public class SetNonStrokeColorAdvanced : IGraphicsStateOperation
+    public sealed class SetNonStrokeColorAdvanced : IGraphicsStateOperation
     {
         private static readonly TokenWriter TokenWriter = new TokenWriter();
 
@@ -18,13 +17,15 @@
         /// </summary>
         public const string Symbol = "scn";
 
+        private readonly double[] operands;
+
         /// <inheritdoc />
         public string Operator => Symbol;
 
         /// <summary>
         /// The values for the color.
         /// </summary>
-        public IReadOnlyList<double> Operands { get; }
+        public ReadOnlySpan<double> Operands => operands;
 
         /// <summary>
         /// The name of an entry in the Pattern subdictionary of the current resource dictionary.
@@ -35,9 +36,9 @@
         /// Create a new <see cref="SetNonStrokeColorAdvanced"/>.
         /// </summary>
         /// <param name="operands">The color operands.</param>
-        public SetNonStrokeColorAdvanced(IReadOnlyList<double> operands)
+        public SetNonStrokeColorAdvanced(double[] operands)
         {
-            Operands = operands;
+            this.operands = operands;
         }
 
         /// <summary>
@@ -45,9 +46,9 @@
         /// </summary>
         /// <param name="operands">The color operands.</param>
         /// <param name="patternName">The pattern name.</param>
-        public SetNonStrokeColorAdvanced(IReadOnlyList<double> operands, NameToken patternName)
+        public SetNonStrokeColorAdvanced(double[] operands, NameToken patternName)
+            : this(operands)
         {
-            Operands = operands;
             PatternName = patternName;
         }
 
@@ -66,7 +67,7 @@
                 stream.WriteWhiteSpace();
             }
 
-            if (PatternName != null)
+            if (PatternName is not null)
             {
                 TokenWriter.WriteToken(PatternName, stream);
             }
@@ -78,9 +79,9 @@
         /// <inheritdoc />
         public override string ToString()
         {
-            var arguments = string.Join(" ", Operands.Select(x => x.ToString("N")));
+            var arguments = string.Join(" ", operands.Select(x => x.ToString("N")));
 
-            if (PatternName != null)
+            if (PatternName is not null)
             {
                 arguments += $" {PatternName}";
             }

--- a/src/UglyToad.PdfPig/Graphics/Operations/SetStrokeColor.cs
+++ b/src/UglyToad.PdfPig/Graphics/Operations/SetStrokeColor.cs
@@ -1,18 +1,19 @@
 ﻿namespace UglyToad.PdfPig.Graphics.Operations
 {
-    using System.Collections.Generic;
     using System.IO;
     using System.Linq;
 
     /// <summary>
     /// Set the stroking color based on the current color space.
     /// </summary>
-    public class SetStrokeColor : IGraphicsStateOperation
+    public sealed class SetStrokeColor : IGraphicsStateOperation
     {
         /// <summary>
         /// The symbol for this operation in a stream.
         /// </summary>
         public const string Symbol = "SC";
+
+        private readonly double[] operands;
 
         /// <inheritdoc />
         public string Operator => Symbol;
@@ -20,7 +21,7 @@
         /// <summary>
         /// The values for the color, 1 for grayscale, 3 for RGB, 4 for CMYK.
         /// </summary>
-        public IReadOnlyList<double> Operands { get; }
+        public ReadOnlySpan<double> Operands => operands;
 
         /// <summary>
         /// Create a new <see cref="SetStrokeColor"/>.
@@ -28,7 +29,7 @@
         /// <param name="operands">The color operands.</param>
         public SetStrokeColor(double[] operands)
         {
-            Operands = operands;
+            this.operands = operands;
         }
 
         /// <inheritdoc />
@@ -53,7 +54,7 @@
         /// <inheritdoc />
         public override string ToString()
         {
-            var arguments = string.Join(" ", Operands.Select(x => x.ToString("N")));
+            var arguments = string.Join(" ", operands.Select(x => x.ToString("N")));
             return $"{arguments} {Symbol}";
         }
     }

--- a/src/UglyToad.PdfPig/Graphics/Operations/SetStrokeColorAdvanced.cs
+++ b/src/UglyToad.PdfPig/Graphics/Operations/SetStrokeColorAdvanced.cs
@@ -1,6 +1,5 @@
 ﻿namespace UglyToad.PdfPig.Graphics.Operations
 {
-    using System.Collections.Generic;
     using System.IO;
     using System.Linq;
     using Tokens;
@@ -9,7 +8,7 @@
     /// <summary>
     /// Set the stroking color based on the current color space with support for Pattern, Separation, DeviceN, and ICCBased color spaces.
     /// </summary>
-    public class SetStrokeColorAdvanced : IGraphicsStateOperation
+    public sealed class SetStrokeColorAdvanced : IGraphicsStateOperation
     {
         private static readonly TokenWriter TokenWriter = new TokenWriter();
 
@@ -18,13 +17,15 @@
         /// </summary>
         public const string Symbol = "SCN";
 
+        private readonly double[] operands;
+
         /// <inheritdoc />
         public string Operator => Symbol;
 
         /// <summary>
         /// The values for the color.
         /// </summary>
-        public IReadOnlyList<double> Operands { get; }
+        public ReadOnlySpan<double> Operands => operands;
 
         /// <summary>
         /// The name of an entry in the Pattern subdictionary of the current resource dictionary.
@@ -35,9 +36,9 @@
         /// Create a new <see cref="SetStrokeColor"/>.
         /// </summary>
         /// <param name="operands">The color operands.</param>
-        public SetStrokeColorAdvanced(IReadOnlyList<double> operands)
+        public SetStrokeColorAdvanced(double[] operands)
         {
-            Operands = operands;
+            this.operands = operands;
         }
 
         /// <summary>
@@ -45,9 +46,9 @@
         /// </summary>
         /// <param name="operands">The color operands.</param>
         /// <param name="patternName">The pattern name.</param>
-        public SetStrokeColorAdvanced(IReadOnlyList<double> operands, NameToken patternName)
+        public SetStrokeColorAdvanced(double[] operands, NameToken patternName)
+            : this(operands)
         {
-            Operands = operands;
             PatternName = patternName;
         }
 
@@ -66,7 +67,7 @@
                 stream.WriteWhiteSpace();
             }
 
-            if (PatternName != null)
+            if (PatternName is not null)
             {
                 TokenWriter.WriteToken(PatternName, stream);
             }
@@ -78,9 +79,9 @@
         /// <inheritdoc />
         public override string ToString()
         {
-            var arguments = string.Join(" ", Operands.Select(x => x.ToString("N")));
+            var arguments = string.Join(" ", operands.Select(x => x.ToString("N")));
 
-            if (PatternName != null)
+            if (PatternName is not null)
             {
                 arguments += $" {PatternName}";
             }

--- a/src/UglyToad.PdfPig/Graphics/ReflectionGraphicsStateOperationFactory.cs
+++ b/src/UglyToad.PdfPig/Graphics/ReflectionGraphicsStateOperationFactory.cs
@@ -404,11 +404,12 @@ namespace UglyToad.PdfPig.Graphics
                 case SetStrokeColorAdvanced.Symbol:
                     if (operands[operands.Count - 1] is NameToken scnPatternName)
                     {
-                        return new SetStrokeColorAdvanced(operands.Take(operands.Count - 1).Select(x => ((NumericToken)x).Data).ToList(), scnPatternName);
+                        return new SetStrokeColorAdvanced(operands.Take(operands.Count - 1).Select(x => ((NumericToken)x).Data).ToArray(), scnPatternName);
                     }
-                    else if (operands.All(x => x is NumericToken))
+                    
+                    if (operands.All(x => x is NumericToken))
                     {
-                        return new SetStrokeColorAdvanced(operands.Select(x => ((NumericToken)x).Data).ToList());
+                        return new SetStrokeColorAdvanced(operands.Select(x => ((NumericToken)x).Data).ToArray());
                     }
 
                     var errorMessageScn = string.Join(", ", operands.Select(x => x.ToString()));

--- a/src/UglyToad.PdfPig/UglyToad.PdfPig.csproj
+++ b/src/UglyToad.PdfPig/UglyToad.PdfPig.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;netstandard2.1;net462;net471;net6.0;net8.0;net9.0</TargetFrameworks>
-    <LangVersion>12</LangVersion>
+    <LangVersion>13</LangVersion>
     <Version>0.1.16</Version>
     <IsTestProject>False</IsTestProject>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>


### PR DESCRIPTION
- Converts the color APIs from `params double[]` / `IReadOnlyList<double>` to `ReadOnlySpan<double>`. This is in order to avoid allocation when possible.
- `Set[Non]StrokeColor` and `Set[Non]StrokeColorAdvanced` operations are updated to use `ReadOnlySpan<double>` instead of `IReadOnlyList<double>` -> we preserve the read only aspect.
- `LangVersion` was bumped from 12 to 13 in order to allow usage of `AlternateLookup<ReadOnlySpan<double>>`
- Fix inconsistency in `DeviceN` and `Separation` color spaces: `GetColor` and `GetRgb` disagreed on tint component mismatch

This PR introduces breaking changes:

### Calling `GetColor` with loose arguments

```csharp
// Before
colorSpace.GetColor(1.0, 0.0, 0.0);

// After: wrap in a collection expression
colorSpace.GetColor([1.0, 0.0, 0.0]);
```

### Implementing `IColorSpaceContext`

```csharp
// Before
void SetStrokingColor(IReadOnlyList<double> operands, NameToken? patternName = null);
void SetNonStrokingColor(IReadOnlyList<double> operands, NameToken? patternName = null);

// After
void SetStrokingColor(ReadOnlySpan<double> operands, NameToken? patternName = null);
void SetNonStrokingColor(ReadOnlySpan<double> operands, NameToken? patternName = null);
```

**NB: Given the length of the `ColorSpaceDetails.cs` file, it becomes necessary to split it and put each color space in its own file**