### PR TITLE
Improve caching: found tokens in token scanner, resolved resources and XObject forms

### DIFF
--- a/src/UglyToad.PdfPig.Tests/ContentTests/ResourceStoreCachingTests.cs
+++ b/src/UglyToad.PdfPig.Tests/ContentTests/ResourceStoreCachingTests.cs
@@ -1,0 +1,104 @@
+namespace UglyToad.PdfPig.Tests.ContentTests
+{
+    using System.Collections.Generic;
+    using PdfPig.Content;
+    using PdfPig.Core;
+    using PdfPig.PdfFonts;
+    using PdfPig.Tokens;
+    using PdfPig.Tests.Tokens;
+    using Xunit;
+
+    /// <summary>
+    /// Issue #1390: a page with thousands of form XObjects sharing one resource dictionary re-expanded that
+    /// dictionary on every invocation, which is quadratic in the number of resource entries.
+    /// </summary>
+    public class ResourceStoreCachingTests
+    {
+        private sealed class NoOpFontFactory : IFontFactory
+        {
+            public IFont Get(DictionaryToken dictionary) => null!;
+        }
+
+        private static ResourceStore BuildStore(TestPdfTokenScanner scanner)
+        {
+            return new ResourceStore(
+                scanner,
+                new NoOpFontFactory(),
+                new TestFilterProvider(),
+                new ParsingOptions
+                {
+                    UseLenientParsing = true,
+                    SkipMissingFonts = true,
+                });
+        }
+
+        /// <summary>
+        /// Builds `&lt;&lt; /ExtGState 20 0 R &gt;&gt;` where object 20 is `&lt;&lt; /G0 21 0 R /G1 22 0 R &gt;&gt;`,
+        /// matching the shape of the document in issue #1390.
+        /// </summary>
+        private static DictionaryToken RegisterResourcesWithIndirectExtGState(TestPdfTokenScanner scanner)
+        {
+            var extGStateReference = new IndirectReference(20, 0);
+            var g0Reference = new IndirectReference(21, 0);
+            var g1Reference = new IndirectReference(22, 0);
+
+            void Register(IndirectReference reference, IToken token)
+                => scanner.Objects[reference] = new ObjectToken(XrefLocation.File(0), reference, token);
+
+            Register(g0Reference, new DictionaryToken(new Dictionary<NameToken, IToken>
+            {
+                { NameToken.Lw, new NumericToken(1) }
+            }));
+
+            Register(g1Reference, new DictionaryToken(new Dictionary<NameToken, IToken>
+            {
+                { NameToken.Lw, new NumericToken(2) }
+            }));
+
+            Register(extGStateReference, new DictionaryToken(new Dictionary<NameToken, IToken>
+            {
+                { NameToken.Create("G0"), new IndirectReferenceToken(g0Reference) },
+                { NameToken.Create("G1"), new IndirectReferenceToken(g1Reference) }
+            }));
+
+            return new DictionaryToken(new Dictionary<NameToken, IToken>
+            {
+                { NameToken.ExtGState, new IndirectReferenceToken(extGStateReference) }
+            });
+        }
+
+        [Fact]
+        public void ReloadingTheSameResourceDictionaryResolvesNoFurtherObjects()
+        {
+            var scanner = new TestPdfTokenScanner();
+            var resources = RegisterResourcesWithIndirectExtGState(scanner);
+            var store = BuildStore(scanner);
+
+            store.LoadResourceDictionary(resources);
+            store.UnloadResourceDictionary();
+
+            var afterFirstLoad = scanner.GetCallCount;
+
+            store.LoadResourceDictionary(resources);
+
+            Assert.Equal(afterFirstLoad, scanner.GetCallCount);
+        }
+
+        [Fact]
+        public void ReloadingTheSameResourceDictionaryStillResolvesItsEntries()
+        {
+            var scanner = new TestPdfTokenScanner();
+            var resources = RegisterResourcesWithIndirectExtGState(scanner);
+            var store = BuildStore(scanner);
+
+            store.LoadResourceDictionary(resources);
+            var firstLoad = store.GetExtendedGraphicsStateDictionary(NameToken.Create("G1"));
+            store.UnloadResourceDictionary();
+
+            store.LoadResourceDictionary(resources);
+            var secondLoad = store.GetExtendedGraphicsStateDictionary(NameToken.Create("G1"));
+
+            Assert.Same(firstLoad, secondLoad);
+        }
+    }
+}

--- a/src/UglyToad.PdfPig.Tests/Graphics/FormXObjectCachingTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Graphics/FormXObjectCachingTests.cs
@@ -1,0 +1,148 @@
+namespace UglyToad.PdfPig.Tests.Graphics
+{
+    using System.Collections.Generic;
+    using PdfPig.Content;
+    using PdfPig.Core;
+    using PdfPig.Geometry;
+    using PdfPig.Graphics;
+    using PdfPig.Graphics.Operations;
+    using PdfPig.Logging;
+    using PdfPig.Parser;
+    using PdfPig.PdfFonts;
+    using PdfPig.Tokens;
+    using PdfPig.Tests.Tokens;
+    using Xunit;
+
+    /// <summary>
+    /// Issue #1390: a page can invoke the same form XObject thousands of times. Every invocation used to
+    /// resolve the form's stream again and re-parse its content stream.
+    /// </summary>
+    public class FormXObjectCachingTests
+    {
+        private static readonly NameToken FormName = NameToken.Create("Fm0");
+
+        private static readonly IndirectReference FormReference = new IndirectReference(5, 0);
+
+        private sealed class NoOpFontFactory : IFontFactory
+        {
+            public IFont Get(DictionaryToken dictionary) => null!;
+        }
+
+        private sealed class CountingPageContentParser : IPageContentParser
+        {
+            private readonly IPageContentParser inner;
+
+            public CountingPageContentParser(IPageContentParser inner) => this.inner = inner;
+
+            public int ParseCallCount { get; private set; }
+
+            public IReadOnlyList<IGraphicsStateOperation> Parse(int pageNumber, IInputBytes inputBytes, ILog log)
+            {
+                ParseCallCount++;
+
+                return inner.Parse(pageNumber, inputBytes, log);
+            }
+        }
+
+        private static TestPdfTokenScanner CreateScannerWithForm()
+        {
+            var scanner = new TestPdfTokenScanner();
+
+            var formDictionary = new DictionaryToken(new Dictionary<NameToken, IToken>
+            {
+                { NameToken.Type, NameToken.Xobject },
+                { NameToken.Subtype, NameToken.Form },
+                {
+                    NameToken.Bbox, new ArrayToken(new IToken[]
+                    {
+                        new NumericToken(0), new NumericToken(0), new NumericToken(10), new NumericToken(10)
+                    })
+                }
+            });
+
+            var formStream = new StreamToken(formDictionary, OtherEncodings.StringAsLatin1Bytes("0 0 10 10 re f\n"));
+
+            scanner.Objects[FormReference] = new ObjectToken(XrefLocation.File(0), FormReference, formStream);
+
+            return scanner;
+        }
+
+        private static ContentStreamProcessor CreateProcessor(TestPdfTokenScanner scanner,
+            IPageContentParser pageContentParser)
+        {
+            var parsingOptions = new ParsingOptions { UseLenientParsing = true, SkipMissingFonts = true };
+
+            var resourceStore = new ResourceStore(scanner, new NoOpFontFactory(), new TestFilterProvider(), parsingOptions);
+
+            resourceStore.LoadResourceDictionary(new DictionaryToken(new Dictionary<NameToken, IToken>
+            {
+                {
+                    NameToken.Xobject, new DictionaryToken(new Dictionary<NameToken, IToken>
+                    {
+                        { FormName, new IndirectReferenceToken(FormReference) }
+                    })
+                }
+            }));
+
+            return new ContentStreamProcessor(
+                1,
+                resourceStore,
+                scanner,
+                pageContentParser,
+                new TestFilterProvider(),
+                new CropBox(new PdfRectangle(0, 0, 612, 792)),
+                UserSpaceUnit.Default,
+                new PageRotationDegrees(0),
+                TransformationMatrix.Identity,
+                parsingOptions);
+        }
+
+        private static CountingPageContentParser CreateParser()
+        {
+            return new CountingPageContentParser(
+                new PageContentParser(ReflectionGraphicsStateOperationFactory.Instance, new StackDepthGuard(256)));
+        }
+
+        [Fact]
+        public void RepeatedFormInvocationParsesTheContentStreamOnce()
+        {
+            var scanner = CreateScannerWithForm();
+            var parser = CreateParser();
+            var processor = CreateProcessor(scanner, parser);
+
+            processor.ApplyXObject(FormName);
+            processor.ApplyXObject(FormName);
+
+            Assert.Equal(1, parser.ParseCallCount);
+        }
+
+        [Fact]
+        public void RepeatedFormInvocationResolvesTheStreamOnce()
+        {
+            var scanner = CreateScannerWithForm();
+            var processor = CreateProcessor(scanner, CreateParser());
+
+            processor.ApplyXObject(FormName);
+            var afterFirstInvocation = scanner.GetCallCount;
+
+            processor.ApplyXObject(FormName);
+
+            Assert.Equal(afterFirstInvocation, scanner.GetCallCount);
+        }
+
+        [Fact]
+        public void RepeatedFormInvocationRunsTheContentEveryTime()
+        {
+            var scanner = CreateScannerWithForm();
+            var processor = CreateProcessor(scanner, CreateParser());
+
+            processor.ApplyXObject(FormName);
+            processor.ApplyXObject(FormName);
+            processor.ApplyXObject(FormName);
+
+            var content = processor.Process(1, new List<IGraphicsStateOperation>());
+
+            Assert.Equal(3, content.Paths.Count);
+        }
+    }
+}

--- a/src/UglyToad.PdfPig.Tests/Tokenization/Scanner/PdfTokenScannerTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Tokenization/Scanner/PdfTokenScannerTests.cs
@@ -717,6 +717,39 @@ endobj".Replace("\r\n", "\n").Replace("\n", "\r\n");
             Assert.IsType<NumericToken>(lengthValue);
         }
 
+        [Fact]
+        public void GetResolvesObjectFromXrefTableOnlyOnce()
+        {
+            // Issue #1390: objects located via a classic xref table were re-read and re-tokenized
+            // on every lookup because only the object stream and brute force paths populated the cache.
+            const string s = "12 0 obj\n<< /Type /Page >>\nendobj\n";
+
+            var reference = new IndirectReference(12, 0);
+            var scanner = GetScannerWithRealLocationProvider(s, (reference, 0));
+
+            var first = scanner.Get(reference);
+            var second = scanner.Get(reference);
+
+            Assert.Same(first, second);
+        }
+
+        [Fact]
+        public void GetDoesNotCacheStreamObjects()
+        {
+            // Streams are deliberately left out of the object cache. Caching them would pin the raw
+            // bytes of every image and content stream ever resolved for the lifetime of the document.
+            const string s = "7 0 obj\n<< /Length 11 >>\nstream\nhello world\nendstream\nendobj\n";
+
+            var reference = new IndirectReference(7, 0);
+            var scanner = GetScannerWithRealLocationProvider(s, (reference, 0));
+
+            var first = scanner.Get(reference);
+            var second = scanner.Get(reference);
+
+            Assert.IsType<StreamToken>(first.Data);
+            Assert.NotSame(first, second);
+        }
+
         private static PdfTokenScanner GetScanner(string s, TestObjectLocationProvider locationProvider = null, bool useLenientParsing = false)
         {
             var input = StringBytesTestConverter.Convert(s, false);
@@ -727,6 +760,23 @@ endobj".Replace("\r\n", "\n").Replace("\n", "\r\n");
                 NoOpEncryptionHandler.Instance,
                 new FileHeaderOffset(0),
                 useLenientParsing ? new ParsingOptions() : ParsingOptions.LenientParsingOff,
+                new StackDepthGuard(256));
+        }
+
+
+        private static PdfTokenScanner GetScannerWithRealLocationProvider(string s,
+            params (IndirectReference Reference, long Offset)[] offsets)
+        {
+            var input = StringBytesTestConverter.Convert(s, false);
+
+            var xrefOffsets = offsets.ToDictionary(x => x.Reference, x => XrefLocation.File(x.Offset));
+
+            return new PdfTokenScanner(input.Bytes,
+                new ObjectLocationProvider(xrefOffsets, null, input.Bytes),
+                new TestFilterProvider(),
+                NoOpEncryptionHandler.Instance,
+                new FileHeaderOffset(0),
+                ParsingOptions.LenientParsingOff,
                 new StackDepthGuard(256));
         }
 

--- a/src/UglyToad.PdfPig.Tests/Tokens/TestPdfTokenScanner.cs
+++ b/src/UglyToad.PdfPig.Tests/Tokens/TestPdfTokenScanner.cs
@@ -11,7 +11,12 @@ namespace UglyToad.PdfPig.Tests.Tokens
         public StackDepthGuard StackDepthGuard => StackDepthGuard.Infinite;
 
         public Dictionary<IndirectReference, ObjectToken> Objects { get; } = new Dictionary<IndirectReference, ObjectToken>();
-     
+
+        /// <summary>
+        /// Number of times <see cref="Get"/> has been called, so tests can assert that work is not repeated.
+        /// </summary>
+        public int GetCallCount { get; private set; }
+
         public bool MoveNext()
         {
             throw new NotImplementedException();
@@ -43,6 +48,7 @@ namespace UglyToad.PdfPig.Tests.Tokens
 
         public ObjectToken Get(IndirectReference reference)
         {
+            GetCallCount++;
             return Objects[reference];
         }
 

--- a/src/UglyToad.PdfPig.Tests/Util/StackDictionaryTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Util/StackDictionaryTests.cs
@@ -1,0 +1,102 @@
+namespace UglyToad.PdfPig.Tests.Util
+{
+    using System.Collections.Generic;
+    using PdfPig.Util;
+    using Xunit;
+
+    public class StackDictionaryTests
+    {
+        [Fact]
+        public void HigherLevelsShadowLowerOnes()
+        {
+            var stack = new StackDictionary<string, int>();
+
+            stack.Push();
+            stack["a"] = 1;
+            stack["b"] = 2;
+
+            stack.Push();
+            stack["a"] = 10;
+
+            Assert.Equal(10, stack["a"]);
+            Assert.Equal(2, stack["b"]);
+        }
+
+        [Fact]
+        public void PopRestoresTheShadowedValue()
+        {
+            var stack = new StackDictionary<string, int>();
+
+            stack.Push();
+            stack["a"] = 1;
+            stack.Push();
+            stack["a"] = 10;
+
+            stack.Pop();
+
+            Assert.Equal(1, stack["a"]);
+        }
+
+        [Fact]
+        public void PushedLevelIsNotMutatedByALaterWrite()
+        {
+            var cached = new Dictionary<string, int> { { "a", 1 } };
+
+            var stack = new StackDictionary<string, int>();
+            stack.Push(cached);
+
+            stack["a"] = 99;
+            stack["b"] = 100;
+
+            Assert.Equal(1, cached["a"]);
+            Assert.False(cached.ContainsKey("b"));
+        }
+
+        [Fact]
+        public void WriteToAPushedLevelIsVisibleThroughTheStack()
+        {
+            var cached = new Dictionary<string, int> { { "a", 1 } };
+
+            var stack = new StackDictionary<string, int>();
+            stack.Push(cached);
+
+            stack["a"] = 99;
+
+            Assert.Equal(99, stack["a"]);
+        }
+
+        [Fact]
+        public void TheSameLevelCanBePushedTwiceIndependently()
+        {
+            var cached = new Dictionary<string, int> { { "a", 1 } };
+
+            var stack = new StackDictionary<string, int>();
+            stack.Push(cached);
+            stack.Push(cached);
+
+            stack["a"] = 99;
+            Assert.Equal(99, stack["a"]);
+
+            stack.Pop();
+
+            Assert.Equal(1, stack["a"]);
+            Assert.Equal(1, cached["a"]);
+        }
+
+        [Fact]
+        public void FlattenPrefersHigherLevels()
+        {
+            var stack = new StackDictionary<string, int>();
+
+            stack.Push();
+            stack["a"] = 1;
+            stack["b"] = 2;
+            stack.Push(new Dictionary<string, int> { { "a", 10 } });
+
+            var flattened = stack.Flatten();
+
+            Assert.Equal(10, flattened["a"]);
+            Assert.Equal(2, flattened["b"]);
+        }
+    }
+}

--- a/src/UglyToad.PdfPig.Tokens/ArrayToken.cs
+++ b/src/UglyToad.PdfPig.Tokens/ArrayToken.cs
@@ -12,6 +12,8 @@
     /// </summary>
     public sealed class ArrayToken : IDataToken<IReadOnlyList<IToken>>
     {
+        private readonly int hashCode;
+
         /// <summary>
         /// The tokens contained in this array.
         /// </summary>
@@ -58,6 +60,7 @@
 
             Data = result;
             Length = Data.Count;
+            hashCode = ComputeHashCode();
         }
 
         /// <inheritdoc />
@@ -83,9 +86,8 @@
 
             return builder.ToString();
         }
-        
-        /// <inheritdoc />
-        public override int GetHashCode()
+
+        private int ComputeHashCode()
         {
             HashCode hash = new HashCode();
             foreach (var t in Data)
@@ -94,6 +96,12 @@
             }
 
             return hash.ToHashCode();
+        }
+        
+        /// <inheritdoc />
+        public override int GetHashCode()
+        {
+            return hashCode;
         }
 
         /// <inheritdoc />

--- a/src/UglyToad.PdfPig.Tokens/DictionaryToken.cs
+++ b/src/UglyToad.PdfPig.Tokens/DictionaryToken.cs
@@ -10,6 +10,8 @@
     /// </summary>
     public sealed class DictionaryToken : IDataToken<IReadOnlyDictionary<string, IToken>>, IEquatable<DictionaryToken>
     {
+        private readonly int hashCode;
+
         /// <summary>
         /// The key value pairs in this dictionary.
         /// </summary>
@@ -39,11 +41,13 @@
             }
 
             Data = result;
+            hashCode = ComputeHashCode();
         }
 
         private DictionaryToken(IReadOnlyDictionary<string, IToken> data)
         {
             Data = data;
+            hashCode = ComputeHashCode();
         }
 
         /// <summary>
@@ -167,8 +171,7 @@
             return new DictionaryToken(data ?? throw new ArgumentNullException(nameof(data)));
         }
 
-        /// <inheritdoc />
-        public override int GetHashCode()
+        private int ComputeHashCode()
         {
             // Equals is insensitive to entry order so the hash must be too
             int hash = 0;
@@ -182,6 +185,12 @@
             }
 
             return hash;
+        }
+        
+        /// <inheritdoc />
+        public override int GetHashCode()
+        {
+            return hashCode;
         }
 
         /// <inheritdoc />

--- a/src/UglyToad.PdfPig.Tokens/StreamToken.cs
+++ b/src/UglyToad.PdfPig.Tokens/StreamToken.cs
@@ -8,6 +8,8 @@
     /// </summary>
     public sealed class StreamToken : IDataToken<Memory<byte>>
     {
+        private readonly int hashCode;
+
         /// <summary>
         /// The dictionary specifying the length of the stream, any applied compression filters and additional information.
         /// </summary>
@@ -17,7 +19,7 @@
         /// The compressed byte data of the stream.
         /// </summary>
         public Memory<byte> Data { get; }
-
+        
         /// <summary>
         /// Create a new <see cref="StreamToken"/>.
         /// </summary>
@@ -27,6 +29,7 @@
         {
             StreamDictionary = streamDictionary ?? throw new ArgumentNullException(nameof(streamDictionary));
             Data = data ?? throw new ArgumentNullException(nameof(data));
+            hashCode = ComputeHashCode();
         }
 
         /// <summary>
@@ -38,10 +41,10 @@
         {
             StreamDictionary = streamDictionary ?? throw new ArgumentNullException(nameof(streamDictionary));
             Data = data;
+            hashCode = ComputeHashCode();
         }
-
-        /// <inheritdoc />
-        public override int GetHashCode()
+        
+        private int ComputeHashCode()
         {
             var hash = new HashCode();
             hash.Add(StreamDictionary);
@@ -55,6 +58,12 @@
             }
 #endif
             return hash.ToHashCode();
+        }
+        
+        /// <inheritdoc />
+        public override int GetHashCode()
+        {
+            return hashCode;
         }
 
         /// <inheritdoc />

--- a/src/UglyToad.PdfPig/Content/IResourceStore.cs
+++ b/src/UglyToad.PdfPig/Content/IResourceStore.cs
@@ -2,6 +2,7 @@
 {
     using System.Collections.Generic;
     using System.Diagnostics.CodeAnalysis;
+    using Core;
     using Graphics.Colors;
     using PdfFonts;
     using Tokens;
@@ -31,6 +32,12 @@
         /// Try getting the XObject corresponding to the name.
         /// </summary>
         bool TryGetXObject(NameToken name, [NotNullWhen(true)] out StreamToken? stream);
+
+        /// <summary>
+        /// Try getting the reference of the XObject corresponding to the name, without resolving the object
+        /// it points at. Lets a caller identify an XObject it has already seen without re-reading its stream.
+        /// </summary>
+        bool TryGetXObjectReference(NameToken name, out IndirectReference reference);
 
         /// <summary>
         /// Get the extended graphics state dictionary corresponding to the name.

--- a/src/UglyToad.PdfPig/Content/ResourceStore.cs
+++ b/src/UglyToad.PdfPig/Content/ResourceStore.cs
@@ -36,6 +36,8 @@
         private readonly StackDictionary<NameToken, Shading> shadingsProperties = new StackDictionary<NameToken, Shading>();
 
         private readonly StackDictionary<NameToken, PatternColor> patternsProperties = new StackDictionary<NameToken, PatternColor>();
+        
+        private readonly Dictionary<DictionaryToken, ResolvedResources> resolvedResources = new();
 
         // 8.6.5.6: while a DefaultGray/RGB/CMYK substitution is being resolved, any device colour space
         // encountered inside the substitute's own definition refers to the genuine device space and shall
@@ -63,19 +65,50 @@
             loadedNamedColorSpaceDetails.Clear();
             loadedColorSpaceDetailsCache.Clear();
 
-            namedColorSpaces.Push();
-            currentFontState.Push();
-            currentXObjectState.Push();
-            extendedGraphicsStates.Push();
-            markedContentProperties.Push();
+            if (!resolvedResources.TryGetValue(resourceDictionary, out var resolved))
+            {
+                resolved = ResolveResources(resourceDictionary);
+                resolvedResources[resourceDictionary] = resolved;
+            }
+
+            namedColorSpaces.Push(resolved.NamedColorSpaces);
+            currentFontState.Push(resolved.Fonts);
+            currentXObjectState.Push(resolved.XObjects);
+            extendedGraphicsStates.Push(resolved.ExtendedGraphicsStates);
+            markedContentProperties.Push(resolved.MarkedContentProperties);
             shadingsProperties.Push();
             patternsProperties.Push();
+
+            // Fonts given inline rather than by indirect reference are keyed by name in a store shared
+            // across resource dictionaries, so their binding is re-established on every load. The font
+            // itself was parsed when this dictionary was first resolved.
+            for (var i = 0; i < resolved.DirectFonts.Count; i++)
+            {
+                var directFont = resolved.DirectFonts[i];
+                loadedDirectFonts[directFont.Name] = directFont.Font;
+            }
+
+            // Patterns and shadings resolve their colour spaces through the resource stack, so unlike the
+            // categories above their result depends on the levels below this one and cannot be cached
+            // against the resource dictionary alone.
+            LoadPatterns(resourceDictionary);
+            LoadShadings(resourceDictionary);
+        }
+
+        private ResolvedResources ResolveResources(DictionaryToken resourceDictionary)
+        {
+            var fonts = new Dictionary<NameToken, IndirectReference>();
+            var directFonts = new List<(NameToken Name, IFont Font)>();
+            var xObjects = new Dictionary<NameToken, IndirectReference>();
+            var extendedGraphicsStateDictionaries = new Dictionary<NameToken, DictionaryToken>();
+            var colorSpaces = new Dictionary<NameToken, ResourceColorSpace>();
+            var properties = new Dictionary<NameToken, DictionaryToken>();
 
             if (resourceDictionary.TryGet(NameToken.Font, out var fontBase))
             {
                 var fontDictionary = DirectObjectFinder.Get<DictionaryToken>(fontBase, scanner);
 
-                LoadFontDictionary(fontDictionary);
+                LoadFontDictionary(fontDictionary, fonts, directFonts);
             }
 
             if (resourceDictionary.TryGet(NameToken.Xobject, out var xobjectBase))
@@ -94,7 +127,7 @@
                         throw new InvalidOperationException($"Expected the XObject dictionary value for key /{pair.Key} to be an indirect reference, instead got: {pair.Value}.");
                     }
 
-                    currentXObjectState[NameToken.Create(pair.Key)] = reference.Data;
+                    xObjects[NameToken.Create(pair.Key)] = reference.Data;
                 }
             }
 
@@ -105,7 +138,7 @@
                     var name = NameToken.Create(pair.Key);
                     var state = DirectObjectFinder.Get<DictionaryToken>(pair.Value, scanner);
 
-                    extendedGraphicsStates[name] = state;
+                    extendedGraphicsStateDictionaries[name] = state;
                 }
             }
 
@@ -117,7 +150,7 @@
 
                     if (DirectObjectFinder.TryGet(nameColorSpacePair.Value, scanner, out NameToken? colorSpaceName))
                     {
-                        namedColorSpaces[name] = new ResourceColorSpace(colorSpaceName);
+                        colorSpaces[name] = new ResourceColorSpace(colorSpaceName);
                     }
                     else if (DirectObjectFinder.TryGet(nameColorSpacePair.Value, scanner, out ArrayToken? colorSpaceArray))
                     {
@@ -133,29 +166,19 @@
                             throw new PdfDocumentFormatException($"Invalid ColorSpace array encountered in page resource dictionary: {colorSpaceArray}.");
                         }
 
-                        namedColorSpaces[name] = new ResourceColorSpace(arrayNamedColorSpace, colorSpaceArray);
+                        colorSpaces[name] = new ResourceColorSpace(arrayNamedColorSpace, colorSpaceArray);
                     }
                     else if (parsingOptions.UseLenientParsing &&
                              DirectObjectFinder.TryGet(nameColorSpacePair.Value, scanner, out DictionaryToken? dict) &&
                              dict.TryGet(NameToken.ColorSpace, scanner, out NameToken? csName))
                     {
                         // See issue #1061
-                        namedColorSpaces[name] = new ResourceColorSpace(csName);
+                        colorSpaces[name] = new ResourceColorSpace(csName);
                     }
                     else
                     {
                         throw new PdfDocumentFormatException($"Invalid ColorSpace token encountered in page resource dictionary: {nameColorSpacePair.Value}.");
                     }
-                }
-            }
-
-            if (resourceDictionary.TryGet(NameToken.Pattern, scanner, out DictionaryToken? patternDictionary))
-            {
-                // NB: in PDF, all patterns shall be local to the context in which they are defined.
-                foreach (var namePatternPair in patternDictionary.Data)
-                {
-                    var name = NameToken.Create(namePatternPair.Key);
-                    patternsProperties[name] = PatternParser.Create(namePatternPair.Value, scanner, this, filterProvider);
                 }
             }
 
@@ -170,29 +193,51 @@
                         continue;
                     }
 
-                    markedContentProperties[key] = namedProperties;
+                    properties[key] = namedProperties;
                 }
             }
 
-            if (resourceDictionary.TryGet(NameToken.Shading, scanner, out DictionaryToken? shadingList))
+            return new ResolvedResources(fonts, directFonts, xObjects, extendedGraphicsStateDictionaries, colorSpaces, properties);
+        }
+
+        private void LoadPatterns(DictionaryToken resourceDictionary)
+        {
+            if (!resourceDictionary.TryGet(NameToken.Pattern, scanner, out DictionaryToken? patternDictionary))
             {
-                foreach (var pair in shadingList.Data)
+                return;
+            }
+
+            // NB: in PDF, all patterns shall be local to the context in which they are defined.
+            foreach (var namePatternPair in patternDictionary.Data)
+            {
+                var name = NameToken.Create(namePatternPair.Key);
+                patternsProperties[name] = PatternParser.Create(namePatternPair.Value, scanner, this, filterProvider);
+            }
+        }
+
+        private void LoadShadings(DictionaryToken resourceDictionary)
+        {
+            if (!resourceDictionary.TryGet(NameToken.Shading, scanner, out DictionaryToken? shadingList))
+            {
+                return;
+            }
+
+            foreach (var pair in shadingList.Data)
+            {
+                var key = NameToken.Create(pair.Key);
+                if (DirectObjectFinder.TryGet(pair.Value, scanner, out DictionaryToken? namedPropertiesDictionary))
                 {
-                    var key = NameToken.Create(pair.Key);
-                    if (DirectObjectFinder.TryGet(pair.Value, scanner, out DictionaryToken? namedPropertiesDictionary))
-                    {
-                        shadingsProperties[key] = ShadingParser.Create(namedPropertiesDictionary, scanner, this, filterProvider);
-                    }
-                    else if (DirectObjectFinder.TryGet(pair.Value, scanner, out StreamToken? namedPropertiesStream))
-                    {
-                        // Shading types 4 to 7 shall be defined by a stream containing descriptive data characterizing
-                        // the shading's gradient fill.
-                       shadingsProperties[key] = ShadingParser.Create(namedPropertiesStream, scanner, this, filterProvider);
-                    }
-                    else
-                    {
-                        throw new NotImplementedException("Shading");
-                    }
+                    shadingsProperties[key] = ShadingParser.Create(namedPropertiesDictionary, scanner, this, filterProvider);
+                }
+                else if (DirectObjectFinder.TryGet(pair.Value, scanner, out StreamToken? namedPropertiesStream))
+                {
+                    // Shading types 4 to 7 shall be defined by a stream containing descriptive data characterizing
+                    // the shading's gradient fill.
+                    shadingsProperties[key] = ShadingParser.Create(namedPropertiesStream, scanner, this, filterProvider);
+                }
+                else
+                {
+                    throw new NotImplementedException("Shading");
                 }
             }
         }
@@ -211,7 +256,9 @@
             patternsProperties.Pop();
         }
 
-        private void LoadFontDictionary(DictionaryToken fontDictionary)
+        private void LoadFontDictionary(DictionaryToken fontDictionary,
+            Dictionary<NameToken, IndirectReference> fonts,
+            List<(NameToken Name, IFont Font)> directFonts)
         {
             lastLoadedFont = (null, null);
 
@@ -221,7 +268,7 @@
                 {
                     var reference = objectKey.Data;
 
-                    currentFontState[NameToken.Create(pair.Key)] = reference;
+                    fonts[NameToken.Create(pair.Key)] = reference;
 
                     if (loadedFonts.ContainsKey(reference))
                     {
@@ -255,12 +302,55 @@
                 }
                 else if (pair.Value is DictionaryToken fd)
                 {
-                    loadedDirectFonts[NameToken.Create(pair.Key)] = fontFactory.Get(fd);
+                    var name = NameToken.Create(pair.Key);
+                    var font = fontFactory.Get(fd);
+
+                    directFonts.Add((name, font));
+                    loadedDirectFonts[name] = font;
                 }
                 else
                 {
                     continue;
                 }
+            }
+        }
+
+        /// <summary>
+        /// The result of expanding a resource dictionary, used for caching.
+        /// </summary>
+        private sealed class ResolvedResources
+        {
+            public Dictionary<NameToken, IndirectReference> Fonts { get; }
+
+            /// <summary>
+            /// Fonts written inline in the resource dictionary rather than referenced indirectly. These are
+            /// held by name in a store shared across resource dictionaries so the binding, unlike the parsed
+            /// font, has to be re-applied on every load.
+            /// </summary>
+            public IReadOnlyList<(NameToken Name, IFont Font)> DirectFonts { get; }
+
+            public Dictionary<NameToken, IndirectReference> XObjects { get; }
+
+            public Dictionary<NameToken, DictionaryToken> ExtendedGraphicsStates { get; }
+
+            public Dictionary<NameToken, ResourceColorSpace> NamedColorSpaces { get; }
+
+            public Dictionary<NameToken, DictionaryToken> MarkedContentProperties { get; }
+
+            public ResolvedResources(
+                Dictionary<NameToken, IndirectReference> fonts,
+                IReadOnlyList<(NameToken Name, IFont Font)> directFonts,
+                Dictionary<NameToken, IndirectReference> xObjects,
+                Dictionary<NameToken, DictionaryToken> extendedGraphicsStates,
+                Dictionary<NameToken, ResourceColorSpace> namedColorSpaces,
+                Dictionary<NameToken, DictionaryToken> markedContentProperties)
+            {
+                Fonts = fonts;
+                DirectFonts = directFonts;
+                XObjects = xObjects;
+                ExtendedGraphicsStates = extendedGraphicsStates;
+                NamedColorSpaces = namedColorSpaces;
+                MarkedContentProperties = markedContentProperties;
             }
         }
 
@@ -498,6 +588,11 @@
             }
 
             return DirectObjectFinder.TryGet(new IndirectReferenceToken(indirectReference), scanner, out stream);
+        }
+
+        public bool TryGetXObjectReference(NameToken name, out IndirectReference reference)
+        {
+            return currentXObjectState.TryGetValue(name, out reference);
         }
 
         public DictionaryToken? GetExtendedGraphicsStateDictionary(NameToken name)

--- a/src/UglyToad.PdfPig/Graphics/BaseStreamProcessor.cs
+++ b/src/UglyToad.PdfPig/Graphics/BaseStreamProcessor.cs
@@ -119,6 +119,10 @@
         /// </summary>
         private readonly Dictionary<(IType3Font Font, int Code), PdfRectangle?> _type3GlyphBoxCache = new();
 
+        private readonly Dictionary<IndirectReference, StreamToken> _formXObjectCache = new();
+
+        private readonly Dictionary<StreamToken, IReadOnlyList<IGraphicsStateOperation>> _formOperationsCache = new();
+
         /// <summary>
         /// Abstract stream processor constructor.
         /// </summary>
@@ -479,6 +483,14 @@
         /// <inheritdoc/>
         public virtual void ApplyXObject(NameToken xObjectName)
         {
+            var hasReference = ResourceStore.TryGetXObjectReference(xObjectName, out var xObjectReference);
+
+            if (hasReference && _formXObjectCache.TryGetValue(xObjectReference, out var cachedForm))
+            {
+                ProcessFormXObject(cachedForm, xObjectName);
+                return;
+            }
+
             if (!ResourceStore.TryGetXObject(xObjectName, out var xObjectStream))
             {
                 if (ParsingOptions.SkipMissingFonts)
@@ -519,6 +531,11 @@
             }
             else if (subType.Equals(NameToken.Form))
             {
+                if (hasReference)
+                {
+                    _formXObjectCache[xObjectReference] = xObjectStream;
+                }
+
                 ProcessFormXObject(xObjectStream, xObjectName);
             }
             else
@@ -646,11 +663,7 @@
                 // 2. Update current transformation matrix.
                 ModifyCurrentTransformationMatrix(formMatrix);
 
-                var contentStream = formStream.Decode(FilterProvider, PdfScanner);
-
-                var operations = PageContentParser.Parse(PageNumber,
-                    new MemoryInputBytes(contentStream),
-                    ParsingOptions.Logger);
+                var operations = GetFormOperations(formStream);
 
                 // 3. Clip according to the form dictionary's BBox entry.
                 if (formStream.StreamDictionary.TryGet<ArrayToken>(NameToken.Bbox, PdfScanner, out var bboxToken))
@@ -698,6 +711,26 @@
                     ResourceStore.UnloadResourceDictionary();
                 }
             }
+        }
+
+        /// <summary>
+        /// Get the operations of a form XObject's content stream with caching.
+        /// </summary>
+        protected IReadOnlyList<IGraphicsStateOperation> GetFormOperations(StreamToken formStream)
+        {
+            if (_formOperationsCache.TryGetValue(formStream, out var cached))
+            {
+                return cached;
+            }
+
+            var contentStream = formStream.Decode(FilterProvider, PdfScanner);
+
+            var operations = PageContentParser.Parse(PageNumber,
+                new MemoryInputBytes(contentStream), ParsingOptions.Logger);
+
+            _formOperationsCache[formStream] = operations;
+
+            return operations;
         }
 
         /// <summary>

--- a/src/UglyToad.PdfPig/Tokenization/Scanner/PdfTokenScanner.cs
+++ b/src/UglyToad.PdfPig/Tokenization/Scanner/PdfTokenScanner.cs
@@ -797,6 +797,13 @@
 
             if (found.Number.Equals(reference))
             {
+                // We don't cache StreamToken as this would keep
+                // the attached raw bytes (can be large)
+                if (found.Data is not StreamToken)
+                {
+                    objectLocationProvider.Cache(found);
+                }
+
                 return found;
             }
 

--- a/src/UglyToad.PdfPig/Util/StackDictionary.cs
+++ b/src/UglyToad.PdfPig/Util/StackDictionary.cs
@@ -7,7 +7,7 @@ namespace UglyToad.PdfPig.Util
 
     internal sealed class StackDictionary<K, V> where K : notnull
     {
-        private readonly List<Dictionary<K, V>> values = new List<Dictionary<K, V>>();
+        private readonly List<StackItem> values = new List<StackItem>();
 
         public V this[K key]
         {
@@ -32,7 +32,19 @@ namespace UglyToad.PdfPig.Util
                     throw new InvalidOperationException($"Cannot set item in empty stack, call {nameof(Push)} before use.");
                 }
 
-                values[values.Count - 1][key] = value;
+                var index = values.Count - 1;
+                var level = values[index];
+
+                if (level.IsShared)
+                {
+                    // Because this level in the stack is shared (i.e. the Dictionary<> came
+                    // from Push(Dictionary<> level)), this Dictionary<> can be used outside
+                    // here. As a defensive measure we clone it before modifying it.
+                    level = new StackItem(new Dictionary<K, V>(level.Values), false);
+                    values[index] = level;
+                }
+
+                level.Values[key] = value;
             }
         }
 
@@ -46,7 +58,7 @@ namespace UglyToad.PdfPig.Util
 
             for (var i = values.Count - 1; i >= 0; i--)
             {
-                if (values[i].TryGetValue(key, out result!))
+                if (values[i].Values.TryGetValue(key, out result!))
                 {
                     return true;
                 }
@@ -67,7 +79,7 @@ namespace UglyToad.PdfPig.Util
 
             foreach (var v in values)
             {
-                foreach (var pair in v)
+                foreach (var pair in v.Values)
                 {
                     result[pair.Key] = pair.Value;
                 }
@@ -78,7 +90,21 @@ namespace UglyToad.PdfPig.Util
 
         public void Push()
         {
-            values.Add(new Dictionary<K, V>());
+            values.Add(new StackItem(new Dictionary<K, V>(), false));
+        }
+
+        /// <summary>
+        /// Pushes a pre-computed level. The dictionary is not copied, so the caller may keep and re-push it;
+        /// any write to this level copies it first.
+        /// </summary>
+        public void Push(Dictionary<K, V> level)
+        {
+            if (level is null)
+            {
+                throw new ArgumentNullException(nameof(level));
+            }
+
+            values.Add(new StackItem(level, true));
         }
 
         public void Pop()
@@ -89,6 +115,26 @@ namespace UglyToad.PdfPig.Util
             }
 
             values.RemoveAt(values.Count - 1);
+        }
+
+        private readonly struct StackItem
+        {
+            public readonly Dictionary<K, V> Values;
+
+            /// <summary>
+            /// <see langword="true"/> if the caller handed the <see cref="Values"/>, and hence the stack does
+            /// NOT own it, and we need to be careful when modifying it.
+            /// <para>
+            /// <see langword="false"/> if the stack allocated the dictionary, hence owns it (safe to modify).
+            /// </para>
+            /// </summary>
+            public readonly bool IsShared;
+
+            public StackItem(Dictionary<K, V> values, bool isShared)
+            {
+                Values = values;
+                IsShared = isShared;
+            }
         }
     }
 }


### PR DESCRIPTION
_The code changes were made with AI assistance._

fix #1390

As  noted by @mikethea1, `ArrayToken`, `DictionaryToken` and `StreamToken` are now computing the hash code on construction, which is a cost we were not paying before - this is to avoid re-compute the hash on every `GetHashCode()` call.

An alternative could be:
```csharp
return _hashCode is 0 ? (_hashCode = ComputeHashCode()) : _hashCode;?
```

For completeness, the documents used while debugging are the following: 

[isolate-extgstate-1-entry-200do.pdf](https://github.com/user-attachments/files/31215396/isolate-extgstate-1-entry-200do.pdf)
[isolate-extgstate-direct-30k-200do.pdf](https://github.com/user-attachments/files/31215397/isolate-extgstate-direct-30k-200do.pdf)
[isolate-extgstate-indirect-30k-200do.pdf](https://github.com/user-attachments/files/31215400/isolate-extgstate-indirect-30k-200do.pdf)
[isolate-properties-30k-200do.pdf](https://github.com/user-attachments/files/31215401/isolate-properties-30k-200do.pdf)
[isolate-xobject-30k-200do.pdf](https://github.com/user-attachments/files/31215402/isolate-xobject-30k-200do.pdf)
[objstm-xobject-30k-200do.pdf](https://github.com/user-attachments/files/31215403/objstm-xobject-30k-200do.pdf)
[scaling-extgstate-30k-50do.pdf](https://github.com/user-attachments/files/31215404/scaling-extgstate-30k-50do.pdf)
[scaling-extgstate-30k-100do.pdf](https://github.com/user-attachments/files/31215405/scaling-extgstate-30k-100do.pdf)
[formstream-15b-200do.pdf](https://github.com/user-attachments/files/31215406/formstream-15b-200do.pdf)
[formstream-196kb-200do.pdf](https://github.com/user-attachments/files/31215407/formstream-196kb-200do.pdf)
[fullscale-extgstate-30k-4200do.pdf](https://github.com/user-attachments/files/31215409/fullscale-extgstate-30k-4200do.pdf)
[inline-resources-5k-500do.pdf](https://github.com/user-attachments/files/31215413/inline-resources-5k-500do.pdf)
[inline-resources-200-2000do.pdf](https://github.com/user-attachments/files/31215414/inline-resources-200-2000do.pdf)
[isolate-colorspace-30k-200do.pdf](https://github.com/user-attachments/files/31215415/isolate-colorspace-30k-200do.pdf)

