### PR TITLE
Allow skipping token that are not an IndirectReferenceToken in BasePageFactory.Create and fix #1286

### DIFF
--- a/src/UglyToad.PdfPig.Tests/Integration/GithubIssuesTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Integration/GithubIssuesTests.cs
@@ -16,6 +16,27 @@
     public class GithubIssuesTests
     {
         [Fact]
+        public void Issues1286()
+        {
+            var path = IntegrationHelpers.GetSpecificTestDocumentPath("issue_1286.pdf");
+
+            // Lenient parsing On
+            using (var document = PdfDocument.Open(path))
+            {
+                Assert.Equal(1, document.NumberOfPages);
+                Assert.NotNull(document.GetPage(1));
+            }
+
+            // Lenient parsing Off
+            using (var document = PdfDocument.Open(path, ParsingOptions.LenientParsingOff))
+            {
+                Assert.Equal(1, document.NumberOfPages);
+                var ex = Assert.Throws<PdfDocumentFormatException>(() => document.GetPage(1));
+                Assert.Equal("The contents contained something which was not an indirect reference: null.", ex.Message);
+            }
+        }
+        
+        [Fact]
         public void Issues1371()
         {
             var path = IntegrationHelpers.GetSpecificTestDocumentPath("094.-.Fiat.CR.32.Aces.of.the.Spanish.Civil.War.pdf");

--- a/src/UglyToad.PdfPig.Tests/Integration/SpecificTestDocuments/issue_1286.pdf
+++ b/src/UglyToad.PdfPig.Tests/Integration/SpecificTestDocuments/issue_1286.pdf
@@ -1,0 +1,48 @@
+%PDF-1.7
+%‚„œ”
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [ 3 0 R ] /Count 1 >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [ 0 0 595 842 ] /Resources << /Font << /F1 5 0 R >> >> /Contents [ 4 0 R null 6 0 R 7 ] >>
+endobj
+4 0 obj
+<< /Length 59 >>
+stream
+BT
+/F1 24 Tf
+1 0 0 1 60 700 Tm
+(Hello from stream 1) Tj
+ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica /Encoding /WinAnsiEncoding >>
+endobj
+6 0 obj
+<< /Length 83 >>
+stream
+BT
+/F1 18 Tf
+1 0 0 1 60 660 Tm
+(...and from stream 3, after the bad entries) Tj
+ET
+endstream
+endobj
+xref
+0 7
+0000000000 65535 f 
+0000000015 00000 n 
+0000000064 00000 n 
+0000000123 00000 n 
+0000000268 00000 n 
+0000000376 00000 n 
+0000000473 00000 n 
+trailer
+<< /Size 7 /Root 1 0 R >>
+startxref
+605
+%%EOF

--- a/src/UglyToad.PdfPig/Content/BasePageFactory.cs
+++ b/src/UglyToad.PdfPig/Content/BasePageFactory.cs
@@ -122,11 +122,18 @@
                 {
                     var item = array.Data[i];
 
-                    if (!(item is IndirectReferenceToken obj))
+                    if (item is not IndirectReferenceToken obj)
                     {
+                        // Malformed pdf document
+                        if (ParsingOptions.UseLenientParsing)
+                        {
+                            // Should not be possible that the token is already a StreamToken
+                            continue; // We skip the token
+                        }
+
                         throw new PdfDocumentFormatException($"The contents contained something which was not an indirect reference: {item}.");
                     }
-
+                    
                     var contentStream = DirectObjectFinder.Get<StreamToken>(obj, PdfScanner);
 
                     if (contentStream is null)


### PR DESCRIPTION
fix #1286