### PR TITLE
Use the operands values an uncoloured tiling pattern is selected with

### DIFF
--- a/src/UglyToad.PdfPig.Tests/Graphics/Colors/UncolouredTilingPatternColorTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Graphics/Colors/UncolouredTilingPatternColorTests.cs
@@ -1,0 +1,283 @@
+﻿namespace UglyToad.PdfPig.Tests.Graphics.Colors
+{
+    using System;
+    using System.Collections.Generic;
+    using PdfPig.Core;
+    using PdfPig.Functions;
+    using PdfPig.Graphics;
+    using PdfPig.Graphics.Colors;
+    using PdfPig.Tokens;
+    using Xunit;
+
+    /// <summary>
+    /// <c>SCN</c>/<c>scn</c> selects a pattern by name, and for an uncoloured tiling pattern
+    /// (<c>/PaintType 2</c>) it also supplies the colour the pattern's cell is painted in, as operands in the
+    /// underlying colour space the Pattern space was declared with (8.7.3.3). The graphics state keeps those
+    /// operands rather than dropping them, so the colour they select is available to every consumer.
+    /// </summary>
+    public class UncolouredTilingPatternColorTests
+    {
+        private static readonly NameToken PatternName = NameToken.Create("P0");
+
+        private static TilingPatternColor UncolouredPattern()
+            => TilingPattern(PatternPaintType.Uncoloured);
+
+        private static TilingPatternColor ColouredPattern()
+            => TilingPattern(PatternPaintType.Coloured);
+
+        private static TilingPatternColor TilingPattern(PatternPaintType paintType)
+        {
+            var empty = new DictionaryToken(new Dictionary<NameToken, IToken>());
+
+            return new TilingPatternColor(
+                TransformationMatrix.Identity,
+                empty,
+                new StreamToken(empty, []),
+                paintType,
+                PatternTilingType.ConstantSpacing,
+                new PdfRectangle(0, 0, 1, 1),
+                1,
+                1,
+                empty,
+                ReadOnlyMemory<byte>.Empty);
+        }
+
+        private static ShadingPatternColor ShadingPattern()
+        {
+            var empty = new DictionaryToken(new Dictionary<NameToken, IToken>());
+
+            var function = new PdfFunctionType2(
+                new DictionaryToken(new Dictionary<NameToken, IToken>
+                {
+                    { NameToken.FunctionType, new NumericToken(2) }
+                }),
+                new ArrayToken([new NumericToken(0), new NumericToken(1)]),
+                null,
+                new ArrayToken([new NumericToken(0)]),
+                new ArrayToken([new NumericToken(1)]),
+                1);
+
+            var shading = new AxialShading(
+                antiAlias: false,
+                shadingDictionary: empty,
+                colorSpace: DeviceGrayColorSpaceDetails.Instance,
+                bbox: null,
+                background: null,
+                coords: [0.0, 0.0, 1.0, 0.0],
+                domain: [0.0, 1.0],
+                functions: [function],
+                extend: [false, false]);
+
+            return new ShadingPatternColor(TransformationMatrix.Identity, empty, empty, shading);
+        }
+
+        /// <summary>
+        /// A Pattern colour space over <paramref name="underlying"/>, and a graphics state to select into.
+        /// A <see langword="null"/> underlying space is how a bare <c>/Pattern</c> - a coloured tiling
+        /// pattern or a shading pattern, which supply their own colours - is parsed.
+        /// </summary>
+        private static (CurrentGraphicsState State, PatternColorSpaceDetails Space) Build(
+            ColorSpaceDetails? underlying, PatternColor? pattern = null)
+        {
+            var patterns = new Dictionary<NameToken, PatternColor> { { PatternName, pattern ?? UncolouredPattern() } };
+
+            return (new CurrentGraphicsState(),
+                new PatternColorSpaceDetails(patterns, underlying!));
+        }
+
+        [Fact]
+        public void TheOperandsSelectTheColourTheCellIsPaintedIn()
+        {
+            var (state, space) = Build(DeviceRgbColorSpaceDetails.Instance);
+
+            state.SetNonStrokingPatternColor(space, PatternName, [1.0, 0.0, 0.0]);
+
+            // The current colour is still the pattern - that part is unchanged.
+            Assert.IsType<TilingPatternColor>(state.CurrentNonStrokingColor);
+
+            var (r, g, b) = state.CurrentNonStrokingUnderlyingColor!.ToRGBValues();
+            Assert.Equal(1.0, r);
+            Assert.Equal(0.0, g);
+            Assert.Equal(0.0, b);
+        }
+
+        [Fact]
+        public void TheStrokingOperatorKeepsItsOwnOperands()
+        {
+            var (state, space) = Build(DeviceRgbColorSpaceDetails.Instance);
+
+            state.SetStrokingPatternColor(space, PatternName, [0.0, 1.0, 0.0]);
+
+            var (r, g, b) = state.CurrentStrokingUnderlyingColor!.ToRGBValues();
+            Assert.Equal(0.0, r);
+            Assert.Equal(1.0, g);
+            Assert.Equal(0.0, b);
+
+            // Selecting a stroking pattern says nothing about the non-stroking colour.
+            Assert.Null(state.CurrentNonStrokingUnderlyingColor);
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void NoOperandsMeansTheUnderlyingSpacesInitialColour(bool nullRatherThanEmpty)
+        {
+            var (state, space) = Build(DeviceRgbColorSpaceDetails.Instance);
+
+            state.SetNonStrokingPatternColor(space, PatternName, nullRatherThanEmpty ? null : []);
+
+            // Not the same as "no underlying colour": the space still has an initial colour, and DeviceRGB's
+            // is black. Empty and null must not be told apart - scn writes an empty operand list.
+            var (r, g, b) = state.CurrentNonStrokingUnderlyingColor!.ToRGBValues();
+            Assert.Equal(0.0, r);
+            Assert.Equal(0.0, g);
+            Assert.Equal(0.0, b);
+        }
+
+        [Fact]
+        public void AColouredPatternHasNoUnderlyingColour()
+        {
+            // A bare /Pattern colour space declares no underlying space, because the pattern's own content
+            // stream sets the colours.
+            var (state, space) = Build(underlying: null);
+
+            state.SetNonStrokingPatternColor(space, PatternName, []);
+
+            Assert.IsType<TilingPatternColor>(state.CurrentNonStrokingColor);
+            Assert.Null(state.CurrentNonStrokingUnderlyingColor);
+        }
+
+        [Fact]
+        public void AShadingPatternHasNoUnderlyingColourEvenOverADeclaredUnderlyingSpace()
+        {
+            // A shading pattern paints the colours its shading defines, so there is no colour to tint its
+            // content with. It is normally selected from a bare /Pattern space, which would settle this -
+            // but the space is declared in the resource dictionary while the pattern is chosen per scn, so
+            // a [/Pattern /DeviceRGB] space can be left in force over one. The pattern is what knows.
+            var (state, space) = Build(DeviceRgbColorSpaceDetails.Instance, pattern: ShadingPattern());
+
+            state.SetNonStrokingPatternColor(space, PatternName, []);
+
+            Assert.IsType<ShadingPatternColor>(state.CurrentNonStrokingColor);
+            Assert.Null(state.CurrentNonStrokingUnderlyingColor);
+        }
+
+        [Fact]
+        public void AColouredTilingPatternHasNoUnderlyingColourEvenOverADeclaredUnderlyingSpace()
+        {
+            // /PaintType 1: the pattern's own content stream sets its colours, so as with a shading pattern
+            // there is nothing for an underlying colour to mean.
+            var (state, space) = Build(DeviceRgbColorSpaceDetails.Instance, pattern: ColouredPattern());
+
+            state.SetNonStrokingPatternColor(space, PatternName, []);
+
+            Assert.Null(state.CurrentNonStrokingUnderlyingColor);
+        }
+
+        [Fact]
+        public void AnUnsupportedUnderlyingSpaceHasNoUnderlyingColour()
+        {
+            var (state, space) = Build(UnsupportedColorSpaceDetails.Instance);
+
+            state.SetNonStrokingPatternColor(space, PatternName, [0.5]);
+
+            Assert.Null(state.CurrentNonStrokingUnderlyingColor);
+        }
+
+        [Fact]
+        public void OperandsThatDoNotFitTheUnderlyingSpaceYieldNoColourRatherThanThrowing()
+        {
+            // ColorSpaceDetails.GetColor throws on a component count it did not expect. This conversion
+            // happens while the content stream is processed, so a /Pattern array that disagrees with the
+            // operator must not take down every consumer of the page.
+            var (state, space) = Build(DeviceRgbColorSpaceDetails.Instance);
+
+            var exception = Record.Exception(
+                () => state.SetNonStrokingPatternColor(space, PatternName, [0.5]));
+
+            Assert.Null(exception);
+            Assert.Null(state.CurrentNonStrokingUnderlyingColor);
+
+            // The pattern itself still selected, so painting it is still possible.
+            Assert.IsType<TilingPatternColor>(state.CurrentNonStrokingColor);
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void AnUnderlyingSpaceThatCannotConvertYieldsNoColourRatherThanThrowing(bool withOperands)
+        {
+            // A component count that fits is not on its own enough. A Separation or DeviceN space runs the
+            // operands through a tint transform, an arbitrary function that can fail on values it does not
+            // accept, and deriving the initial colour goes through the same machinery. Neither failure is
+            // any more fatal than a count that does not fit.
+            var (state, space) = Build(new UnconvertibleColorSpaceDetails());
+
+            double[]? operands = withOperands ? [0.5] : null;
+
+            var exception = Record.Exception(
+                () => state.SetNonStrokingPatternColor(space, PatternName, operands));
+
+            Assert.Null(exception);
+            Assert.Null(state.CurrentNonStrokingUnderlyingColor);
+
+            // The pattern itself still selected, so painting it is still possible.
+            Assert.IsType<TilingPatternColor>(state.CurrentNonStrokingColor);
+        }
+
+        /// <summary>
+        /// A one-component space that cannot convert anything, standing in for a tint transform that fails.
+        /// </summary>
+        private sealed class UnconvertibleColorSpaceDetails : ColorSpaceDetails
+        {
+            public UnconvertibleColorSpaceDetails() : base(ColorSpace.DeviceGray)
+            {
+            }
+
+            public override int NumberOfColorComponents => 1;
+
+            public override int BaseNumberOfColorComponents => 1;
+
+            public override IColor GetColor(ReadOnlySpan<double> values) => throw new InvalidOperationException();
+
+            public override void GetRgb(ReadOnlySpan<double> values, out double r, out double g, out double b)
+                => throw new InvalidOperationException();
+
+            public override IColor? GetInitializeColor() => throw new InvalidOperationException();
+
+            internal override double[] Process(params double[] values) => throw new InvalidOperationException();
+
+            internal override Span<byte> Transform(Span<byte> decoded) => throw new InvalidOperationException();
+        }
+
+        [Fact]
+        public void AnOrdinaryColourHasNoUnderlyingColour()
+        {
+            // The property must answer only for patterns, not hand back the current colour under another
+            // name.
+            var state = new CurrentGraphicsState();
+
+            state.SetNonStrokingColor(DeviceRgbColorSpaceDetails.Instance, [1.0, 0.0, 0.0]);
+
+            Assert.NotNull(state.CurrentNonStrokingColor);
+            Assert.Null(state.CurrentNonStrokingUnderlyingColor);
+        }
+
+        [Fact]
+        public void DeepCloneCarriesBothThePatternAndItsUnderlyingColour()
+        {
+            var (state, space) = Build(DeviceRgbColorSpaceDetails.Instance);
+
+            state.SetNonStrokingPatternColor(space, PatternName, [1.0, 0.0, 0.0]);
+
+            var clone = state.DeepClone();
+
+            Assert.IsType<TilingPatternColor>(clone.CurrentNonStrokingColor);
+
+            var (r, g, b) = clone.CurrentNonStrokingUnderlyingColor!.ToRGBValues();
+            Assert.Equal(1.0, r);
+            Assert.Equal(0.0, g);
+            Assert.Equal(0.0, b);
+        }
+    }
+}

--- a/src/UglyToad.PdfPig/Graphics/ColorSpaceContext.cs
+++ b/src/UglyToad.PdfPig/Graphics/ColorSpaceContext.cs
@@ -28,7 +28,7 @@
                 return;
             }
 
-            currentStateFunc().CurrentStrokingColor = CurrentStrokingColorSpace.GetInitializeColor();
+            currentStateFunc().SetStrokingColor(CurrentStrokingColorSpace, null);
         }
 
         public void SetStrokingColor(double[] operands, NameToken? patternName)
@@ -38,14 +38,17 @@
                 return;
             }
 
-            if (patternName is not null && CurrentStrokingColorSpace.Type == ColorSpace.Pattern)
+            var state = currentStateFunc();
+            if (patternName is not null && CurrentStrokingColorSpace is PatternColorSpaceDetails patternCs)
             {
-                currentStateFunc().CurrentStrokingColor = ((PatternColorSpaceDetails)CurrentStrokingColorSpace).GetColor(patternName);
-                // TODO - use operands values for Uncoloured Tiling Patterns
+                // The operands travel with the pattern: an uncoloured tiling pattern (/PaintType 2) paints
+                // its cell in the colour they select from the underlying colour space (8.7.3.3), read back
+                // through CurrentGraphicsState.CurrentStrokingUnderlyingColor.
+                state.SetStrokingPatternColor(patternCs, patternName, operands);
             }
             else
             {
-                currentStateFunc().CurrentStrokingColor = CurrentStrokingColorSpace.GetColor(operands);
+                state.SetStrokingColor(CurrentStrokingColorSpace, operands);
             }
         }
 
@@ -72,7 +75,7 @@
                 return;
             }
 
-            currentStateFunc().CurrentNonStrokingColor = CurrentNonStrokingColorSpace.GetInitializeColor();
+            currentStateFunc().SetNonStrokingColor(CurrentNonStrokingColorSpace, null);
         }
 
         public void SetNonStrokingColor(double[] operands, NameToken? patternName)
@@ -82,14 +85,15 @@
                 return;
             }
 
-            if (patternName is not null && CurrentNonStrokingColorSpace.Type == ColorSpace.Pattern)
+            var state = currentStateFunc();
+            if (patternName is not null && CurrentNonStrokingColorSpace is PatternColorSpaceDetails patternCs)
             {
-                currentStateFunc().CurrentNonStrokingColor = ((PatternColorSpaceDetails)CurrentNonStrokingColorSpace).GetColor(patternName);
-                // TODO - use operands values for Uncoloured Tiling Patterns
+                // See the stroking counterpart: the operands select the uncoloured tiling pattern's colour.
+                state.SetNonStrokingPatternColor(patternCs, patternName, operands);
             }
             else
             {
-                currentStateFunc().CurrentNonStrokingColor = CurrentNonStrokingColorSpace.GetColor(operands);
+                state.SetNonStrokingColor(CurrentNonStrokingColorSpace, operands);
             }
         }
 
@@ -124,12 +128,12 @@
             if (stroking)
             {
                 CurrentStrokingColorSpace = colorSpace;
-                state.CurrentStrokingColor = color;
+                state.SetStrokingColor(color);
             }
             else
             {
                 CurrentNonStrokingColorSpace = colorSpace;
-                state.CurrentNonStrokingColor = color;
+                state.SetNonStrokingColor(color);
             }
         }
 

--- a/src/UglyToad.PdfPig/Graphics/CurrentGraphicsState.cs
+++ b/src/UglyToad.PdfPig/Graphics/CurrentGraphicsState.cs
@@ -1,11 +1,10 @@
-﻿#nullable disable
-
-// ReSharper disable RedundantDefaultMemberInitializer
+﻿// ReSharper disable RedundantDefaultMemberInitializer
 namespace UglyToad.PdfPig.Graphics
 {
     using Colors;
     using Core;
     using PdfPig.Core;
+    using Tokens;
 
     /// <summary>
     /// The state of the current graphics control parameters set by operations in the content stream.
@@ -23,7 +22,7 @@ namespace UglyToad.PdfPig.Graphics
         /// <summary>
         /// The <see cref="CurrentFontState"/> for this graphics state.
         /// </summary>
-        public CurrentFontState FontState { get; set; } = new CurrentFontState();
+        public CurrentFontState? FontState { get; set; } = new CurrentFontState();
 
         /// <summary>
         /// Thickness in user space units of path to be stroked.
@@ -81,7 +80,7 @@ namespace UglyToad.PdfPig.Graphics
         /// that shall be used in the transparent imaging model, or the name None if
         /// no such mask is specified.
         /// </summary>
-        public SoftMask SoftMask { get; set; }
+        public SoftMask? SoftMask { get; set; }
 
         /// <summary>
         /// Maps positions from user coordinates to device coordinates.
@@ -91,17 +90,134 @@ namespace UglyToad.PdfPig.Graphics
         /// <summary>
         /// The active colorspaces for this content stream.
         /// </summary>
-        public IColorSpaceContext ColorSpaceContext { get; set; }
+        public IColorSpaceContext? ColorSpaceContext { get; set; }
+
+        private PdfColorInfo strokingColorInfo;
+        private PdfColorInfo nonStrokingColorInfo;
+
+        private const string ColorSetterRemoved = "Setting the current colour directly is no longer supported. Use the relevant 'Set[...]StrokingColor()' instead.";
 
         /// <summary>
         /// The current active stroking color for paths.
         /// </summary>
-        public IColor CurrentStrokingColor { get; set; }
+        public IColor? CurrentStrokingColor
+        {
+            get => strokingColorInfo.Color;
+
+            [Obsolete(ColorSetterRemoved, error: true)]
+            set => throw new NotSupportedException(ColorSetterRemoved);
+        }
 
         /// <summary>
         /// The current active non-stroking color for text and fill.
         /// </summary>
-        public IColor CurrentNonStrokingColor { get; set; }
+        public IColor? CurrentNonStrokingColor
+        {
+            get => nonStrokingColorInfo.Color;
+
+            [Obsolete(ColorSetterRemoved, error: true)]
+            set => throw new NotSupportedException(ColorSetterRemoved);
+        }
+
+        /// <summary>
+        /// The colour an <b>uncoloured</b> tiling pattern selected for stroking paints its content in, or
+        /// <see langword="null"/> when the current stroking colour is not such a pattern.
+        /// <para>
+        /// <c>SCN</c> selects a pattern by name, and for <c>/PaintType 2</c> it also supplies the colour to
+        /// paint the pattern's cell in, as operands in the underlying colour space the Pattern space was
+        /// declared with (8.7.3.3). <see cref="CurrentStrokingColor"/> answers the pattern; this answers
+        /// that colour. It is <see langword="null"/> for a coloured tiling pattern, a shading pattern, and
+        /// any non-pattern colour.
+        /// </para>
+        /// </summary>
+        public IColor? CurrentStrokingUnderlyingColor => strokingColorInfo.UnderlyingColor;
+
+        /// <summary>
+        /// The non-stroking counterpart of <see cref="CurrentStrokingUnderlyingColor"/>, selected by <c>scn</c>.
+        /// </summary>
+        public IColor? CurrentNonStrokingUnderlyingColor => nonStrokingColorInfo.UnderlyingColor;
+
+        /// <summary>
+        /// Select the stroking colour from the operands it was written with.
+        /// </summary>
+        /// <param name="colorSpace">The colour space the operands belong to.</param>
+        /// <param name="operands">The selected component values, or <see langword="null"/> for the colour
+        /// space's own initial colour. Stored by reference, the caller must not mutate the array afterward.
+        /// </param>
+        public void SetStrokingColor(ColorSpaceDetails colorSpace, double[]? operands)
+        {
+            strokingColorInfo = PdfColorInfo.FromOperands(colorSpace, operands);
+        }
+
+        /// <summary>
+        /// The non-stroking counterpart of <see cref="SetStrokingColor(ColorSpaceDetails, double[])"/>.
+        /// </summary>
+        /// <param name="colorSpace">The colour space the operands belong to.</param>
+        /// <param name="operands">The selected component values, or <see langword="null"/> for the colour
+        /// space's own initial colour. Stored by reference, the caller must not mutate the array afterward.</param>
+        public void SetNonStrokingColor(ColorSpaceDetails colorSpace, double[]? operands)
+        {
+            nonStrokingColorInfo = PdfColorInfo.FromOperands(colorSpace, operands);
+        }
+
+        /// <summary>
+        /// Select a Pattern colour for stroking, by name, together with any operands accompanying it.
+        /// <para>
+        /// The pattern itself is fixed, but for an uncoloured tiling pattern the operands select the colour
+        /// its content is painted in; read it back through <see cref="CurrentStrokingUnderlyingColor"/>.
+        /// </para>
+        /// </summary>
+        /// <param name="patternColorSpace">The Pattern colour space the name is resolved against.</param>
+        /// <param name="patternName">The name of an entry in the <c>/Pattern</c> subdictionary of the current resource dictionary.</param>
+        /// <param name="operands">The component values accompanying the name, in the pattern's underlying colour space, or empty
+        /// when there are none. Stored by reference, the caller must not mutate the array afterward.</param>
+        public void SetStrokingPatternColor(PatternColorSpaceDetails patternColorSpace, NameToken patternName,
+            double[]? operands)
+        {
+            strokingColorInfo = PdfColorInfo.ForPattern(patternColorSpace, patternName, operands);
+        }
+
+        /// <summary>
+        /// The non-stroking counterpart of <see cref="SetStrokingPatternColor"/>.
+        /// </summary>
+        /// <param name="patternColorSpace">The Pattern colour space the name is resolved against.</param>
+        /// <param name="patternName">The name of an entry in the <c>/Pattern</c> subdictionary of the current resource dictionary.</param>
+        /// <param name="operands">The component values accompanying the name, in the pattern's underlying colour space, or empty
+        /// when there are none. Stored by reference, the caller must not mutate the array afterward.</param>
+        public void SetNonStrokingPatternColor(PatternColorSpaceDetails patternColorSpace, NameToken patternName,
+            double[]? operands)
+        {
+            nonStrokingColorInfo = PdfColorInfo.ForPattern(patternColorSpace, patternName, operands);
+        }
+
+        /// <summary>
+        /// Record an already-converted stroking colour, with no colour space or operands behind it.
+        /// <para>
+        /// Use it only for a colour a consumer has deliberately computed for itself. A colour selected from
+        /// operands belongs on <see cref="SetStrokingColor(ColorSpaceDetails, double[])"/> and a Pattern
+        /// colour on <see cref="SetStrokingPatternColor"/>.
+        /// </para>
+        /// </summary>
+        /// <param name="color">
+        /// The colour, or <see langword="null"/>, which is what a Pattern colour space's initial colour is,
+        /// and which <see cref="CurrentStrokingColor"/> then hands back.
+        /// </param>
+        public void SetStrokingColor(IColor? color)
+        {
+            strokingColorInfo = PdfColorInfo.Fixed(color);
+        }
+
+        /// <summary>
+        /// The non-stroking counterpart of <see cref="SetStrokingColor(IColor)"/>.
+        /// </summary>
+        /// <param name="color">
+        /// The colour, or <see langword="null"/>, which is what a Pattern colour space's initial colour is,
+        /// and which <see cref="CurrentNonStrokingColor"/> then hands back.
+        /// </param>
+        public void SetNonStrokingColor(IColor? color)
+        {
+            nonStrokingColorInfo = PdfColorInfo.Fixed(color);
+        }
 
         /// <summary>
         /// The current blend mode.
@@ -160,8 +276,8 @@ namespace UglyToad.PdfPig.Graphics
                 OverprintMode = OverprintMode,
                 Smoothness = Smoothness,
                 StrokeAdjustment = StrokeAdjustment,
-                CurrentStrokingColor = CurrentStrokingColor,
-                CurrentNonStrokingColor = CurrentNonStrokingColor,
+                strokingColorInfo = strokingColorInfo,
+                nonStrokingColorInfo = nonStrokingColorInfo,
                 CurrentClippingPath = CurrentClippingPath,
                 ColorSpaceContext = ColorSpaceContext?.DeepClone(),
                 BlendMode = BlendMode,

--- a/src/UglyToad.PdfPig/Graphics/PdfColorInfo.cs
+++ b/src/UglyToad.PdfPig/Graphics/PdfColorInfo.cs
@@ -1,0 +1,143 @@
+﻿namespace UglyToad.PdfPig.Graphics
+{
+    using Colors;
+    using Tokens;
+
+    /// <summary>
+    /// A current colour, together with the Pattern it was selected through when it was selected that way.
+    /// <para>
+    /// A Pattern colour is two things at once: the pattern itself, which is what the colour <i>is</i>, and
+    /// (for an uncoloured tiling pattern) the colour its cell is painted in, which is selected by the same
+    /// operator from a different colour space.
+    /// </para>
+    /// </summary>
+    internal readonly struct PdfColorInfo
+    {
+        /// <summary>
+        /// What the operands convert to. For a Pattern colour this is the <i>underlying</i> colour an
+        /// uncoloured tiling pattern paints with, and <see cref="patternColor"/> is the colour itself.
+        /// </summary>
+        private readonly IColor? color;
+
+        /// <summary>
+        /// The Pattern colour, when one was selected; <see langword="null"/> otherwise. A pattern is chosen
+        /// by name rather than by component values, so it never converts.
+        /// </summary>
+        private readonly IColor? patternColor;
+
+        private PdfColorInfo(IColor? color, IColor? patternColor)
+        {
+            this.color = color;
+            this.patternColor = patternColor;
+        }
+
+        /// <summary>
+        /// A colour with nothing behind it, which is what a consumer handing over an already-converted
+        /// colour stores.
+        /// </summary>
+        public static PdfColorInfo Fixed(IColor? color) => new(color, null);
+
+        /// <summary>
+        /// A colour selected in <paramref name="colorSpace"/>.
+        /// </summary>
+        /// <param name="colorSpace">The colour space the operands belong to.</param>
+        /// <param name="operands">The selected component values, or <see langword="null"/> for the colour
+        /// space's initial colour.</param>
+        public static PdfColorInfo FromOperands(ColorSpaceDetails colorSpace, double[]? operands)
+            => new(Convert(colorSpace, operands), null);
+
+        /// <summary>
+        /// A Pattern colour selected by <c>SCN</c>/<c>scn</c>. The pattern itself comes from a name, but an
+        /// <b>uncoloured</b> tiling pattern (<c>/PaintType 2</c>) also carries the colour its content is
+        /// painted in, as operands in the <i>underlying</i> colour space that the Pattern space was declared
+        /// with (8.7.3.3). Those operands are converted here and read back through
+        /// <see cref="UnderlyingColor"/>.
+        /// </summary>
+        /// <param name="patternColorSpace">The Pattern colour space the name is resolved against.</param>
+        /// <param name="patternName">The name of an entry in the <c>/Pattern</c> subdictionary of the current resource dictionary.</param>
+        /// <param name="operands">The component values accompanying the name, in the underlying colour space.
+        /// Empty or <see langword="null"/> is the normal case for a coloured tiling pattern and for a shading
+        /// pattern, neither of which has an underlying colour at all. For an uncoloured tiling pattern it is
+        /// malformed, the operator owes a colour and supplied none, and the underlying space's own initial
+        /// colour stands in for it.</param>
+        public static PdfColorInfo ForPattern(PatternColorSpaceDetails patternColorSpace, NameToken patternName,
+            double[]? operands)
+        {
+            // Normalise "no operands" to null so that the underlying space derives its own initial colour
+            // rather than being asked to convert an empty component list.
+            if (operands is { Length: 0 })
+            {
+                operands = null;
+            }
+
+            var patternColor = patternColorSpace.GetColor(patternName);
+            var underlyingColorSpace = GetUnderlyingColorSpace(patternColorSpace, patternColor, operands);
+
+            // No underlying colour at all: a coloured tiling pattern or a shading pattern.
+            return underlyingColorSpace is null
+                ? new PdfColorInfo(null, patternColor)
+                : new PdfColorInfo(TryConvert(underlyingColorSpace, operands), patternColor);
+        }
+
+        /// <summary>
+        /// The underlying colour space to convert <paramref name="operands"/> through, or
+        /// <see langword="null"/> when there is no usable one and the pattern therefore has no underlying
+        /// colour.
+        /// </summary>
+        private static ColorSpaceDetails? GetUnderlyingColorSpace(PatternColorSpaceDetails patternColorSpace,
+            PatternColor patternColor, double[]? operands)
+        {
+            if (patternColor is not TilingPatternColor { PaintType: PatternPaintType.Uncoloured })
+            {
+                return null;
+            }
+
+            var underlying = patternColorSpace.UnderlyingColourSpace;
+
+            if (underlying is null or UnsupportedColorSpaceDetails or PatternColorSpaceDetails)
+            {
+                return null;
+            }
+
+            if (operands is not null && operands.Length != underlying.NumberOfColorComponents)
+            {
+                return null;
+            }
+
+            return underlying;
+        }
+
+        /// <summary>
+        /// The converted colour. For a Pattern colour this is the pattern itself; see
+        /// <see cref="UnderlyingColor"/> for the colour an uncoloured tiling pattern paints in.
+        /// </summary>
+        public IColor? Color => patternColor ?? color;
+
+        /// <summary>
+        /// The colour an uncoloured tiling pattern paints its content in. <see langword="null"/> unless a
+        /// Pattern colour was selected <i>and</i> its colour space declared a usable underlying space.
+        /// </summary>
+        public IColor? UnderlyingColor => patternColor is null ? null : color;
+
+        private static IColor? Convert(ColorSpaceDetails colorSpace, double[]? operands)
+            => operands is null
+                ? colorSpace.GetInitializeColor()
+                : colorSpace.GetColor(operands);
+
+        /// <summary>
+        /// <see cref="Convert"/>, but answering <see langword="null"/> instead of throwing when the
+        /// underlying space cannot turn the operands into a colour.
+        /// </summary>
+        private static IColor? TryConvert(ColorSpaceDetails colorSpace, double[]? operands)
+        {
+            try
+            {
+                return Convert(colorSpace, operands);
+            }
+            catch
+            {
+                return null;
+            }
+        }
+    }
+}


### PR DESCRIPTION
The driver is that `SCN`/`scn` carries two things at once for an uncoloured tiling pattern (`/PaintType 2`): the pattern, selected by name, and the colour its cell is painted in, selected by component values in the underlying colour space the Pattern space was declared with (PDF 32000-1, 8.7.3.3).

A single settable `IColor` property could only hold one of them, so the operands were being discarded. The state now stores what the colour was *selected from*, not just what it converted to, which means the conversion has to happen inside the state rather than at the call site.

# Breaking changes

| # | Change |
|---|--------|
| 1 | `CurrentStrokingColor` / `CurrentNonStrokingColor` setters no longer usable |
| 2 | Uncoloured tiling pattern operands are no longer discarded |

Most affected: anyone implementing `IColorSpaceContext` themselves, or building a `CurrentGraphicsState` by hand in a custom `BaseStreamProcessor` subclass.

---

## 1. The colour setters are gone

```csharp
public IColor? CurrentStrokingColor
{
    get => strokingColorInfo.Color;

    [Obsolete(ColorSetterRemoved, error: true)]
    set => throw new NotSupportedException(ColorSetterRemoved);
}
```

Assigning either property is now a compile error (`CS0619`). Code compiled against an earlier version keeps binding to the setter and throws `NotSupportedException` at runtime instead.

Replace the assignment with whichever setter method describes where the colour came from, that is the information the state needs in order to answer `CurrentStrokingUnderlyingColor` later.

### 1a. You already have an `IColor`

The direct swap. Use it only for a colour you deliberately computed yourself; if you have the operands, prefer 1b so the pattern case keeps working.

```csharp
// Before
state.CurrentNonStrokingColor = myColor;

// After
state.SetNonStrokingColor(myColor);
```

`null` is accepted, and is what a Pattern colour space's initial colour is.

### 1b. You have operands and a colour space

This is the common case inside an `IColorSpaceContext`. Note that the state now performs the conversion, so you no longer call `GetColor` / `GetInitializeColor` yourself.

```csharp
// Before
state.CurrentStrokingColor = colorSpace.GetColor(operands);
// ...and, for the initial colour:
state.CurrentStrokingColor = colorSpace.GetInitializeColor();

// After — pass null operands for the colour space's own initial colour
state.SetStrokingColor(colorSpace, operands);
state.SetStrokingColor(colorSpace, null);
```

The array is stored by reference. Do not mutate or pool it after handing it over.

### 1c. You have a pattern name

```csharp
// Before
state.CurrentNonStrokingColor = patternColorSpace.GetColor(patternName);
// TODO - use operands values for Uncoloured Tiling Patterns

// After — the operands are no longer dropped
state.SetNonStrokingPatternColor(patternColorSpace, patternName, operands);
```

`CurrentNonStrokingColor` still answers the `PatternColor`, exactly as before. The operands now surface separately through `CurrentNonStrokingUnderlyingColor` (see 6).

### 1d. Object initialisers

`DeepClone`-style initialisers that copied the colours across need the same treatment. Because the backing state is private, a clone written outside the assembly has to go through the setter methods:

```csharp
// Before
var copy = new CurrentGraphicsState
{
    LineWidth = source.LineWidth,
    CurrentStrokingColor = source.CurrentStrokingColor,
    CurrentNonStrokingColor = source.CurrentNonStrokingColor
};

// After
var copy = new CurrentGraphicsState { LineWidth = source.LineWidth };
copy.SetStrokingColor(source.CurrentStrokingColor);
copy.SetNonStrokingColor(source.CurrentNonStrokingColor);
```

Be aware this loses the underlying colour of an uncoloured tiling pattern, because `SetStrokingColor(IColor?)` records a colour with nothing behind it. `CurrentGraphicsState.DeepClone` copies both halves correctly and needs no changes => prefer it over hand-rolled copying.

---

## 2. Uncoloured tiling pattern operands are no longer discarded

Additive, but it changes what you should be doing. Previously the operands on `SCN`/`scn` were dropped and the only way to recover the tint colour was to re-parse the content stream. Two new read-only properties now expose it:

```csharp
public IColor? CurrentStrokingUnderlyingColor { get; }
public IColor? CurrentNonStrokingUnderlyingColor { get; }
```

```csharp
if (state.CurrentNonStrokingColor is TilingPatternColor { PaintType: PatternPaintType.Uncoloured })
{
    // The colour the pattern's cell is painted in, converted through the underlying colour space.
    var tint = state.CurrentNonStrokingUnderlyingColor;
}
```

Both are null unless a Pattern colour was selected *and* it is an uncoloured tiling pattern *and* its colour space declared a usable underlying space. Specifically they stay null for:

- a coloured tiling pattern (`/PaintType 1`) and a shading pattern — these supply their own colours;
- an underlying space that is missing, unsupported, or itself a Pattern space;
- operands whose count does not match the underlying space's component count;
- an underlying space that throws while converting, such as a failing Separation or DeviceN tint transform.

Omitted operands are *not* in that list: an empty or absent operand list falls back to the underlying space's own initial colour, so the pattern still paints.

---

## Full list of new members

All additive on `CurrentGraphicsState`:

```csharp
public IColor? CurrentStrokingUnderlyingColor { get; }
public IColor? CurrentNonStrokingUnderlyingColor { get; }

public void SetStrokingColor(ColorSpaceDetails colorSpace, double[]? operands);
public void SetNonStrokingColor(ColorSpaceDetails colorSpace, double[]? operands);

public void SetStrokingPatternColor(PatternColorSpaceDetails patternColorSpace, NameToken patternName, double[]? operands);
public void SetNonStrokingPatternColor(PatternColorSpaceDetails patternColorSpace, NameToken patternName, double[]? operands);

public void SetStrokingColor(IColor? color);
public void SetNonStrokingColor(IColor? color);
```

`IColorSpaceContext` is unchanged.

---

## Finding affected code

```
rg "CurrentStrokingColor\s*=[^=]|CurrentNonStrokingColor\s*=[^=]"
```