### PR TITLE
Resolve BaseType to the space colours actually end in

### DIFF
--- a/src/UglyToad.PdfPig.Tests/Graphics/Colors/NestedColorSpaceComponentCountTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Graphics/Colors/NestedColorSpaceComponentCountTests.cs
@@ -7,7 +7,8 @@ namespace UglyToad.PdfPig.Tests.Graphics.Colors
     /// <summary>
     /// <see cref="ColorSpaceDetails.BaseNumberOfColorComponents"/> must report the component count of the
     /// space the samples are ultimately expressed in, i.e. the count that <see cref="ColorSpaceDetails.Process"/>
-    /// (and therefore <see cref="ColorSpaceDetails.Transform"/>) actually produces per sample.
+    /// (and therefore <see cref="ColorSpaceDetails.Transform"/>) actually produces per sample, and
+    /// <see cref="ColorSpaceDetails.BaseType"/> must name that same space, resolved to the same depth.
     /// </summary>
     public class NestedColorSpaceComponentCountTests
     {
@@ -79,16 +80,32 @@ namespace UglyToad.PdfPig.Tests.Graphics.Colors
         }
 
         [Fact]
-        public void Separation_OverIccBased_SetsBaseTypeToIccBased()
+        public void Separation_OverIccBased_ResolvesToTheDeviceAlternate()
         {
+            // The ICCBased space is really converting through DeviceCMYK, which is what
+            // BaseNumberOfColorComponents has always said, and what BaseType now says too. Naming the
+            // intermediate ICCBased here would describe a step the colours do not actually take.
             var icc = new ICCBasedColorSpaceDetails(4, DeviceCmykColorSpaceDetails.Instance, null, null);
             var separation = new SeparationColorSpaceDetails(
                 NameToken.Create("Spot"),
                 icc,
                 Tint([0, 0, 0, 0], [0, 0, 0, 1]));
 
-            Assert.Equal(ColorSpace.ICCBased, separation.BaseType);
+            Assert.Equal(ColorSpace.DeviceCMYK, separation.BaseType);
             Assert.Equal(4, separation.BaseNumberOfColorComponents);
+        }
+
+        [Fact]
+        public void IccBased_OverASeparation_ReportsTheSeparationsOwnBaseWidth()
+        {
+            // The alternate is what Transform delegates to, so a 3 component ICCBased over a Separation
+            // that expands to CMYK still writes 4 bytes per sample. Reporting NumberOfColorComponents
+            // here sized every downstream buffer to 3 and ran the write off the end.
+            var icc = new ICCBasedColorSpaceDetails(3, SeparationOverCmyk(), null, null);
+
+            Assert.Equal(3, icc.NumberOfColorComponents);
+            Assert.Equal(4, icc.BaseNumberOfColorComponents);
+            Assert.Equal(ColorSpace.DeviceCMYK, icc.BaseType);
         }
 
         [Fact]
@@ -207,7 +224,10 @@ namespace UglyToad.PdfPig.Tests.Graphics.Colors
 
             Assert.Equal(1, indexed.NumberOfColorComponents);
             Assert.Equal(4, indexed.BaseNumberOfColorComponents);
-            Assert.Equal(ColorSpace.Separation, indexed.BaseType);
+
+            // Through both Separations to the device space underneath, matching the component count
+            // beside it rather than naming the first link in the chain.
+            Assert.Equal(ColorSpace.DeviceCMYK, indexed.BaseType);
         }
     }
 }

--- a/src/UglyToad.PdfPig.Tests/Integration/ColorSpaceTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Integration/ColorSpaceTests.cs
@@ -27,14 +27,16 @@
                 // image 12
                 var image12 = images1[12];
                 Assert.Equal(ColorSpace.Indexed, image12.ColorSpaceDetails.Type);
-                Assert.Equal(ColorSpace.DeviceN, image12.ColorSpaceDetails.BaseType);
+                Assert.Equal(ColorSpace.DeviceN, ((IndexedColorSpaceDetails)image12.ColorSpaceDetails).BaseColorSpace.Type);
+                Assert.Equal(ColorSpace.DeviceCMYK, image12.ColorSpaceDetails.BaseType);
                 Assert.True(image12.TryGetPng(out byte[] bytes1_12)); // Cyan square
                 File.WriteAllBytes(Path.Combine(OutputFolder, "MOZILLA-3136-0_1_12.png"), bytes1_12);
 
                 // image 13
                 var image13 = images1[13];
                 Assert.Equal(ColorSpace.Indexed, image13.ColorSpaceDetails.Type);
-                Assert.Equal(ColorSpace.DeviceN, image13.ColorSpaceDetails.BaseType);
+                Assert.Equal(ColorSpace.DeviceN, ((IndexedColorSpaceDetails)image13.ColorSpaceDetails).BaseColorSpace.Type);
+                Assert.Equal(ColorSpace.DeviceCMYK, image13.ColorSpaceDetails.BaseType);
                 Assert.True(image13.TryGetPng(out byte[] bytes1_13)); // Cyan square
                 File.WriteAllBytes(Path.Combine(OutputFolder, "MOZILLA-3136-0_1_13.png"), bytes1_13);
             }

--- a/src/UglyToad.PdfPig/Graphics/Colors/ColorSpaces/ColorSpaceDetails.cs
+++ b/src/UglyToad.PdfPig/Graphics/Colors/ColorSpaces/ColorSpaceDetails.cs
@@ -19,13 +19,20 @@
         public abstract int NumberOfColorComponents { get; }
 
         /// <summary>
-        /// The underlying type of <see cref="ColorSpace"/>, usually equal to <see cref="Type"/>
-        /// unless <see cref="ColorSpace.Indexed"/> or <see cref="ColorSpace.DeviceN"/>.
+        /// The device colour space this one's colours are ultimately expressed in, or this colour space
+        /// itself when they are not device colours at all.
+        /// <para>
+        /// Resolved all the way down: a Separation over an ICCBased that fell back to
+        /// DeviceCMYK reports <see cref="ColorSpace.DeviceCMYK"/>, because that is what its colours end up
+        /// being. It pairs with <see cref="BaseNumberOfColorComponents"/>, which counts the components of
+        /// that same space, and the two are always resolved to the same depth.
+        /// </para>
         /// </summary>
         public ColorSpace BaseType { get; protected set; }
 
         /// <summary>
-        /// The number of components for the underlying color space.
+        /// The number of components of the colour space <see cref="BaseType"/> names, which is also the
+        /// number <see cref="Transform"/> writes per sample.
         /// </summary>
         public abstract int BaseNumberOfColorComponents { get; }
 

--- a/src/UglyToad.PdfPig/Graphics/Colors/ColorSpaces/DeviceNColorSpaceDetails.cs
+++ b/src/UglyToad.PdfPig/Graphics/Colors/ColorSpaces/DeviceNColorSpaceDetails.cs
@@ -75,7 +75,7 @@
             AlternateColorSpace = alternateColorSpaceDetails;
             Attributes = attributes;
             TintFunction = tintFunction;
-            BaseType = AlternateColorSpace.Type;
+            BaseType = AlternateColorSpace.BaseType;
 
 #if NET9_0_OR_GREATER
             lookup = cache.GetAlternateLookup<ReadOnlySpan<double>>();

--- a/src/UglyToad.PdfPig/Graphics/Colors/ColorSpaces/ICCBasedColorSpaceDetails.cs
+++ b/src/UglyToad.PdfPig/Graphics/Colors/ColorSpaces/ICCBasedColorSpaceDetails.cs
@@ -26,7 +26,7 @@
         public override int NumberOfColorComponents { get; }
 
         /// <inheritdoc/>
-        public override int BaseNumberOfColorComponents => NumberOfColorComponents;
+        public override int BaseNumberOfColorComponents => AlternateColorSpace.BaseNumberOfColorComponents;
 
         /// <summary>
         /// An alternate color space that can be used in case the one specified in the stream data is not

--- a/src/UglyToad.PdfPig/Graphics/Colors/ColorSpaces/IndexedColorSpaceDetails.cs
+++ b/src/UglyToad.PdfPig/Graphics/Colors/ColorSpaces/IndexedColorSpaceDetails.cs
@@ -57,7 +57,7 @@
             BaseColorSpace = baseColorSpaceDetails ?? throw new ArgumentNullException(nameof(baseColorSpaceDetails));
             HiVal = hiVal;
             this.colorTable = colorTable;
-            BaseType = baseColorSpaceDetails.Type;
+            BaseType = baseColorSpaceDetails.BaseType;
         }
 
         /// <summary>
@@ -165,83 +165,32 @@
                 }
             }
 
-            switch (BaseType)
+            int components = BaseColorSpace.NumberOfColorComponents;
+
+            if (components == 1)
             {
-                case ColorSpace.DeviceRGB:
-                case ColorSpace.CalRGB:
-                case ColorSpace.Lab:
-                    {
-                        Span<byte> result = new byte[input.Length * 3];
-                        var i = 0;
-                        foreach (var x in input)
-                        {
-                            for (var j = 0; j < 3; ++j)
-                            {
-                                result[i++] = ColorTable[x * 3 + j];
-                            }
-                        }
+                // One index byte becomes one colour byte, so the lookup is done in place.
+                for (var i = 0; i < input.Length; ++i)
+                {
+                    ref byte b = ref input[i];
+                    b = ColorTable[b];
+                }
 
-                        return result;
-                    }
-
-                case ColorSpace.DeviceCMYK:
-                    {
-                        Span<byte> result = new byte[input.Length * 4];
-                        var i = 0;
-                        foreach (var x in input)
-                        {
-                            for (var j = 0; j < 4; ++j)
-                            {
-                                result[i++] = ColorTable[x * 4 + j];
-                            }
-                        }
-
-                        return result;
-                    }
-
-                case ColorSpace.DeviceGray:
-                case ColorSpace.CalGray:
-                case ColorSpace.Separation:
-                    {
-                        for (var i = 0; i < input.Length; ++i)
-                        {
-                            ref byte b = ref input[i];
-                            b = ColorTable[b];
-                        }
-
-                        return input;
-                    }
-
-                case ColorSpace.DeviceN:
-                case ColorSpace.ICCBased:
-                    {
-                        int i = 0;
-                        if (BaseColorSpace.NumberOfColorComponents == 1)
-                        {
-                            // In place
-                            for (i = 0; i < input.Length; ++i)
-                            {
-                                ref byte b = ref input[i];
-                                b = ColorTable[b];
-                            }
-
-                            return input;
-                        }
-
-                        Span<byte> result = new byte[input.Length * BaseColorSpace.NumberOfColorComponents];
-                        foreach (var x in input)
-                        {
-                            for (var j = 0; j < BaseColorSpace.NumberOfColorComponents; ++j)
-                            {
-                                result[i++] = ColorTable[x * BaseColorSpace.NumberOfColorComponents + j];
-                            }
-                        }
-
-                        return result;
-                    }
+                return input;
             }
 
-            return input;
+            Span<byte> result = new byte[input.Length * components];
+            int index = 0;
+
+            foreach (var x in input)
+            {
+                for (var j = 0; j < components; ++j)
+                {
+                    result[index++] = ColorTable[x * components + j];
+                }
+            }
+
+            return result;
         }
 
         /// <inheritdoc/>

--- a/src/UglyToad.PdfPig/Graphics/Colors/ColorSpaces/SeparationColorSpaceDetails.cs
+++ b/src/UglyToad.PdfPig/Graphics/Colors/ColorSpaces/SeparationColorSpaceDetails.cs
@@ -64,7 +64,7 @@
             Name = name;
             AlternateColorSpace = alternateColorSpaceDetails;
             TintFunction = tintFunction;
-            BaseType = AlternateColorSpace.Type;
+            BaseType = AlternateColorSpace.BaseType;
         }
 
         /// <inheritdoc/>


### PR DESCRIPTION
This is in order to have consistency with colour spaces `BaseType` as it started to have different meaning