### PR TITLE
Scan for xref keywords with a byte window over blocks

### DIFF
--- a/src/UglyToad.PdfPig/Parser/FileStructure/XrefBruteForcer.cs
+++ b/src/UglyToad.PdfPig/Parser/FileStructure/XrefBruteForcer.cs
@@ -89,34 +89,43 @@ internal static class XrefBruteForcer
             numberOverflowed = false;
         }
 
-        var block = ArrayPool<byte>.Shared.Rent(BlockSize);
+        // The block has one byte of room in front of the data read into it, for the byte that
+        // the previous read ended on: it is visited only once the next read has shown that it
+        // was not the last byte of the input. That way the scan needs no length from the input,
+        // which a buffering stream does not know until it has been read to the end, and it
+        // leaves the last byte unvisited like the byte-wise loop it replaces. No keyword that
+        // ends on the last byte could yield anything: an object with nothing after it, a table
+        // or a trailer with nothing left to read.
+        var block = ArrayPool<byte>.Shared.Rent(BlockSize + 1);
 
         try
         {
-            // The scan visits every byte but the last one, as the byte-wise loop it replaces did.
             // Positions are computed from the index: the input reports an offset one past the
             // byte it is on. Where a keyword hands the input to another parser, the scan resumes
-            // from wherever that left the input, again as before.
-            var last = bytes.Length - 1;
+            // from wherever that left the input, as the byte-wise loop did.
             var next = 0L;
+            var hasPending = false;
 
-            while (next < last)
+            while (true)
             {
                 bytes.Seek(next);
 
-                var read = bytes.Read(block);
+                var read = bytes.Read(block.AsSpan(1, BlockSize));
                 if (read <= 0)
                 {
                     break;
                 }
 
-                var limit = (int)Math.Min(read, last - next);
-                var blockStart = next;
-                next = blockStart + limit;
+                var start = hasPending ? 0 : 1;
+                var end = 1 + read;
+                var firstIndex = hasPending ? next - 1 : next;
+                next += read;
 
-                for (var k = 0; k < limit; k++)
+                var resumed = false;
+
+                for (var k = start; k < end - 1; k++)
                 {
-                    var currentOffset = blockStart + k + 1;
+                    var currentOffset = firstIndex + (k - start) + 1;
                     var current = block[k];
 
                     if (current == '%')
@@ -230,6 +239,7 @@ internal static class XrefBruteForcer
                             // keyword — otherwise a failed parse can skip past later keywords such
                             // as a recoverable 'trailer' dictionary.
                             next = currentOffset;
+                            resumed = true;
                             break;
                         }
 
@@ -266,6 +276,7 @@ internal static class XrefBruteForcer
 
                             // Same position-preservation as the table branch above.
                             next = currentOffset;
+                            resumed = true;
                             break;
                         }
                     }
@@ -285,8 +296,19 @@ internal static class XrefBruteForcer
 
                         // The scan goes on from wherever the dictionary ended, as it always has.
                         next = bytes.CurrentOffset;
+                        resumed = true;
                         break;
                     }
+                }
+
+                if (resumed)
+                {
+                    hasPending = false;
+                }
+                else
+                {
+                    block[0] = block[end - 1];
+                    hasPending = true;
                 }
             }
         }

--- a/src/UglyToad.PdfPig/Parser/FileStructure/XrefBruteForcer.cs
+++ b/src/UglyToad.PdfPig/Parser/FileStructure/XrefBruteForcer.cs
@@ -1,15 +1,30 @@
 namespace UglyToad.PdfPig.Parser.FileStructure;
 
+using System.Buffers;
 using Core;
 using Logging;
-using System.Globalization;
 using Tokenization.Scanner;
 using Tokens;
 using Filters;
-using Util;
 
 internal static class XrefBruteForcer
 {
+    // The keywords the scan looks for, packed into the low bytes of a 64-bit window with the
+    // newest byte lowest, and the masks that select just their length. Each keyword ends in a
+    // byte the others do not, so the byte just read tells which one comparison to make.
+    private static readonly ulong ObjTail = Tail(" obj");
+    private static readonly ulong XrefTail = Tail(" xref");
+    private static readonly ulong XrefStreamTail = Tail("/XRef");
+    private static readonly ulong TrailerTail = Tail("trailer ");
+    private const ulong FourByteMask = 0xFFFFFFFFUL;
+    private const ulong FiveByteMask = 0xFFFFFFFFFFUL;
+
+    /// <summary>
+    /// The input is read in blocks of this size and scanned from the array, rather than a byte at
+    /// a time through the input's interface.
+    /// </summary>
+    private const int BlockSize = 64 * 1024;
+
     public static Result FindAllXrefsInFileOrder(
         IInputBytes bytes,
         ISeekableTokenScanner scanner,
@@ -25,11 +40,16 @@ internal static class XrefBruteForcer
 
         DictionaryToken? trailer = null;
 
-        bytes.Seek(0);
+        // The last eight bytes seen, whitespace normalized to a space, newest byte lowest. A
+        // keyword has been read when the low bytes equal its packed form; before enough bytes
+        // are in, the zeros above them cannot equal any keyword byte.
+        var window = 0UL;
 
-        var buffer = new CircularByteBuffer(10);
-
-        var numberByteBuffer = new List<byte>();
+        // The number being read: its value, how many digits it has, and whether it outgrew a
+        // long, in which case it is not a number this scan can use, as long.TryParse would say.
+        var number = 0L;
+        var numberLength = 0;
+        var numberOverflowed = false;
 
         var inNum = false;
         var lastWhitespace = false;
@@ -44,180 +64,235 @@ internal static class XrefBruteForcer
         {
             numericsQueue[0] = 0;
             numericsQueue[1] = 0;
-
             positionsQueue[0] = 0;
             positionsQueue[1] = 0;
         }
 
-        void AddQueues(long num)
+        // The offset is the position the input reports while on the byte after the number.
+        void AddQueues(long num, long currentOffset)
         {
             numericsQueue[0] = numericsQueue[1];
             numericsQueue[1] = num;
-
             positionsQueue[0] = positionsQueue[1];
-            positionsQueue[1] = bytes.CurrentOffset - numberByteBuffer.Count - 1;
+            positionsQueue[1] = currentOffset - numberLength - 1;
         }
 
-        // search for xref tables and /XRef stream types, record all object positions.
-        while (bytes.MoveNext() && !bytes.IsAtEnd())
+        void EndNumber(long currentOffset)
         {
-            if (bytes.CurrentByte == '%')
+            if (inNum && numberLength > 0 && !numberOverflowed)
             {
-                inComment = true;
+                AddQueues(number, currentOffset);
+            }
 
-                if (inNum && numberByteBuffer.Count > 0)
+            number = 0;
+            numberLength = 0;
+            numberOverflowed = false;
+        }
+
+        var block = ArrayPool<byte>.Shared.Rent(BlockSize);
+
+        try
+        {
+            // The scan visits every byte but the last one, as the byte-wise loop it replaces did.
+            // Positions are computed from the index: the input reports an offset one past the
+            // byte it is on. Where a keyword hands the input to another parser, the scan resumes
+            // from wherever that left the input, again as before.
+            var last = bytes.Length - 1;
+            var next = 0L;
+
+            while (next < last)
+            {
+                bytes.Seek(next);
+
+                var read = bytes.Read(block);
+                if (read <= 0)
                 {
-                    var num = OtherEncodings.BytesAsLatin1String(numberByteBuffer.ToArray());
-                    if (long.TryParse(num, NumberStyles.Integer, CultureInfo.InvariantCulture, out var numLong))
+                    break;
+                }
+
+                var limit = (int)Math.Min(read, last - next);
+                var blockStart = next;
+                next = blockStart + limit;
+
+                for (var k = 0; k < limit; k++)
+                {
+                    var currentOffset = blockStart + k + 1;
+                    var current = block[k];
+
+                    if (current == '%')
                     {
-                        AddQueues(numLong);
+                        inComment = true;
+
+                        EndNumber(currentOffset);
+
+                        inNum = false;
+                        lastWhitespace = false;
                     }
 
-                    numberByteBuffer.Clear();
-                }
-                
-                inNum = false;
-                lastWhitespace = false;
-
-            }
-
-            if (ReadHelper.IsWhitespace(bytes.CurrentByte))
-            {
-                if (ReadHelper.IsEndOfLine(bytes.CurrentByte))
-                {
-                    inComment = false;
-                }
-
-                // Normalize whitespace
-                buffer.Add((byte)' ');
-
-                if (inNum && numberByteBuffer.Count > 0)
-                {
-                    var num = OtherEncodings.BytesAsLatin1String(numberByteBuffer.ToArray());
-                    if (long.TryParse(num, NumberStyles.Integer, CultureInfo.InvariantCulture, out var numLong))
+                    if (ReadHelper.IsWhitespace(current))
                     {
-                        AddQueues(numLong);
+                        if (ReadHelper.IsEndOfLine(current))
+                        {
+                            inComment = false;
+                        }
+
+                        // Normalize whitespace
+                        window = (window << 8) | (byte)' ';
+
+                        EndNumber(currentOffset);
+
+                        lastWhitespace = true;
+                        inNum = false;
+                    }
+                    else
+                    {
+                        window = (window << 8) | current;
+
+                        if (!inComment && ReadHelper.IsDigit(current) && (inNum || lastWhitespace))
+                        {
+                            inNum = true;
+
+                            var digit = current - '0';
+                            if (numberOverflowed || number > (long.MaxValue - digit) / 10)
+                            {
+                                numberOverflowed = true;
+                            }
+                            else
+                            {
+                                number = (number * 10) + digit;
+                            }
+
+                            numberLength++;
+                        }
+                        else
+                        {
+                            inNum = false;
+                            number = 0;
+                            numberLength = 0;
+                            numberOverflowed = false;
+                        }
+
+                        lastWhitespace = false;
                     }
 
-                    numberByteBuffer.Clear();
-                }
+                    // The byte just added is the last of the keyword, if any, and the four
+                    // keywords end in three different bytes.
+                    var lastByte = (byte)window;
 
-                lastWhitespace = true;
-                inNum = false;
-            }
-            else
-            {
-                buffer.Add(bytes.CurrentByte);
+                    if (lastByte == 'j')
+                    {
+                        if ((window & FourByteMask) == ObjTail && numericsQueue[0] > 0)
+                        {
+                            bruteForceObjPositions[new IndirectReference(numericsQueue[0], (int)numericsQueue[1])] = XrefLocation.File(positionsQueue[0]);
 
-                if (!inComment && ReadHelper.IsDigit(bytes.CurrentByte) && (inNum || lastWhitespace))
-                {
-                    inNum = true;
-                    numberByteBuffer.Add(bytes.CurrentByte);
-                }
-                else
-                {
-                    inNum = false;
-                    numberByteBuffer.Clear();
-                }
+                            lastObjPosition = positionsQueue[0];
 
-                lastWhitespace = false;
-            }
+                            ClearQueues();
+                        }
+                    }
+                    else if (lastByte == 'f')
+                    {
+                        var tail = window & FiveByteMask;
 
-            if (buffer.EndsWith(" obj") && numericsQueue[0] > 0)
-            {
-                bruteForceObjPositions[new IndirectReference(numericsQueue[0], (int)numericsQueue[1])] = XrefLocation.File(positionsQueue[0]);
+                        if (tail == XrefTail)
+                        {
+                            ClearQueues();
 
-                lastObjPosition = positionsQueue[0];
+                            var potentialTableOffset = currentOffset - 4;
 
-                ClearQueues();
-            }
-            else if (buffer.EndsWith(" xref"))
-            {
-                ClearQueues();
+                            if (xrefOffsetSeen.Contains(potentialTableOffset))
+                            {
+                                log.Debug($"Skipping circular xref reference at {potentialTableOffset}");
+                                continue;
+                            }
 
-                var potentialTableOffset = bytes.CurrentOffset - 4;
+                            xrefOffsetSeen.Add(potentialTableOffset);
 
-                // TryReadTableAtOffset seeks the shared stream and does not restore
-                // position (including on failure). Snapshot so the scan resumes from
-                // here — otherwise a failed parse can skip past later keywords such
-                // as a recoverable 'trailer' dictionary.
-                var resumePosition = bytes.CurrentOffset;
+                            var table = XrefTableParser.TryReadTableAtOffset(
+                                new FileHeaderOffset(0),
+                                potentialTableOffset,
+                                bytes,
+                                scanner,
+                                log);
 
-                if (xrefOffsetSeen.Contains(potentialTableOffset))
-                {
-                    log.Debug($"Skipping circular xref reference at {potentialTableOffset}");
-                    continue;
-                }
-                xrefOffsetSeen.Add(potentialTableOffset);
+                            if (table != null)
+                            {
+                                results.Add(table);
+                            }
+                            else
+                            {
+                                log.Warn(
+                                    $"Found a table at {potentialTableOffset} but couldn't parse it.");
+                            }
 
-                var table = XrefTableParser.TryReadTableAtOffset(
-                    new FileHeaderOffset(0),
-                    potentialTableOffset,
-                    bytes,
-                    scanner,
-                    log);
+                            // TryReadTableAtOffset seeks the shared input and does not restore the
+                            // position (including on failure). The scan resumes right after the
+                            // keyword — otherwise a failed parse can skip past later keywords such
+                            // as a recoverable 'trailer' dictionary.
+                            next = currentOffset;
+                            break;
+                        }
 
-                if (table != null)
-                {
-                    results.Add(table);
-                }
-                else
-                {
-                    log.Warn(
-                        $"Found a table at {potentialTableOffset} but couldn't parse it.");
-                }
+                        if (tail == XrefStreamTail)
+                        {
+                            ClearQueues();
 
-                bytes.Seek(resumePosition);
-            }
-            else if (buffer.EndsWith("/XRef"))
-            {
-                ClearQueues();
+                            if (lastObjPosition is not long offset)
+                            {
+                                log.Error("Found an /XRef without having encountered an object first");
+                                continue;
+                            }
 
-                if (lastObjPosition is not long offset)
-                {
-                    log.Error("Found an /XRef without having encountered an object first");
-                    continue;
-                }
+                            if (xrefOffsetSeen.Contains(offset))
+                            {
+                                log.Debug($"Skipping circular /XRef reference at {offset}");
+                                continue;
+                            }
 
-                if (xrefOffsetSeen.Contains(offset))
-                {
-                    log.Debug($"Skipping circular /XRef reference at {offset}");
-                    continue;
-                }
-                xrefOffsetSeen.Add(offset);
+                            xrefOffsetSeen.Add(offset);
 
-                // Same position-preservation as the table branch above.
-                var resumePosition = bytes.CurrentOffset;
+                            var stream = XrefStreamParser.TryReadStreamAtOffset(
+                                new FileHeaderOffset(0),
+                                offset,
+                                bytes,
+                                scanner,
+                                filterProvider,
+                                log);
 
-                var stream = XrefStreamParser.TryReadStreamAtOffset(
-                    new FileHeaderOffset(0),
-                    offset,
-                    bytes,
-                    scanner,
-                    filterProvider,
-                    log);
+                            if (stream != null)
+                            {
+                                results.Add(stream);
+                            }
 
-                if (stream != null)
-                {
-                    results.Add(stream);
-                }
+                            // Same position-preservation as the table branch above.
+                            next = currentOffset;
+                            break;
+                        }
+                    }
+                    else if (lastByte == ' ' && window == TrailerTail)
+                    {
+                        ClearQueues();
 
-                bytes.Seek(resumePosition);
-            }
-            else if (buffer.EndsWith("trailer "))
-            {
-                ClearQueues();
+                        // Ensure the scanner reads from the byte scan's current position —
+                        // a preceding failed table/stream parse may have moved it elsewhere.
+                        scanner.Seek(currentOffset);
 
-                // Ensure the scanner reads from the byte scan's current position —
-                // a preceding failed table/stream parse may have moved it elsewhere.
-                scanner.Seek(bytes.CurrentOffset);
+                        // Grab the last trailer dictionary as backup in case we find no valid xrefs.
+                        if (scanner.TryReadToken(out DictionaryToken trailerDict))
+                        {
+                            trailer = trailerDict;
+                        }
 
-                // Grab the last trailer dictionary as backup in case we find no valid xrefs.
-                if (scanner.TryReadToken(out DictionaryToken trailerDict))
-                {
-                    trailer = trailerDict;
+                        // The scan goes on from wherever the dictionary ended, as it always has.
+                        next = bytes.CurrentOffset;
+                        break;
+                    }
                 }
             }
+        }
+        finally
+        {
+            ArrayPool<byte>.Shared.Return(block);
         }
 
         return new Result(
@@ -226,15 +301,26 @@ internal static class XrefBruteForcer
             trailer);
     }
 
+    /// <summary>The keyword packed into the low bytes of a window, its last byte lowest.</summary>
+    private static ulong Tail(string keyword)
+    {
+        var value = 0UL;
+
+        foreach (var c in keyword)
+        {
+            value = (value << 8) | (byte)c;
+        }
+
+        return value;
+    }
+
     public class Result(
         IReadOnlyList<IXrefSection> xRefParts,
         IReadOnlyDictionary<IndirectReference, XrefLocation> objectOffsets,
         DictionaryToken? lastTrailer)
     {
         public IReadOnlyList<IXrefSection> XRefParts { get; } = xRefParts;
-
         public IReadOnlyDictionary<IndirectReference, XrefLocation> ObjectOffsets { get; } = objectOffsets;
-
         public DictionaryToken? LastTrailer { get; } = lastTrailer;
     }
 }


### PR DESCRIPTION
XrefBruteForcer, which runs when the xref chain cannot be read, added every byte to a ring buffer and asked it four times whether a keyword had just ended, each answer a loop over the keyword; every number was gathered in a list, turned into a string and parsed. The last eight bytes now sit in a ulong, whitespace normalized, and the byte just read selects the one masked comparison that could match, as the four keywords end in three different bytes. Numbers accumulate in a long, with overflow treated as no number, like long.TryParse did. The input is read in 64 KB blocks and scanned from the array instead of through IInputBytes a byte at a time; after a keyword hands the input to another parser the scan resumes where that parser left it, as before. On 13 documents that need the scan (3.5 MB on average) opening takes 9 ms instead of 32. A signature of trailer, page text, letter and image counts is unchanged for 21,673 documents of a corpus sample, 21 of them brute-forced.