### PR TITLE
Configure TPageFactory<TPage> instance

### DIFF
--- a/src/UglyToad.PdfPig/Content/Pages.cs
+++ b/src/UglyToad.PdfPig/Content/Pages.cs
@@ -117,6 +117,35 @@
             pageFactoryCache.Add(type, pageFactory);
         }
 
+        /// <exception cref="InvalidOperationException"></exception>
+        internal TPageFactory GetPageFactory<TPage, TPageFactory>() where TPageFactory : IPageFactory<TPage>
+        {
+            Type type = typeof(TPage);
+            if (!pageFactoryCache.ContainsKey(type))
+            {
+                throw new InvalidOperationException($"Could not get page factory for page type '{type}' as it was not added.");
+            }
+
+            if (pageFactoryCache[type] is TPageFactory pageFactory)
+            {
+                return pageFactory;
+            }
+
+            throw new InvalidOperationException($"Could not get page factory for page type '{type}' as it is not {typeof(TPageFactory).FullName}.");
+        }
+
+        internal bool TryGetPageFactory<TPage, TPageFactory>(out TPageFactory? pageFactory) where TPageFactory : IPageFactory<TPage>
+        {
+            if (pageFactoryCache.TryGetValue(typeof(TPage), out var f) && f is TPageFactory pf)
+            {
+                pageFactory = pf;
+                return true;
+            }
+
+            pageFactory = default;
+            return false;
+        }
+
 #if NET
         internal void AddPageFactory<TPage, [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors)] TPageFactory>() where TPageFactory : IPageFactory<TPage>
 #else

--- a/src/UglyToad.PdfPig/PdfDocument.cs
+++ b/src/UglyToad.PdfPig/PdfDocument.cs
@@ -152,6 +152,23 @@
         }
 
         /// <summary>
+        /// Get a page factory instance.
+        /// </summary>
+        /// <exception cref="InvalidOperationException"></exception>
+        public TPageFactory GetPageFactory<TPage, TPageFactory>() where TPageFactory : IPageFactory<TPage>
+        {
+            return pages.GetPageFactory<TPage, TPageFactory>();
+        }
+
+        /// <summary>
+        /// Try get a page factory instance.
+        /// </summary>
+        public bool TryGetPageFactory<TPage, TPageFactory>(out TPageFactory? pageFactory) where TPageFactory : IPageFactory<TPage>
+        {
+            return pages.TryGetPageFactory<TPage, TPageFactory>(out pageFactory);
+        }
+
+        /// <summary>
         /// Add a page factory.
         /// </summary>
 #if NET


### PR DESCRIPTION
Currently, there is no way to access the factory instance after registering it with document.AddPageFactory<SKPicture, SkiaPageFactory>(); to configure additional options.

It relates to https://github.com/BobLd/PdfPig.Rendering.Skia/pull/146 when need to replace default font (`SKTypeface.Default` and use a font from file, https://github.com/BobLd/PdfPig.Rendering.Skia/issues/145).