### PR TITLE
Inflate flate streams in blocks and keep the partial output (#1404)

### DIFF
--- a/src/UglyToad.PdfPig.Tests/Filters/FlateFilterTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Filters/FlateFilterTests.cs
@@ -1,5 +1,6 @@
 ﻿namespace UglyToad.PdfPig.Tests.Filters
 {
+    using System.Text;
     using PdfPig.Core;
     using PdfPig.Filters;
     using PdfPig.Tokens;
@@ -38,6 +39,51 @@
             var text = OtherEncodings.BytesAsLatin1String(result.ToArray());
 
             Assert.StartsWith("q", text);
+        }
+
+        [Fact]
+        public void DataThatIsNoDeflateStreamDoesNotComeBackAsThoughItWereDecoded()
+        {
+            var parameters = new DictionaryToken(new Dictionary<NameToken, IToken>());
+            var input = OtherEncodings.StringAsLatin1Bytes("This is not a deflate stream.");
+
+            var decoded = filter.Decode(input, parameters, TestFilterProvider.Instance, 0);
+
+            // The input used to be handed straight back, which a caller cannot tell apart
+            // from content that happens to look like that.
+            Assert.NotEqual(input, decoded.ToArray());
+        }
+
+        [Fact]
+        public void TruncatedStreamKeepsWhatInflated()
+        {
+            var parameters = new DictionaryToken(new Dictionary<NameToken, IToken>());
+
+            // Comfortably more than one deflate block: the inflater of .NET Framework
+            // hands over completed blocks only, so a stream small enough to be a single
+            // block yields nothing there while .NET yields a prefix of it.
+            var content = new StringBuilder();
+            for (var i = 0; content.Length < 200000; i++)
+            {
+                content.Append("Line ").Append(i).Append(" of a document spanning several blocks.\n");
+            }
+
+            var original = OtherEncodings.StringAsLatin1Bytes(content.ToString());
+
+            byte[] compressed;
+            using (var inputStream = new MemoryStream(original))
+            {
+                compressed = filter.Encode(inputStream, parameters);
+            }
+
+            var half = new byte[compressed.Length / 2];
+            Array.Copy(compressed, half, half.Length);
+
+            var decoded = filter.Decode(half, parameters, TestFilterProvider.Instance, 0).ToArray();
+
+            Assert.NotEmpty(decoded);
+            Assert.True(decoded.Length < original.Length, "a truncated stream cannot yield everything");
+            Assert.Equal(original.AsSpan(0, decoded.Length).ToArray(), decoded);
         }
     }
 }

--- a/src/UglyToad.PdfPig/Filters/FlateFilter.cs
+++ b/src/UglyToad.PdfPig/Filters/FlateFilter.cs
@@ -1,6 +1,6 @@
 ﻿namespace UglyToad.PdfPig.Filters
 {
-    using Fonts;
+    using System.Buffers;
     using System;
     using System.IO;
     using System.IO.Compression;
@@ -24,6 +24,9 @@
         private const int DefaultColors = 1;
         private const int DefaultBitsPerComponent = 8;
         private const int DefaultColumns = 1;
+
+        /// <summary>How much is inflated per read; a damaged stream costs at most one block.</summary>
+        private const int BlockLength = 8192;
 
         private const byte Deflate32KbWindow = 120;
         private const byte ChecksumBits = 1;
@@ -65,21 +68,50 @@
             memoryStream.ReadByte();
             memoryStream.ReadByte();
 
-            try
-            {
-                using var deflate = new DeflateStream(memoryStream, CompressionMode.Decompress);
-                using var output = new MemoryStream((int)(input.Length * 1.5));
-                using var f = PngPredictor.WrapPredictor(output, predictor, colors, bitsPerComponent, columns);
-                
-                deflate.CopyTo(f);
-                f.Flush();
+            using var output = new MemoryStream((int)(input.Length * 1.5));
 
-                return output.AsMemory();
-            }
-            catch (InvalidDataException ex)
+            using (var deflate = new DeflateStream(memoryStream, CompressionMode.Decompress))
+            using (var f = PngPredictor.WrapPredictor(output, predictor, colors, bitsPerComponent, columns))
             {
-                throw new CorruptCompressedDataException("Invalid Flate compressed stream encountered", ex);
+                // Copied a block at a time rather than with CopyTo, because a damaged
+                // stream throws out of the read and CopyTo would discard the whole buffer
+                // it was filling. Keeping each block that did inflate is what PDFBox's
+                // FlateFilterDecoderStream does, and it is worth a lot on a large stream.
+                var block = ArrayPool<byte>.Shared.Rent(BlockLength);
+
+                try
+                {
+                    while (true)
+                    {
+                        int read;
+
+                        try
+                        {
+                            read = deflate.Read(block, 0, block.Length);
+                        }
+                        catch (InvalidDataException)
+                        {
+                            // Damaged from here on; what came before still stands.
+                            break;
+                        }
+
+                        if (read == 0)
+                        {
+                            break;
+                        }
+
+                        f.Write(block, 0, read);
+                    }
+                }
+                finally
+                {
+                    ArrayPool<byte>.Shared.Return(block);
+                }
+
+                f.Flush();
             }
+
+            return output.AsMemory();
         }
 
         /// <summary>


### PR DESCRIPTION
Part of #1404 — not `Fixes`, see below.

`FlateFilter.Decode` returned the compressed input when decompression threw, which
a caller cannot tell apart from decoded content. `Decompress` now inflates a block
at a time and keeps what it got, like `FlateFilterDecoderStream` in PDFBox. `CopyTo`
was no good for this: a damaged stream throws out of the read and the whole buffer
being filled goes with it.

Over 201 single byte corruptions of a 3,217 byte stream holding 65,550 bytes:

| | before | after |
|---|---:|---:|
| input handed back | 51 | 0 |
| nothing returned | 0 | 24 |
| partial content | 150 | 177 |

The leniency from #1254 is untouched — bad checksums still decode and the test for
the document from #1235 passes.

One behaviour change worth naming: a stream declaring `/FlateDecode` that carries
uncompressed data used to come back unchanged and now comes back empty. PDFBox
ends up in the same place, but no test document covers it.

Two tests. `DataThatIsNoDeflateStreamDoesNotComeBackAsThoughItWereDecoded` fails
without the change. `TruncatedStreamKeepsWhatInflated` is a guard, with a fixture
larger than one deflate block on purpose: below that the inflater on .NET Framework
yields nothing while .NET yields a prefix.

Green on net462, net471, net8.0 and net9.0; the library compiles for all seven
target frameworks.

This does not make the failure observable, which #1404 also asks for. There is a
route that breaks nothing and I left a note on the issue.