### PR TITLE
Bound Type 0 function /Size before allocating the sample table

### DIFF
--- a/src/UglyToad.PdfPig.Tests/Functions/PdfFunctionType0Tests.cs
+++ b/src/UglyToad.PdfPig.Tests/Functions/PdfFunctionType0Tests.cs
@@ -1,5 +1,6 @@
 ﻿namespace UglyToad.PdfPig.Tests.Functions
 {
+    using UglyToad.PdfPig.Core;
     using UglyToad.PdfPig.Functions;
     using UglyToad.PdfPig.Tests.Tokens;
     using UglyToad.PdfPig.Tokens;
@@ -210,6 +211,32 @@
             result = function0.Eval(new double[] { 0.3333 });
             Assert.Equal(3, result.Length);
             Assert.Equal(new double[] { 0.6667, 0.0, 0.3333 }, result); // 1/3 point
+        }
+
+        [Fact]
+        public void OversizedSizeThrowsInsteadOfAllocating()
+        {
+            // A crafted /Size whose product far exceeds what the (tiny) sample stream can hold used to
+            // drive an unchecked 32-bit multiply and a multi-gigabyte allocation before any bounds check.
+            // It must now fail fast with a catchable format exception.
+            DictionaryToken dictionaryToken = new DictionaryToken(new Dictionary<NameToken, IToken>()
+            {
+                { NameToken.FunctionType, new NumericToken(0) },
+                { NameToken.Domain, GetArrayToken(0, 1, 0, 1) },
+                { NameToken.Range, GetArrayToken(0, 1, 0, 1, 0, 1) },
+
+                { NameToken.BitsPerSample, new NumericToken(8) },
+                { NameToken.Size, GetArrayToken(100000, 100000) }
+            });
+
+            byte[] data = new byte[] { 0, 0, 0 };
+
+            StreamToken function = new StreamToken(dictionaryToken, data);
+
+            var func = PdfFunctionParser.Create(function, testPdfTokenScanner, testFilterProvider);
+            var function0 = func as PdfFunctionType0;
+
+            Assert.Throws<PdfDocumentFormatException>(() => function0.Eval(new double[] { 0.5, 0.5 }));
         }
     }
 }

--- a/src/UglyToad.PdfPig/Functions/PdfFunctionType0.cs
+++ b/src/UglyToad.PdfPig/Functions/PdfFunctionType0.cs
@@ -260,15 +260,32 @@ namespace UglyToad.PdfPig.Functions
         {
             if (samples is null)
             {
-                int arraySize = 1;
                 int nIn = NumberOfInputParameters;
                 int nOut = NumberOfOutputParameters;
+                int bitsPerSample = BitsPerSample;
+
+                // The number of samples is the product of the per-dimension /Size values. Compute it
+                // in 64-bit to avoid the 32-bit wraparound a crafted /Size could trigger, and reject a
+                // table that claims more samples than the sample stream can hold before allocating -
+                // otherwise a tiny document can drive a multi-gigabyte array allocation.
+                long sampleCount = 1;
                 for (int i = 0; i < nIn; i++)
                 {
-                    arraySize *= (int)sizeValues[i];
+                    sampleCount *= (long)sizeValues[i];
                 }
+
+                long maxSamples = nOut > 0 && bitsPerSample > 0
+                    ? ((long)FunctionStream!.Data.Length * 8) / ((long)nOut * bitsPerSample)
+                    : 0;
+
+                if (sampleCount <= 0 || sampleCount > maxSamples)
+                {
+                    throw new PdfDocumentFormatException(
+                        $"Type 0 function /Size implies {sampleCount} samples but the sample stream holds at most {maxSamples}.");
+                }
+
+                int arraySize = (int)sampleCount;
                 samples = new int[arraySize][];
-                int bitsPerSample = BitsPerSample;
 
                 // PDF spec 1.7 p.171:
                 // Each sample value is represented as a sequence of BitsPerSample bits.


### PR DESCRIPTION
A crafted /Size drove an unchecked 32-bit multiply and a multi-gigabyte allocation in PdfFunctionType0.GetSamples. Compute the sample count in 64-bit and reject a table larger than the sample stream can hold.