### PR TITLE
Prefer double array over span in IColorSpaceContext so that operands can be saved without allocation

### DIFF
--- a/src/UglyToad.PdfPig/Graphics/ColorSpaceContext.cs
+++ b/src/UglyToad.PdfPig/Graphics/ColorSpaceContext.cs
@@ -31,7 +31,7 @@
             currentStateFunc().CurrentStrokingColor = CurrentStrokingColorSpace.GetInitializeColor();
         }
 
-        public void SetStrokingColor(ReadOnlySpan<double> operands, NameToken? patternName)
+        public void SetStrokingColor(double[] operands, NameToken? patternName)
         {
             if (CurrentStrokingColorSpace is UnsupportedColorSpaceDetails)
             {
@@ -75,7 +75,7 @@
             currentStateFunc().CurrentNonStrokingColor = CurrentNonStrokingColorSpace.GetInitializeColor();
         }
 
-        public void SetNonStrokingColor(ReadOnlySpan<double> operands, NameToken? patternName)
+        public void SetNonStrokingColor(double[] operands, NameToken? patternName)
         {
             if (CurrentNonStrokingColorSpace is UnsupportedColorSpaceDetails)
             {

--- a/src/UglyToad.PdfPig/Graphics/IColorSpaceContext.cs
+++ b/src/UglyToad.PdfPig/Graphics/IColorSpaceContext.cs
@@ -36,7 +36,7 @@
         /// <summary>
         /// Set the color to use for stroking operations using the current color space.
         /// </summary>
-        void SetStrokingColor(ReadOnlySpan<double> operands, NameToken? patternName = null);
+        void SetStrokingColor(double[] operands, NameToken? patternName = null);
 
         /// <summary>
         /// Set the stroking color space to DeviceGray and set the gray level to use for stroking operations.
@@ -64,7 +64,7 @@
         /// <summary>
         /// Set the color to use for nonstroking operations using the current color space.
         /// </summary>
-        void SetNonStrokingColor(ReadOnlySpan<double> operands, NameToken? patternName = null);
+        void SetNonStrokingColor(double[] operands, NameToken? patternName = null);
 
         /// <summary>
         /// Set the nonstroking color space to DeviceGray and set the gray level to use for nonstroking operations.

--- a/src/UglyToad.PdfPig/Graphics/Operations/SetNonStrokeColor.cs
+++ b/src/UglyToad.PdfPig/Graphics/Operations/SetNonStrokeColor.cs
@@ -35,7 +35,7 @@
         /// <inheritdoc />
         public void Run(IOperationContext operationContext)
         {
-            operationContext.GetCurrentState().ColorSpaceContext.SetNonStrokingColor(Operands);
+            operationContext.GetCurrentState().ColorSpaceContext.SetNonStrokingColor(operands);
         }
 
         /// <inheritdoc />

--- a/src/UglyToad.PdfPig/Graphics/Operations/SetNonStrokeColorAdvanced.cs
+++ b/src/UglyToad.PdfPig/Graphics/Operations/SetNonStrokeColorAdvanced.cs
@@ -55,7 +55,7 @@
         /// <inheritdoc />
         public void Run(IOperationContext operationContext)
         {
-            operationContext.GetCurrentState().ColorSpaceContext.SetNonStrokingColor(Operands, PatternName);
+            operationContext.GetCurrentState().ColorSpaceContext.SetNonStrokingColor(operands, PatternName);
         }
 
         /// <inheritdoc />

--- a/src/UglyToad.PdfPig/Graphics/Operations/SetStrokeColor.cs
+++ b/src/UglyToad.PdfPig/Graphics/Operations/SetStrokeColor.cs
@@ -35,7 +35,7 @@
         /// <inheritdoc />
         public void Run(IOperationContext operationContext)
         {
-            operationContext.GetCurrentState().ColorSpaceContext.SetStrokingColor(Operands);
+            operationContext.GetCurrentState().ColorSpaceContext.SetStrokingColor(operands);
         }
 
         /// <inheritdoc />

--- a/src/UglyToad.PdfPig/Graphics/Operations/SetStrokeColorAdvanced.cs
+++ b/src/UglyToad.PdfPig/Graphics/Operations/SetStrokeColorAdvanced.cs
@@ -55,7 +55,7 @@
         /// <inheritdoc />
         public void Run(IOperationContext operationContext)
         {
-            operationContext.GetCurrentState().ColorSpaceContext.SetStrokingColor(Operands, PatternName);
+            operationContext.GetCurrentState().ColorSpaceContext.SetStrokingColor(operands, PatternName);
         }
 
         /// <inheritdoc />


### PR DESCRIPTION
Saving operands values is useful for correct processing of Uncoloured Tiling Patterns