### PR TITLE
Compare strings ordinally where a culture has no business

### DIFF
--- a/src/UglyToad.PdfPig.Fonts/GlyphList.cs
+++ b/src/UglyToad.PdfPig.Fonts/GlyphList.cs
@@ -123,7 +123,7 @@
             // of four, and if each group of four digits represents a value in the ranges 0000 through D7FF or E000 through FFFF, then
             // interpret each as a Unicode scalar value and map the component to the string made of those scalar values. Note that the range
             // and digit-length restrictions mean that the ‘uni’ glyph name prefix can be used only with UVs in the Basic Multilingual Plane (BMP).
-            else if (name.StartsWith("uni") && (name.Length - 3) % 4 == 0)
+            else if (name.StartsWith("uni", StringComparison.Ordinal) && (name.Length - 3) % 4 == 0)
             {
                 // test for Unicode name in the format uniXXXX where X is hex
                 int nameLength = name.Length;

--- a/src/UglyToad.PdfPig.Fonts/SystemFonts/SystemFontRecord.cs
+++ b/src/UglyToad.PdfPig.Fonts/SystemFonts/SystemFontRecord.cs
@@ -19,23 +19,23 @@
             type = default(SystemFontRecord);
 
             SystemFontType fontType;
-            if (path.EndsWith(".ttf"))
+            if (path.EndsWith(".ttf", StringComparison.Ordinal))
             {
                 fontType = SystemFontType.TrueType;
             }
-            else if (path.EndsWith(".otf"))
+            else if (path.EndsWith(".otf", StringComparison.Ordinal))
             {
                 fontType = SystemFontType.OpenType;
             }
-            else if (path.EndsWith(".ttc"))
+            else if (path.EndsWith(".ttc", StringComparison.Ordinal))
             {
                 fontType = SystemFontType.TrueTypeCollection;
             }
-            else if (path.EndsWith(".otc"))
+            else if (path.EndsWith(".otc", StringComparison.Ordinal))
             {
                 fontType = SystemFontType.OpenTypeCollection;
             }
-            else if (path.EndsWith(".pfb"))
+            else if (path.EndsWith(".pfb", StringComparison.Ordinal))
             {
                 fontType = SystemFontType.Type1;
             }

--- a/src/UglyToad.PdfPig.Fonts/Type1/Parser/Type1FontParser.cs
+++ b/src/UglyToad.PdfPig.Fonts/Type1/Parser/Type1FontParser.cs
@@ -47,7 +47,7 @@
 
             var scanner = new CoreTokenScanner(inputBytes, false, stackDepthGuard);
 
-            if (!scanner.TryReadToken(out CommentToken comment) || !comment.Data.StartsWith("!"))
+            if (!scanner.TryReadToken(out CommentToken comment) || !comment.Data.StartsWith("!", StringComparison.Ordinal))
             {
                 throw new InvalidFontFormatException("The Type1 program did not start with '%!'.");
             }

--- a/src/UglyToad.PdfPig/PdfFonts/Composite/ToUnicodeCMap.cs
+++ b/src/UglyToad.PdfPig/PdfFonts/Composite/ToUnicodeCMap.cs
@@ -29,7 +29,7 @@
 
             if (cMap != null)
             {
-                IsUsingIdentityAsUnicodeMap = cMap.Name?.StartsWith("Identity-", StringComparison.InvariantCultureIgnoreCase) == true;
+                IsUsingIdentityAsUnicodeMap = cMap.Name?.StartsWith("Identity-", StringComparison.OrdinalIgnoreCase) == true;
             }
         }
 

--- a/src/UglyToad.PdfPig/PdfFonts/Parser/CMapParser.cs
+++ b/src/UglyToad.PdfPig/PdfFonts/Parser/CMapParser.cs
@@ -135,7 +135,7 @@
             var resources = typeof(CMapParser).Assembly.GetManifestResourceNames();
 
             var resource = resources.FirstOrDefault(x =>
-                x.EndsWith("CMap." + name, StringComparison.InvariantCultureIgnoreCase));
+                x.EndsWith("CMap." + name, StringComparison.OrdinalIgnoreCase));
 
             if (resource is null)
             {

--- a/src/UglyToad.PdfPig/Tokenization/Scanner/PdfTokenScanner.cs
+++ b/src/UglyToad.PdfPig/Tokenization/Scanner/PdfTokenScanner.cs
@@ -308,7 +308,7 @@
                 return true;
             }
 
-            if (parsingOptions.UseLenientParsing && scanner.CurrentToken is OperatorToken opToken && opToken.Data.EndsWith(token.Data))
+            if (parsingOptions.UseLenientParsing && scanner.CurrentToken is OperatorToken opToken && opToken.Data.EndsWith(token.Data, StringComparison.Ordinal))
             {
                 actualTokenStart = scanner.CurrentTokenStart + opToken.Data.Length - token.Data.Length;
                 return true;

--- a/src/UglyToad.PdfPig/Writer/Colors/ProfileStreamReader.cs
+++ b/src/UglyToad.PdfPig/Writer/Colors/ProfileStreamReader.cs
@@ -12,7 +12,7 @@
             var resources = typeof(ProfileStreamReader).Assembly.GetManifestResourceNames();
 
             var resource = resources.FirstOrDefault(x =>
-                x.EndsWith("sRGB2014.icc", StringComparison.InvariantCultureIgnoreCase));
+                x.EndsWith("sRGB2014.icc", StringComparison.OrdinalIgnoreCase));
 
             if (resource is null)
             {


### PR DESCRIPTION
PdfTokenScanner.IsToken (lenient path), GlyphList, SystemFontRecord and Type1FontParser used the culture-sensitive StartsWith and EndsWith overloads. On .NET 5+ those go through ICU on every call: in a corpus profile the frames CompareInfo.IcuEndsWith and Interop+Globalization .EndsWith showed up under PdfTokenScanner.MoveNext, and a BenchmarkDotNet run of the very comparisons gives 380 ns for "endstream".EndsWith("stream") against 2.4 ns ordinally (.NET 8, x64), 184 ns against 2.3 ns for "uni00E4".StartsWith("uni"). The content compared is PDF syntax and glyph names, ordinal by nature.

ToUnicodeCMap, CMapParser and ProfileStreamReader compared ASCII names with InvariantCultureIgnoreCase and now use OrdinalIgnoreCase.

Analyzer CA1310 reported these four files before the change and nothing after it.