### PR TITLE
Prevent NullReferenceException in NameToken.GetHashCode() race condition

### DIFF
--- a/src/UglyToad.PdfPig.Tokens/NameToken.cs
+++ b/src/UglyToad.PdfPig.Tokens/NameToken.cs
@@ -18,9 +18,9 @@
         
         private NameToken(string text)
         {
-            NameMap[text] = this;
-
             Data = text;
+
+            NameMap[text] = this;
         }
 
         /// <summary>


### PR DESCRIPTION
We need to set the `Data` value before share the `NameToken` via `NameMap` or `Data` can be access as `null`