### PR TITLE
The second half of #1404: making a failure in the flate filter visible. Three commits, each standing on its own.

### DIFF
--- a/src/UglyToad.PdfPig.Tests/Filters/FlateFilterTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Filters/FlateFilterTests.cs
@@ -117,6 +117,49 @@
                 () => new FlateFilter().Decode(input, parameters, provider, 0));
         }
 
+        [Fact]
+        public void TruncationIsReportedToTheLog()
+        {
+            var parameters = new DictionaryToken(new Dictionary<NameToken, IToken>());
+
+            byte[] compressed;
+            using (var inputStream = new MemoryStream(OtherEncodings.StringAsLatin1Bytes(
+                       string.Concat(Enumerable.Repeat("a document that compresses. ", 4000)))))
+            {
+                compressed = filter.Encode(inputStream, parameters);
+            }
+
+            var half = new byte[compressed.Length / 2];
+            Array.Copy(compressed, half, half.Length);
+
+            var log = new RecordingLog();
+            var provider = new FilterProviderWithLookup(DefaultFilterProvider.Instance, log, true);
+
+            filter.Decode(half, parameters, provider, 0);
+
+            Assert.Contains(log.Warnings, x => x.Contains("ended without terminating"));
+        }
+
+        [Fact]
+        public void AnIntactStreamIsNotReported()
+        {
+            var parameters = new DictionaryToken(new Dictionary<NameToken, IToken>());
+
+            byte[] compressed;
+            using (var inputStream = new MemoryStream(OtherEncodings.StringAsLatin1Bytes(
+                       string.Concat(Enumerable.Repeat("a document that compresses. ", 4000)))))
+            {
+                compressed = filter.Encode(inputStream, parameters);
+            }
+
+            var log = new RecordingLog();
+            var provider = new FilterProviderWithLookup(DefaultFilterProvider.Instance, log, true);
+
+            filter.Decode(compressed, parameters, provider, 0);
+
+            Assert.Empty(log.Warnings);
+        }
+
         private sealed class RecordingLog : ILog
         {
             public List<string> Warnings { get; } = new List<string>();

--- a/src/UglyToad.PdfPig.Tests/Filters/FlateFilterTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Filters/FlateFilterTests.cs
@@ -160,9 +160,47 @@
             Assert.Empty(log.Warnings);
         }
 
+        [Fact]
+        public void AFailureIsReportedAndYieldsNothingRatherThanTheInput()
+        {
+            // A predictor row wide enough to overflow the length of the buffer it is
+            // allocated from. Nothing here decodes, and the input must not come back
+            // dressed as content.
+            var parameters = new DictionaryToken(new Dictionary<NameToken, IToken>
+            {
+                // The resolver only hands the parameters over when a filter is named.
+                { NameToken.Filter, NameToken.FlateDecode },
+                {
+                    NameToken.DecodeParms, new DictionaryToken(new Dictionary<NameToken, IToken>
+                    {
+                        { NameToken.Predictor, new NumericToken(12) },
+                        { NameToken.Colors, new NumericToken(32) },
+                        { NameToken.BitsPerComponent, new NumericToken(16) },
+                        { NameToken.Columns, new NumericToken(4194304) },
+                    })
+                },
+            });
+
+            byte[] compressed;
+            using (var inputStream = new MemoryStream(OtherEncodings.StringAsLatin1Bytes("content")))
+            {
+                compressed = filter.Encode(inputStream, new DictionaryToken(new Dictionary<NameToken, IToken>()));
+            }
+
+            var log = new RecordingLog();
+            var provider = new FilterProviderWithLookup(DefaultFilterProvider.Instance, log, true);
+
+            var decoded = filter.Decode(compressed, parameters, provider, 0);
+
+            Assert.NotEqual(compressed, decoded.ToArray());
+            Assert.Contains(log.Errors, x => x.StartsWith("FlateFilter:"));
+        }
+
         private sealed class RecordingLog : ILog
         {
             public List<string> Warnings { get; } = new List<string>();
+
+            public List<string> Errors { get; } = new List<string>();
 
             public void Debug(string message)
             {
@@ -174,13 +212,9 @@
 
             public void Warn(string message) => Warnings.Add(message);
 
-            public void Error(string message)
-            {
-            }
+            public void Error(string message) => Errors.Add(message);
 
-            public void Error(string message, Exception ex)
-            {
-            }
+            public void Error(string message, Exception ex) => Errors.Add(message);
         }
     }
 }

--- a/src/UglyToad.PdfPig.Tests/Filters/FlateFilterTests.cs
+++ b/src/UglyToad.PdfPig.Tests/Filters/FlateFilterTests.cs
@@ -2,6 +2,8 @@
 {
     using System.Text;
     using PdfPig.Core;
+    using PdfPig.Fonts;
+    using PdfPig.Logging;
     using PdfPig.Filters;
     using PdfPig.Tokens;
 
@@ -84,6 +86,58 @@
             Assert.NotEmpty(decoded);
             Assert.True(decoded.Length < original.Length, "a truncated stream cannot yield everything");
             Assert.Equal(original.AsSpan(0, decoded.Length).ToArray(), decoded);
+        }
+
+        [Fact]
+        public void DamageIsReportedToTheLog()
+        {
+            var log = new RecordingLog();
+            var parameters = new DictionaryToken(new Dictionary<NameToken, IToken>());
+            var input = OtherEncodings.StringAsLatin1Bytes("This is not a deflate stream.");
+
+            var provider = new FilterProviderWithLookup(DefaultFilterProvider.Instance, log, true);
+
+            new FlateFilter().Decode(input, parameters, provider, 0);
+
+            Assert.Contains(log.Warnings, x => x.StartsWith("FlateFilter:"));
+        }
+
+        [Fact]
+        public void DamageRaisesWhenTheCallerAskedNotToBeLenient()
+        {
+            var parameters = new DictionaryToken(new Dictionary<NameToken, IToken>());
+            var input = OtherEncodings.StringAsLatin1Bytes("This is not a deflate stream.");
+
+            var provider = new FilterProviderWithLookup(
+                DefaultFilterProvider.Instance,
+                new RecordingLog(),
+                useLenientParsing: false);
+
+            Assert.Throws<CorruptCompressedDataException>(
+                () => new FlateFilter().Decode(input, parameters, provider, 0));
+        }
+
+        private sealed class RecordingLog : ILog
+        {
+            public List<string> Warnings { get; } = new List<string>();
+
+            public void Debug(string message)
+            {
+            }
+
+            public void Debug(string message, Exception ex)
+            {
+            }
+
+            public void Warn(string message) => Warnings.Add(message);
+
+            public void Error(string message)
+            {
+            }
+
+            public void Error(string message, Exception ex)
+            {
+            }
         }
     }
 }

--- a/src/UglyToad.PdfPig/Filters/FilterProviderWithLookup.cs
+++ b/src/UglyToad.PdfPig/Filters/FilterProviderWithLookup.cs
@@ -8,14 +8,31 @@
     using Tokenization.Scanner;
     using Tokens;
     using UglyToad.PdfPig.Util;
+    using Logging;
 
-    internal class FilterProviderWithLookup : ILookupFilterProvider
+    internal class FilterProviderWithLookup : ILookupFilterProvider, IFilterContext
     {
         private readonly IFilterProvider inner;
 
-        public FilterProviderWithLookup(IFilterProvider inner)
+        /// <inheritdoc />
+        public ILog Log { get; }
+
+        /// <inheritdoc />
+        public bool UseLenientParsing { get; }
+
+        public FilterProviderWithLookup(IFilterProvider inner, ILog log, bool useLenientParsing)
         {
             this.inner = inner;
+            Log = log;
+            UseLenientParsing = useLenientParsing;
+        }
+
+        /// <summary>
+        /// Without a log, and lenient, for a caller that decodes outside a document.
+        /// </summary>
+        public FilterProviderWithLookup(IFilterProvider inner)
+            : this(inner, new NoOpLog(), true)
+        {
         }
 
         public IReadOnlyList<IFilter> GetFilters(DictionaryToken dictionary)

--- a/src/UglyToad.PdfPig/Filters/FlateFilter.cs
+++ b/src/UglyToad.PdfPig/Filters/FlateFilter.cs
@@ -1,6 +1,7 @@
 ﻿namespace UglyToad.PdfPig.Filters
 {
     using System.Buffers;
+    using Fonts;
     using System;
     using System.IO;
     using System.IO.Compression;
@@ -47,7 +48,14 @@
                 var bitsPerComponent = parameters.GetIntOrDefault(NameToken.BitsPerComponent, DefaultBitsPerComponent);
                 var columns = parameters.GetIntOrDefault(NameToken.Columns, DefaultColumns);
 
-                return Decompress(input, predictor, colors, bitsPerComponent, columns);
+                return Decompress(input, predictor, colors, bitsPerComponent, columns,
+                    filterProvider as IFilterContext);
+            }
+            catch (CorruptCompressedDataException)
+            {
+                // Raised only when the caller asked not to be lenient, so it is the
+                // answer they wanted rather than something to swallow.
+                throw;
             }
             catch
             {
@@ -61,7 +69,8 @@
             int predictor,
             int colors,
             int bitsPerComponent,
-            int columns)
+            int columns,
+            IFilterContext? context)
         {
             using var memoryStream = MemoryHelper.AsReadOnlyMemoryStream(input);
             // The first 2 bytes are the header which DeflateStream does not support.
@@ -89,9 +98,18 @@
                         {
                             read = deflate.Read(block, 0, block.Length);
                         }
-                        catch (InvalidDataException)
+                        catch (InvalidDataException exception)
                         {
                             // Damaged from here on; what came before still stands.
+                            if (context?.UseLenientParsing == false)
+                            {
+                                throw new CorruptCompressedDataException(
+                                    "Invalid Flate compressed stream encountered", exception);
+                            }
+
+                            context?.Log.Warn(
+                                "FlateFilter: damaged deflate stream, keeping the "
+                                + $"{output.Length} bytes that inflated. {exception.Message}");
                             break;
                         }
 

--- a/src/UglyToad.PdfPig/Filters/FlateFilter.cs
+++ b/src/UglyToad.PdfPig/Filters/FlateFilter.cs
@@ -41,6 +41,7 @@
             var parameters = DecodeParameterResolver.GetFilterParameters(streamDictionary, filterIndex);
 
             var predictor = parameters.GetIntOrDefault(NameToken.Predictor, -1);
+            var context = filterProvider as IFilterContext;
 
             try
             {
@@ -48,8 +49,7 @@
                 var bitsPerComponent = parameters.GetIntOrDefault(NameToken.BitsPerComponent, DefaultBitsPerComponent);
                 var columns = parameters.GetIntOrDefault(NameToken.Columns, DefaultColumns);
 
-                return Decompress(input, predictor, colors, bitsPerComponent, columns,
-                    filterProvider as IFilterContext);
+                return Decompress(input, predictor, colors, bitsPerComponent, columns, context);
             }
             catch (CorruptCompressedDataException)
             {
@@ -57,12 +57,30 @@
                 // answer they wanted rather than something to swallow.
                 throw;
             }
-            catch
+            catch (Exception exception)
             {
-                // ignored.
-            }
+                // This used to hand the compressed input back without a word. Nothing
+                // above can tell that apart from content, so a stream that failed to
+                // decode arrived at the checks looking like a document full of noise -
+                // and a defect in here looked the same, which is the more expensive
+                // half: the failure is invisible to a test run as well.
+                //
+                // Every other filter in this folder lets its exceptions out. This one
+                // keeps catching because it is the filter that meets damaged documents,
+                // but it now says so and returns nothing rather than the input, and it
+                // steps aside entirely for a caller who asked not to be lenient.
+                if (context?.UseLenientParsing == false)
+                {
+                    throw;
+                }
 
-            return input;
+                context?.Log.Error(
+                    $"FlateFilter: {exception.GetType().Name} while decoding, "
+                    + "no content recovered.",
+                    exception);
+
+                return Memory<byte>.Empty;
+            }
         }
 
         private static Memory<byte> Decompress(Memory<byte> input,

--- a/src/UglyToad.PdfPig/Filters/FlateFilter.cs
+++ b/src/UglyToad.PdfPig/Filters/FlateFilter.cs
@@ -72,10 +72,8 @@
             int columns,
             IFilterContext? context)
         {
-            using var memoryStream = MemoryHelper.AsReadOnlyMemoryStream(input);
             // The first 2 bytes are the header which DeflateStream does not support.
-            memoryStream.ReadByte();
-            memoryStream.ReadByte();
+            using var memoryStream = new TailAwareStream(input, 2);
 
             using var output = new MemoryStream((int)(input.Length * 1.5));
 
@@ -129,7 +127,87 @@
                 f.Flush();
             }
 
-            return output.AsMemory();
+            // Read before anything asks the stream itself: where there is no predictor
+            // the wrapper above is the output stream, so it has just been disposed and
+            // its Length would raise.
+            var decoded = output.AsMemory();
+
+            if (memoryStream.ConsumedEverything)
+            {
+                // A deflate stream that ends properly stops at its final block and
+                // leaves whatever follows - the zlib checksum, normally - untouched.
+                // Nothing left over therefore means the data ran out before the
+                // inflater was done. Not conclusive: a producer that writes no
+                // checksum ends here too, which is why this only warns.
+                context?.Log.Warn(
+                    "FlateFilter: the compressed data ended without terminating, "
+                    + $"keeping the {decoded.Length} bytes that inflated.");
+            }
+
+            return decoded;
+        }
+
+        /// <summary>
+        /// A read only view over the input that serves the bulk in one go and the last
+        /// few bytes one at a time.
+        /// </summary>
+        /// <remarks>
+        /// Only so that <see cref="ConsumedEverything"/> means something.
+        /// <see cref="DeflateStream"/> reads ahead into a buffer of its own, so over a
+        /// plain <see cref="MemoryStream"/> the position says nothing about how far the
+        /// inflater actually got. Holding the tail back a byte at a time costs at most
+        /// a few dozen extra reads per stream and makes the difference visible.
+        /// </remarks>
+        private sealed class TailAwareStream : Stream
+        {
+            private const int TailLength = 4;
+
+            private readonly ReadOnlyMemory<byte> data;
+            private int position;
+
+            public TailAwareStream(ReadOnlyMemory<byte> data, int offset)
+            {
+                this.data = data;
+                position = Math.Min(offset, data.Length);
+            }
+
+            /// <summary>Whether the inflater asked for every byte there was.</summary>
+            public bool ConsumedEverything => position >= data.Length;
+
+            public override int Read(byte[] buffer, int offset, int count)
+            {
+                if (count <= 0 || position >= data.Length)
+                {
+                    return 0;
+                }
+
+                var bulkEnd = data.Length - TailLength;
+                var take = position < bulkEnd ? Math.Min(count, bulkEnd - position) : 1;
+
+                data.Span.Slice(position, take).CopyTo(buffer.AsSpan(offset, take));
+                position += take;
+                return take;
+            }
+
+            public override bool CanRead => true;
+            public override bool CanSeek => false;
+            public override bool CanWrite => false;
+            public override long Length => data.Length;
+            public override long Position
+            {
+                get => position;
+                set => throw new NotSupportedException();
+            }
+
+            public override void Flush()
+            {
+            }
+
+            public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+
+            public override void SetLength(long value) => throw new NotSupportedException();
+
+            public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
         }
 
         /// <summary>

--- a/src/UglyToad.PdfPig/Filters/IFilterContext.cs
+++ b/src/UglyToad.PdfPig/Filters/IFilterContext.cs
@@ -1,0 +1,35 @@
+namespace UglyToad.PdfPig.Filters
+{
+    using Logging;
+
+    /// <summary>
+    /// Lets a filter reach the log and the leniency setting of the document being
+    /// decoded.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// A filter receives the <see cref="IFilterProvider"/> it was obtained from, and
+    /// during parsing that is the per document <c>FilterProviderWithLookup</c>. Asking
+    /// it for this interface is therefore the one route from a filter to
+    /// <see cref="ParsingOptions"/> that does not change <see cref="IFilter"/>, which
+    /// is public and cannot gain a member without breaking every implementation of it.
+    /// </para>
+    /// <para>
+    /// A provider that does not offer this - the default one, or a caller decoding a
+    /// stream on their own through <c>PdfExtensions.Decode</c> - simply leaves a filter
+    /// without a log, which is what it had before.
+    /// </para>
+    /// </remarks>
+    internal interface IFilterContext
+    {
+        /// <summary>Where a filter reports what it had to repair.</summary>
+        ILog Log { get; }
+
+        /// <summary>
+        /// Whether a filter should carry on past damaged input. False asks it to raise
+        /// instead, which is what <see cref="ParsingOptions.UseLenientParsing"/> means
+        /// everywhere else in the parser.
+        /// </summary>
+        bool UseLenientParsing { get; }
+    }
+}

--- a/src/UglyToad.PdfPig/Parser/PdfDocumentFactory.cs
+++ b/src/UglyToad.PdfPig/Parser/PdfDocumentFactory.cs
@@ -123,7 +123,10 @@
             ParsingOptions parsingOptions,
             StackDepthGuard stackDepthGuard)
         {
-            var filterProvider = new FilterProviderWithLookup(parsingOptions.FilterProvider ?? DefaultFilterProvider.Instance);
+            var filterProvider = new FilterProviderWithLookup(
+                parsingOptions.FilterProvider ?? DefaultFilterProvider.Instance,
+                parsingOptions.Logger,
+                parsingOptions.UseLenientParsing);
 
             var version = FileHeaderParser.Parse(scanner, inputBytes, parsingOptions.UseLenientParsing, parsingOptions.Logger);
 


### PR DESCRIPTION
The second half of #1404: making a failure in the flate filter visible. Three
commits, each standing on its own.

**Report damaged flate streams, and honour UseLenientParsing.** A filter is handed
the `IFilterProvider` it came from, and while parsing that is the per document
`FilterProviderWithLookup`. Letting it carry the log and the leniency setting is a
route from a filter to `ParsingOptions` that leaves `IFilter` alone — it is public,
and netstandard2.0 rules out adding a member without breaking implementations.
`FlateFilter` then warns about the damage it worked around, and raises instead of
repairing when the caller asked not to be lenient.

**Find flate streams that were cut short.** Truncation raises nothing to catch —
the read just returns zero — so it is found the other way round: a stream that ends
properly leaves the bytes after its final block alone, a truncated one is read to
exhaustion. `DeflateStream` buffers ahead and hides that, so the input now comes
through a wrapper holding the last four bytes back. A producer writing no checksum
ends there too, hence a warning and not a refusal.

**Stop handing the compressed input back when decoding fails.** The bare catch
returned the input, which nothing above can tell apart from content.

## What changes for a caller

- `UseLenientParsing = false` now raises on a damaged flate stream instead of
  quietly repairing it. That is what the option says it is for elsewhere in the
  parser, but it is a behaviour change for anyone setting it.
- A failure that used to yield the compressed bytes now yields nothing. Over 2,000
  real documents and 13,600 streams that path never fired once, but it is not dead
  code: what it hides is a defect in the method itself, which then looks exactly
  like a damaged document.
- Nothing is logged unless a caller supplied a logger; the default is `NoOpLog`.

## Cost

The wrapper replaces the `MemoryStream` the input was read through. Measured over
5,766 flate streams from real documents, 299 MB decoded: **480 ms against 498 ms**
before. The wrapper is cheaper than what it replaces, and holding four bytes back
costs part of that again. A longer tail is not free — at 64 bytes it was 565 ms —
but four is all the checksum needs.

## Tests

Six new ones in `FlateFilterTests`, covering both directions: damage reported,
damage raised when not lenient, truncation reported, an intact stream not reported,
and a failure yielding nothing rather than the input. Each was checked against the
unchanged code first, so none of them passes for the wrong reason.

Full suite green on net462, net471, net8.0 and net9.0; the library compiles for all
seven target frameworks.

## Open

I have not touched what the other filters do — `FlateFilter` is the only one in the
folder that catches anything at all, and the rest let their exceptions out. Whether
the same treatment belongs there is a separate question.